### PR TITLE
bump ros-tooling action versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup ROS2
-        uses: ros-tooling/setup-ros@0.0.20
+        uses: ros-tooling/setup-ros@0.0.25
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
 
@@ -31,7 +31,7 @@ jobs:
           pip3 install lxml
 
       - name: Test nodl
-        uses: ros-tooling/action-ros-ci@0.0.16
+        uses: ros-tooling/action-ros-ci@0.0.17
         id: action_ros_ci_step
         with:
           package-name: nodl_python ros2nodl


### PR DESCRIPTION
Bump setup-ros to 0.0.25 and action-ros-ci to 0.0.17

Signed-off-by: Ted Kern <ted.kern@canonical.com>