### PR TITLE
Guillaume/ci rebase

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,9 +74,6 @@ jobs:
           apt-get -qq install -y curl libasio-dev libtinyxml2-dev
           colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/5c45b95018788deff62202aaa831ad4c20ebe2c6/index.yaml
           colcon mixin update default
-          # Use the apt ones and not the pip one with unsupported version from ament_flake8
-          # https://github.com/osrf/docker_images/issues/640
-          pip3 uninstall -y flake8 pycodestyle
           mkdir -p src
 
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,9 @@ jobs:
       - run: cp src/codecov.yml .
 
       - name: Rosdep
-        run: DEBIAN_FRONTEND=noninteractive rosdep update && rosdep install --from-paths src --ignore-src --rosdistro rolling -y
+        run: |
+          . /opt/ros/$ROS_DISTRO/setup.sh
+          DEBIAN_FRONTEND=noninteractive rosdep update && rosdep install --from-paths src --ignore-src --rosdistro rolling -y
 
       - name: Build
         run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon build --event-handlers console_cohesion+ --mixin coverage-pytest --packages-select nodl_python ros2nodl --merge-install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,9 @@ jobs:
           apt-get -qq install -y curl libasio-dev libtinyxml2-dev
           colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/5c45b95018788deff62202aaa831ad4c20ebe2c6/index.yaml
           colcon mixin update default
+          # Use the apt ones and not the pip one with unsupported version from ament_flake8
+          # https://github.com/osrf/docker_images/issues/640
+          pip3 uninstall -y flake8 pycodestyle
           mkdir -p src
 
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Rosdep
         run: |
           . /opt/ros/$ROS_DISTRO/setup.sh
-          DEBIAN_FRONTEND=noninteractive rosdep update && rosdep install --from-paths src --ignore-src --rosdistro rolling -y
+          DEBIAN_FRONTEND=noninteractive rosdep update && rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
 
       - name: Build
         run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon build --event-handlers console_cohesion+ --mixin coverage-pytest --packages-select nodl_python ros2nodl --merge-install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup ROS2
-        uses: ros-tooling/setup-ros@0.0.26
+        uses: ros-tooling/setup-ros@v0.4
         with:
           use-ros2-testing: true
           required-ros-distributions: ${{ matrix.ros_distribution }}
@@ -35,11 +35,19 @@ jobs:
           pip3 install lxml
 
       - name: Test nodl
-        uses: ros-tooling/action-ros-ci@0.1.0
+        uses: ros-tooling/action-ros-ci@v0.2
         id: action_ros_ci_step
         with:
           package-name: nodl_python ros2nodl
-          colcon-mixin-name: coverage-pytest
+          colcon-defaults: |
+            {
+              "build": {
+                "mixin": ["coverage-pytest"]
+              },
+              "test": {
+                "mixin": ["coverage-pytest"]
+              }
+            }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/5c45b95018788deff62202aaa831ad4c20ebe2c6/index.yaml
           target-ros2-distro: ${{ matrix.ros_distribution }}
 
@@ -106,3 +114,4 @@ jobs:
           name: colcon-logs-linux
           path: log/
         if: always()
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,10 @@ jobs:
             }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/5c45b95018788deff62202aaa831ad4c20ebe2c6/index.yaml
           target-ros2-distro: ${{ matrix.ros_distribution }}
+          vcs-repo-file-url: "https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos"
+          # Necessary because of cyclonedds fails to build otherwise
+          # https://github.com/eclipse-cyclonedds/cyclonedds/issues/1270
+          colcon-extra-args: "--merge-install"
 
       - name: Upload Logs
         uses: actions/upload-artifact@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
       - master
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   build-mac-win:


### PR DESCRIPTION
Fix Linux and MacOS CI

ROS 2 Rolling doesn't support the latest MacOS, so Rolling must be built from source.

There are some tricks used due to some issue linked as comments