### PR TITLE
Formatters/linters: apply polymath_code-standard pre-commit hooks 

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,18 @@
+---
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    name: Pre-commit Checks
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+      - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,29 @@
+---
 repos:
-- repo: https://github.com/nineyards-robotics/dco-sign-off
-  rev: v1.0.0
-  hooks:
-  - id: dco-sign-off
+  - repo: https://github.com/nineyards-robotics/dco-sign-off
+    rev: v1.0.0
+    hooks:
+      - id: dco-sign-off
+
+  - repo: https://github.com/polymathrobotics/polymath_code_standard
+    rev: v2.0.1
+    hooks:
+      # Basic checks and fixes that apply to any text file and the git repository itself
+      - id: polymath-general
+
+      # Enforce and insert copyright headers in source code for the project's license
+      - id: polymath-copyright
+        args: [--license, Apache-2.0, --copyright-org, 'Open Source Robotics Foundation, Inc.']
+
+      # Implementation languages we use in NoDL packages
+      - id: polymath-cpp
+      - id: polymath-python
+      - id: polymath-shell
+      - id: polymath-cmake
+
+      # Markdown/up languages
+      - id: polymath-markdown
+      - id: polymath-xml
+      - id: polymath-toml
+      - id: polymath-json
+      - id: polymath-yaml


### PR DESCRIPTION

It really doesn't matter what standard we pick as long as it's easy.
I've put a bunch of work into making a nice clean autoformatter suite and open sourcing it for general use, so I'd love to apply it here.

The `polymath_code_standard` precommit hooks bundle up a bunch of common config for autoformatters and linters so you don't have to make decisions. Like `black` for a bunch of stuff.

Open for discussion, but I think it's a nice choice.