### PR TITLE
add executable as attribute to Node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,6 @@ name: test nodl
 on:
   pull_request:
   push:
-    branches:
-      - master
   schedule:
     - cron: '0 0 * * *'
 
@@ -21,7 +19,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Setup ROS2
-      uses: ros-tooling/setup-ros@0.0.15
+      uses: ros-tooling/setup-ros@0.0.20
       with:
         required-ros-distributions: eloquent
 
@@ -31,7 +29,7 @@ jobs:
         pip3 install lxml
 
     - name: Run Tests
-      uses: ros-tooling/action-ros-ci@0.0.13
+      uses: ros-tooling/action-ros-ci@0.0.16
       with:
         package-name: nodl_python
 

--- a/nodl_python/nodl/_parsing/_v1/_parsing.py
+++ b/nodl_python/nodl/_parsing/_v1/_parsing.py
@@ -85,6 +85,7 @@ def _parse_nodes(interface: etree._Element) -> List[Node]:
 def _parse_node(node: etree._Element) -> Node:
     """Parse a NoDL node and all the elements it contains from an xml element."""
     name = node.attrib['name']
+    executable = node.attrib['executable']
 
     actions = []
     parameters = []
@@ -101,7 +102,12 @@ def _parse_node(node: etree._Element) -> Node:
         if child.tag == 'topic':
             topics.append(_parse_topic(child))
     return Node(
-        name=name, actions=actions, parameters=parameters, services=services, topics=topics
+        name=name,
+        executable=executable,
+        actions=actions,
+        parameters=parameters,
+        services=services,
+        topics=topics,
     )
 
 

--- a/nodl_python/nodl/schemas/v1.xsd
+++ b/nodl_python/nodl/schemas/v1.xsd
@@ -67,6 +67,7 @@
                 <xs:element ref="service"/>
             </xs:choice>
             <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="executable" type="xs:string" use="required"/>
         </xs:complexType>
     </xs:element>
 

--- a/nodl_python/nodl/types.py
+++ b/nodl_python/nodl/types.py
@@ -117,12 +117,14 @@ class Node(NoDLData):
         self,
         *,
         name: str,
+        executable: str,
         actions: Optional[List[Action]] = None,
         parameters: Optional[List[Parameter]] = None,
         services: Optional[List[Service]] = None,
         topics: Optional[List[Topic]] = None
     ) -> None:
         self.name = name
+        self.executable = executable
 
         self.actions = {action.name: action for action in actions} if actions else {}
         self.parameters = (
@@ -135,6 +137,7 @@ class Node(NoDLData):
     def _as_dict(self):
         return {
             'name': self.name,
+            'executable': self.executable,
             'actions': [action._as_dict for action in self.actions.values()],
             'parameters': [parameter._as_dict for parameter in self.parameters.values()],
             'services': [service._as_dict for service in self.services.values()],

--- a/nodl_python/test/nodl/_parsing/conftest.py
+++ b/nodl_python/test/nodl/_parsing/conftest.py
@@ -1,0 +1,20 @@
+# Copyright 2020 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the
+# GNU Limited General Public License version 3, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranties of MERCHANTABILITY, SATISFACTORY QUALITY, or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Limited General Public License for more details.
+#
+# You should have received a copy of the GNU Limited General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def test_nodl_path():
+    return Path(__file__).parent / 'test.nodl.xml'

--- a/nodl_python/test/nodl/_parsing/test.nodl.xml
+++ b/nodl_python/test/nodl/_parsing/test.nodl.xml
@@ -1,12 +1,12 @@
 <interface version="1">
-  <node name="node_1" >
+  <node name="node_1" executable="first" >
     <parameter name="verbose" type="bool" />
     <topic name="chatter" type="std_msgs/msg/String" publisher="true">
       <qos depth="10"/>
     </topic>
   </node>
 
-  <node name="node_2" >
+  <node name="node_2" executable="second" >
     <parameter name="rate" type="int" />
     <topic name="/foo/bar" type="std_msgs/msg/String" subscription="true">
       <qos

--- a/nodl_python/test/nodl/_parsing/test_nodl_parse.py
+++ b/nodl_python/test/nodl/_parsing/test_nodl_parse.py
@@ -11,8 +11,6 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
 
-from pathlib import Path
-
 from lxml.builder import E
 import lxml.etree as etree
 from nodl import errors
@@ -37,17 +35,17 @@ def test__parse_element_tree(mocker):
     assert nodl._parsing._parsing._parse_element_tree(etree.ElementTree(interface))
 
 
-def test_parse_nodl_file_valid(mocker):
+def test_parse_nodl_file_valid(mocker, test_nodl_path):
     mocker.patch('nodl._parsing._parsing._parse_element_tree')
 
     # Test if accepts a valid xml file
-    assert nodl._parsing._parsing.parse(path=Path('test/nodl/test.nodl.xml')) is not None
+    assert nodl._parsing._parsing.parse(path=test_nodl_path) is not None
 
     # Test if accepts file name as string
-    assert nodl._parsing._parsing.parse(path='test/nodl/test.nodl.xml') is not None
+    assert nodl._parsing._parsing.parse(path=str(test_nodl_path)) is not None
 
     # Test if accepts file object
-    with open('test/nodl/test.nodl.xml', 'rb') as fd:
+    with test_nodl_path.open('rb') as fd:
         assert nodl._parsing._parsing.parse(path=fd) is not None
 
 

--- a/nodl_python/test/nodl/_parsing/test_parsing_v1.py
+++ b/nodl_python/test/nodl/_parsing/test_parsing_v1.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from lxml.builder import E
 import lxml.etree as etree
 from nodl import errors
@@ -10,15 +8,17 @@ import pytest
 
 
 @pytest.fixture()
-def valid_nodl() -> etree._ElementTree:
-    return etree.parse(str(Path('test/nodl/test.nodl.xml')))
+def valid_nodl(test_nodl_path) -> etree._ElementTree:
+    return etree.parse(str(test_nodl_path))
 
 
 def test_parse(valid_nodl):
     # Assert a minimal example passes validation
     element = E.interface(
         E.node(
-            E.action(E.qos(depth='10'), name='bar', type='baz', server='true'), name='foo'
+            E.action(E.qos(depth='10'), name='bar', type='baz', server='true'),
+            name='foo',
+            executable='row',
         ),
         version='1',
     )

--- a/nodl_python/test/nodl/test_types.py
+++ b/nodl_python/test/nodl/test_types.py
@@ -83,8 +83,9 @@ def test_node():
     topic = nodl.types.Topic(name='foo', message_type='bar')
     service = nodl.types.Service(name='baz', service_type='woo')
 
-    node = nodl.types.Node(name='test', topics=[topic], services=[service])
+    node = nodl.types.Node(name='test', executable='toast', topics=[topic], services=[service])
     assert node.name == 'test'
+    assert node.executable == 'toast'
     assert node.topics[topic.name] == topic
     assert node.services[service.name] == service
 
@@ -93,6 +94,7 @@ def test_node__as_dict():
     topic = nodl.types.Topic(name='foo', message_type='bar')
     service = nodl.types.Service(name='baz', service_type='woo')
 
-    node = nodl.types.Node(name='test', topics=[topic], services=[service])
+    node = nodl.types.Node(name='test', executable='toast', topics=[topic], services=[service])
     assert node._as_dict['name'] == node.name
+    assert node._as_dict['executable'] == node.executable
     assert topic._as_dict in node._as_dict['topics']


### PR DESCRIPTION
Adds the `executable` attribute to `types.Node`, needed for most NoDL functionality.

Signed-off-by: Ted Kern <ted.kern@canonical.com>