### PR TITLE
Using underscore names in `setup.cfg`

### DIFF
--- a/nodl_python/setup.cfg
+++ b/nodl_python/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/nodl_python
+script_dir=$base/lib/nodl_python
 [install]
-install-scripts=$base/lib/nodl_python
+install_scripts=$base/lib/nodl_python

--- a/ros2nodl/setup.cfg
+++ b/ros2nodl/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/ros2nodl
+script_dir=$base/lib/ros2nodl
 [install]
-install-scripts=$base/lib/ros2nodl
+install_scripts=$base/lib/ros2nodl


### PR DESCRIPTION
The previous names are now deprecated, so this commit migrates away from
them.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>
