### PR TITLE
temporarily remove windows from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        # windows testing is broken, re-add when the following is resolved
+        # https://github.com/ros-tooling/action-ros-ci/issues/79
         os: [ubuntu-latest, macos-latest]
       fail-fast: false
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
       fail-fast: false
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Windows tests are currently failing - remove them until https://github.com/ros-tooling/action-ros-ci/issues/79 is resolved.

Signed-off-by: Ted Kern <ted.kern@canonical.com>