### PR TITLE
update readme with api separation

### DIFF
--- a/nodl_python/README.md
+++ b/nodl_python/README.md
@@ -1,0 +1,3 @@
+# nodl_python
+
+Implementation of the NoDL API in Python.

--- a/nodl_python/package.xml
+++ b/nodl_python/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>nodl_python</name>
   <version>0.0.1</version>
-  <description>CLI and parsing utilities for the ROS 2 NoDL</description>
+  <description>Implementation of the NoDL API in Python.</description>
   <maintainer email="ubuntu-robotics@lists.launchpad.net">Ubuntu Robotics</maintainer>
   <license>GNU Lesser General Public License 3.0</license>
 

--- a/nodl_python/setup.cfg
+++ b/nodl_python/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script-dir=$base/lib/nodl_python
+[install]
+install-scripts=$base/lib/nodl_python

--- a/nodl_python/setup.py
+++ b/nodl_python/setup.py
@@ -28,7 +28,7 @@ setup(
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
-    description='CLI and parsing utilities for the ROS 2 NoDL',
+    description='Implementation of the NoDL API in Python.',
     license='GNU Limited General Public License v3',
     tests_require=['pytest'],
     package_data={


### PR DESCRIPTION
Add nodl_python readme and clarify nodl_python is API only

Signed-off-by: Ted Kern <ted.kern@canonical.com>