### PR TITLE
bump checkout to v2, remove eloquent-specificity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Setup ROS2
       uses: ros-tooling/setup-ros@0.0.20
-      with:
-        required-ros-distributions: eloquent
 
     - name: Extra Mac Dependencies
       if: contains(matrix.os, 'macos-latest')


### PR DESCRIPTION
Attempt to fix 
`AttributeError: module 'pycodestyle' has no attribute 'break_around_binary_operator'`, as well as other ci failures