### PR TITLE
Remove buildtool_depend on nodl_python

### DIFF
--- a/ros2nodl/package.xml
+++ b/ros2nodl/package.xml
@@ -7,8 +7,6 @@
   <maintainer email="ubuntu-robotics@lists.launchpad.net">Ubuntu Robotics</maintainer>
   <license>GPLv3</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
-
   <depend>ament_index_python</depend>
   <depend>argcomplete</depend>
   <depend>nodl_python</depend>


### PR DESCRIPTION
It's not a valid rosdep dependency and is unnecessary anyway.