### PR TITLE
Add nodl_generator_rust + nodl_rclrs: Rust support for NoDL

### DIFF
--- a/nodl_generator_rust/CMakeLists.txt
+++ b/nodl_generator_rust/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.16)
+project(nodl_generator_rust)
+
+find_package(ament_cmake REQUIRED)
+
+install(PROGRAMS scripts/nodl_generate_rust
+  DESTINATION lib/${PROJECT_NAME})
+
+install(FILES cmake/nodl_generate_rust.cmake
+  DESTINATION share/${PROJECT_NAME}/cmake)
+
+install(DIRECTORY nodl_generator_rust/templates
+  DESTINATION share/${PROJECT_NAME}/templates)
+
+ament_package(CONFIG_EXTRAS "nodl_generator_rust-extras.cmake.in")

--- a/nodl_generator_rust/cmake/nodl_generate_rust.cmake
+++ b/nodl_generator_rust/cmake/nodl_generate_rust.cmake
@@ -1,0 +1,51 @@
+# nodl_generate_rust(target nodl_file)
+#
+# Generates a Rust source file (<target>_nodl.rs) from a NoDL YAML file.
+# The file is written to ${CMAKE_CURRENT_BINARY_DIR}/nodl_generated/ and a
+# CMake custom target is created so it rebuilds when the NoDL file changes.
+#
+# The generated file is a self-contained Rust module.  Add it to your crate
+# by including it from a build.rs-aware location or placing it via a
+# configure step:
+#
+#   nodl_generate_rust(my_node nodl/my_node.nodl.yaml)
+#
+# Then in your crate's build.rs:
+#   println!("cargo:rerun-if-changed=nodl/my_node.nodl.yaml");
+#   // The generated file is at the path printed by the cmake target.
+#
+# Or simply declare a mod in src/lib.rs and point rustc at the build dir via
+# a RUSTFLAGS include path (see nodl_generator_rust documentation).
+#
+function(nodl_generate_rust target nodl_file)
+  get_filename_component(_nodl_abs "${nodl_file}" ABSOLUTE
+    BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  if(NOT EXISTS "${_nodl_abs}")
+    message(WARNING "nodl_generate_rust: NoDL file not found at configure time: ${_nodl_abs}")
+  endif()
+
+  set(_out_dir "${CMAKE_CURRENT_BINARY_DIR}/nodl_generated")
+  file(MAKE_DIRECTORY "${_out_dir}")
+  set(_rs_out "${_out_dir}/${target}_nodl.rs")
+
+  add_custom_command(
+    OUTPUT "${_rs_out}"
+    COMMAND "${Python3_EXECUTABLE}"
+      "${_NODL_GENERATOR_RUST_SCRIPT}"
+      --nodl-file "${_nodl_abs}"
+      --output-dir "${_out_dir}"
+      --target-name "${target}"
+      --templates-dir "${_NODL_GENERATOR_RUST_TEMPLATES_DIR}"
+    DEPENDS
+      "${_nodl_abs}"
+      "${_NODL_GENERATOR_RUST_SCRIPT}"
+    COMMENT "nodl_generate_rust: generating ${target}_nodl.rs from ${nodl_file}"
+    VERBATIM
+  )
+
+  add_custom_target(${target}_nodl_rs ALL DEPENDS "${_rs_out}")
+
+  # Export the generated file path so the Rust build.rs can find it.
+  set(NODL_GENERATED_RS_${target} "${_rs_out}" PARENT_SCOPE)
+endfunction()

--- a/nodl_generator_rust/nodl_generator_rust-extras.cmake.in
+++ b/nodl_generator_rust/nodl_generator_rust-extras.cmake.in
@@ -1,0 +1,5 @@
+set(_NODL_GENERATOR_RUST_SCRIPT
+  "${CMAKE_CURRENT_LIST_DIR}/../../../lib/nodl_generator_rust/nodl_generate_rust")
+set(_NODL_GENERATOR_RUST_TEMPLATES_DIR
+  "${CMAKE_CURRENT_LIST_DIR}/../../../share/nodl_generator_rust/templates")
+include("${CMAKE_CURRENT_LIST_DIR}/nodl_generate_rust.cmake")

--- a/nodl_generator_rust/nodl_generator_rust/generator.py
+++ b/nodl_generator_rust/nodl_generator_rust/generator.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Generate an rclrs node scaffolding module (.rs) from a NoDL YAML file."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Name utilities
+# ---------------------------------------------------------------------------
+
+def _to_snake(name: str) -> str:
+    return re.sub(r'[^a-zA-Z0-9]+', '_', name.strip('/')).strip('_').lower()
+
+
+def _to_pascal(snake: str) -> str:
+    return ''.join(part.capitalize() for part in snake.split('_') if part)
+
+
+# ---------------------------------------------------------------------------
+# ROS type utilities
+# ---------------------------------------------------------------------------
+
+def _ros_type_to_rust(ros_type: str) -> str:
+    """sensor_msgs/msg/LaserScan -> sensor_msgs::msg::LaserScan"""
+    return ros_type.replace('/', '::')
+
+
+def _ros_type_to_crate(ros_type: str) -> str:
+    """sensor_msgs/msg/LaserScan -> sensor_msgs"""
+    return ros_type.split('/')[0]
+
+
+# ---------------------------------------------------------------------------
+# NoDL type -> Rust type
+# ---------------------------------------------------------------------------
+
+_NODL_TO_RUST: dict[str, str] = {
+    'bool': 'bool',
+    'int': 'i64',
+    'double': 'f64',
+    'string': 'String',
+    'byte_array': 'Vec<u8>',
+    'bool_array': 'Vec<bool>',
+    'int_array': 'Vec<i64>',
+    'double_array': 'Vec<f64>',
+    'string_array': 'Vec<String>',
+}
+
+_NODL_TO_RUST_DEFAULT: dict[str, str] = {
+    'bool': 'false',
+    'int': '0_i64',
+    'double': '0.0_f64',
+    'string': 'String::new()',
+    'byte_array': 'vec![]',
+    'bool_array': 'vec![]',
+    'int_array': 'vec![]',
+    'double_array': 'vec![]',
+    'string_array': 'vec![]',
+}
+
+
+def _default_expr(nodl_type: str, default_value) -> str | None:
+    if default_value is None:
+        return None
+    if nodl_type == 'string':
+        return f'"{default_value}".to_string()'
+    if nodl_type in ('byte_array', 'bool_array', 'int_array', 'double_array', 'string_array'):
+        items = ', '.join(repr(v) for v in default_value)
+        return f'vec![{items}]'
+    if nodl_type == 'double':
+        v = float(default_value)
+        return f'{v}_f64' if '.' in str(v) else f'{v}.0_f64'
+    if nodl_type == 'int':
+        return f'{int(default_value)}_i64'
+    return str(default_value).lower()  # bool
+
+
+# ---------------------------------------------------------------------------
+# QoS
+# ---------------------------------------------------------------------------
+
+def _qos_call(qos: dict | None) -> str:
+    if not qos:
+        return 'nodl_rclrs::qos::reliable(10)'
+    history = qos.get('history', 'SYSTEM_DEFAULT')
+    if history == 'KEEP_ALL':
+        history_str = 'ALL'
+    elif history == 'KEEP_LAST':
+        depth = qos.get('depth', 10)
+        history_str = str(depth)
+    else:  # SYSTEM_DEFAULT
+        history_str = 'SYSTEM_DEFAULT'
+    reliability = qos.get('reliability', 'SYSTEM_DEFAULT')
+    durability = qos.get('durability', 'VOLATILE') or 'VOLATILE'
+    return (
+        f'nodl_rclrs::profile_from_nodl("{history_str}", "{reliability}", "{durability}")'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Context builder
+# ---------------------------------------------------------------------------
+
+def _build_context(nodl_data: dict, target_name: str) -> dict:
+    struct_name = _to_pascal(target_name)
+
+    crates: set[str] = set()
+
+    publishers = []
+    for pub in (nodl_data.get('publishers') or []):
+        crates.add(_ros_type_to_crate(pub['type']))
+        topic_name = pub['name']
+        ident = _to_snake(topic_name)
+        publishers.append({
+            'topic': topic_name,
+            'rust_type': _ros_type_to_rust(pub['type']),
+            'ident': ident,
+            'qos_call': _qos_call(pub.get('qos')),
+            'const_name': ident.upper(),
+        })
+
+    subscriptions = []
+    for sub in (nodl_data.get('subscriptions') or []):
+        crates.add(_ros_type_to_crate(sub['type']))
+        topic_name = sub['name']
+        ident = _to_snake(topic_name)
+        subscriptions.append({
+            'topic': topic_name,
+            'rust_type': _ros_type_to_rust(sub['type']),
+            'ident': ident,
+            'qos_call': _qos_call(sub.get('qos')),
+            'const_name': ident.upper(),
+            'builder_method': f'on_{ident}',
+        })
+
+    service_servers = []
+    for srv in (nodl_data.get('service_servers') or []):
+        crates.add(_ros_type_to_crate(srv['type']))
+        ident = _to_snake(srv['name'])
+        service_servers.append({
+            'name': srv['name'],
+            'rust_type': _ros_type_to_rust(srv['type']),
+            'ident': ident,
+            'const_name': ident.upper(),
+            'builder_method': f'on_{ident}',
+        })
+
+    service_clients = []
+    for cli in (nodl_data.get('service_clients') or []):
+        crates.add(_ros_type_to_crate(cli['type']))
+        ident = _to_snake(cli['name'])
+        service_clients.append({
+            'name': cli['name'],
+            'rust_type': _ros_type_to_rust(cli['type']),
+            'ident': ident,
+            'const_name': ident.upper(),
+        })
+
+    parameters = []
+    for param_name, spec in (nodl_data.get('parameters') or {}).items():
+        nodl_type = spec.get('type', 'string')
+        rust_type = _NODL_TO_RUST.get(nodl_type, 'rclrs::ParameterValue')
+        default_val = spec.get('default_value')
+        default_expr = _default_expr(nodl_type, default_val)
+        parameters.append({
+            'name': param_name,
+            'rust_type': rust_type,
+            'has_default': default_expr is not None,
+            'default_expr': default_expr,
+            'read_only': bool(spec.get('read_only', False)),
+        })
+
+    return {
+        'target_name': target_name,
+        'struct_name': struct_name,
+        'crates': sorted(crates),
+        'publishers': publishers,
+        'subscriptions': subscriptions,
+        'service_servers': service_servers,
+        'service_clients': service_clients,
+        'parameters': parameters,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------------------
+
+def _render(templates_dir: Path, context: dict) -> str:
+    try:
+        import jinja2
+    except ImportError:
+        sys.exit('jinja2 is required')
+    loader = jinja2.FileSystemLoader(str(templates_dir))
+    env = jinja2.Environment(loader=loader, trim_blocks=True, lstrip_blocks=True)
+    return env.get_template('node_nodl.rs.jinja2').render(**context)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--nodl-file', required=True)
+    parser.add_argument('--output-dir', required=True)
+    parser.add_argument('--target-name', required=True)
+    parser.add_argument('--templates-dir', required=True)
+    args = parser.parse_args()
+
+    try:
+        import yaml
+    except ImportError:
+        sys.exit('PyYAML is required')
+
+    nodl_path = Path(args.nodl_file)
+    if not nodl_path.exists():
+        sys.exit(f'NoDL file not found: {nodl_path}')
+
+    with nodl_path.open() as f:
+        nodl_data = yaml.safe_load(f) or {}
+
+    context = _build_context(nodl_data, args.target_name)
+    rs_text = _render(Path(args.templates_dir), context)
+
+    out = Path(args.output_dir) / f'{args.target_name}_nodl.rs'
+    out.write_text(rs_text)
+
+
+if __name__ == '__main__':
+    main()

--- a/nodl_generator_rust/nodl_generator_rust/templates/node_nodl.rs.jinja2
+++ b/nodl_generator_rust/nodl_generator_rust/templates/node_nodl.rs.jinja2
@@ -1,0 +1,220 @@
+// GENERATED FILE — do not edit. Regenerated from NoDL by nodl_generator_rust.
+#![allow(dead_code, unused_imports)]
+
+use std::sync::Arc;
+use rclrs::{Node, Publisher, Subscription, Client, RclrsError};
+{% for crate in crates %}
+use {{ crate }};
+{% endfor %}
+
+// ---------------------------------------------------------------------------
+// Topic and service name constants
+// ---------------------------------------------------------------------------
+{% for pub in publishers %}
+pub const TOPIC_{{ pub.const_name }}: &str = "{{ pub.topic }}";
+{% endfor %}
+{% for sub in subscriptions %}
+pub const TOPIC_{{ sub.const_name }}: &str = "{{ sub.topic }}";
+{% endfor %}
+{% for srv in service_servers %}
+pub const SERVICE_{{ srv.const_name }}: &str = "{{ srv.name }}";
+{% endfor %}
+{% for cli in service_clients %}
+pub const SERVICE_{{ cli.const_name }}: &str = "{{ cli.name }}";
+{% endfor %}
+
+// ---------------------------------------------------------------------------
+// Parameter snapshot
+// ---------------------------------------------------------------------------
+{% if parameters %}
+
+#[derive(Debug, Clone)]
+pub struct {{ struct_name }}Params {
+{% for param in parameters %}
+    pub {{ param.name }}: {% if not param.has_default %}Option<{% endif %}{{ param.rust_type }}{% if not param.has_default %}>{% endif %},
+{% endfor %}
+}
+
+/// Declare all parameters on `node` and return a typed snapshot.
+/// Read-only parameters can only be set at startup (via --ros-args -p).
+///
+/// NOTE: The rclrs parameter API may vary by installed version.
+/// Adjust declare_parameter calls if your rclrs differs from the 0.4+ builder API.
+pub fn declare_params(node: &Arc<Node>) -> Result<{{ struct_name }}Params, RclrsError> {
+    Ok({{ struct_name }}Params {
+{% for param in parameters %}
+        {{ param.name }}: {
+            let p = node.declare_parameter("{{ param.name }}");
+            {% if param.has_default %}
+            let p = p.default({{ param.default_expr }});
+            {% endif %}
+            {% if param.read_only %}
+            let _p = p;  // read_only enforcement is ROS-node-launch-time only
+            {% endif %}
+            {% if param.has_default %}
+            p.get()?
+            {% else %}
+            p.optional().get()?
+            {% endif %}
+        },
+{% endfor %}
+    })
+}
+{% else %}
+
+pub fn declare_params(_node: &Arc<Node>) -> Result<(), RclrsError> {
+    Ok(())
+}
+{% endif %}
+
+// ---------------------------------------------------------------------------
+// Publishers
+// ---------------------------------------------------------------------------
+{% if publishers %}
+
+pub struct {{ struct_name }}Publishers {
+{% for pub in publishers %}
+    pub {{ pub.ident }}: Arc<Publisher<{{ pub.rust_type }}>>,
+{% endfor %}
+}
+{% endif %}
+
+// ---------------------------------------------------------------------------
+// Service clients
+// ---------------------------------------------------------------------------
+{% if service_clients %}
+
+pub struct {{ struct_name }}Clients {
+{% for cli in service_clients %}
+    pub {{ cli.ident }}: Arc<Client<{{ cli.rust_type }}>>,
+{% endfor %}
+}
+{% endif %}
+
+// ---------------------------------------------------------------------------
+// Builder — wires subscriptions and service servers, creates publishers
+// ---------------------------------------------------------------------------
+
+pub struct {{ struct_name }}Builder {
+    node: Arc<Node>,
+{% for sub in subscriptions %}
+    {{ sub.builder_method }}: Option<Box<dyn Fn({{ sub.rust_type }}) + Send + Sync + 'static>>,
+{% endfor %}
+{% for srv in service_servers %}
+    {{ srv.builder_method }}: Option<Box<
+        dyn Fn(
+            Arc<rclrs::rmw_request_id_t>,
+            <{{ srv.rust_type }} as rclrs::Service>::Request,
+            Arc<tokio::sync::Mutex<<{{ srv.rust_type }} as rclrs::Service>::Response>>,
+        ) + Send + Sync + 'static
+    >>,
+{% endfor %}
+}
+
+impl {{ struct_name }}Builder {
+    pub fn new(node: Arc<Node>) -> Self {
+        Self {
+            node,
+{% for sub in subscriptions %}
+            {{ sub.builder_method }}: None,
+{% endfor %}
+{% for srv in service_servers %}
+            {{ srv.builder_method }}: None,
+{% endfor %}
+        }
+    }
+
+{% for sub in subscriptions %}
+    pub fn {{ sub.builder_method }}(
+        mut self,
+        f: impl Fn({{ sub.rust_type }}) + Send + Sync + 'static,
+    ) -> Self {
+        self.{{ sub.builder_method }} = Some(Box::new(f));
+        self
+    }
+
+{% endfor %}
+{% for srv in service_servers %}
+    pub fn {{ srv.builder_method }}(
+        mut self,
+        f: impl Fn(
+            Arc<rclrs::rmw_request_id_t>,
+            <{{ srv.rust_type }} as rclrs::Service>::Request,
+            Arc<tokio::sync::Mutex<<{{ srv.rust_type }} as rclrs::Service>::Response>>,
+        ) + Send + Sync + 'static,
+    ) -> Self {
+        self.{{ srv.builder_method }} = Some(Box::new(f));
+        self
+    }
+
+{% endfor %}
+    pub fn build(self) -> Result<{{ struct_name }}Nodl, RclrsError> {
+{% if publishers %}
+        let publishers = {{ struct_name }}Publishers {
+{% for pub in publishers %}
+            {{ pub.ident }}: self.node.create_publisher(
+                TOPIC_{{ pub.const_name }},
+                {{ pub.qos_call }},
+            )?,
+{% endfor %}
+        };
+{% endif %}
+{% for sub in subscriptions %}
+        // Subscription handles must be kept alive; they are stored in the result.
+        let _sub_{{ sub.ident }} = self.node.create_subscription::<{{ sub.rust_type }}, _>(
+            TOPIC_{{ sub.const_name }},
+            {{ sub.qos_call }},
+            self.{{ sub.builder_method }}.unwrap_or_else(|| Box::new(|_| {})),
+        )?;
+{% endfor %}
+{% for srv in service_servers %}
+        let _srv_{{ srv.ident }} = if let Some(cb) = self.{{ srv.builder_method }} {
+            Some(self.node.create_service::<{{ srv.rust_type }}, _>(
+                SERVICE_{{ srv.const_name }}, cb,
+            )?)
+        } else {
+            None
+        };
+{% endfor %}
+{% if service_clients %}
+        let clients = {{ struct_name }}Clients {
+{% for cli in service_clients %}
+            {{ cli.ident }}: self.node.create_client(SERVICE_{{ cli.const_name }})?,
+{% endfor %}
+        };
+{% endif %}
+        Ok({{ struct_name }}Nodl {
+{% if publishers %}
+            publishers,
+{% endif %}
+{% if service_clients %}
+            clients,
+{% endif %}
+{% for sub in subscriptions %}
+            _sub_{{ sub.ident }},
+{% endfor %}
+{% for srv in service_servers %}
+            _srv_{{ srv.ident }},
+{% endfor %}
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Result struct — owns all handles to keep them alive
+// ---------------------------------------------------------------------------
+
+pub struct {{ struct_name }}Nodl {
+{% if publishers %}
+    pub publishers: {{ struct_name }}Publishers,
+{% endif %}
+{% if service_clients %}
+    pub clients: {{ struct_name }}Clients,
+{% endif %}
+{% for sub in subscriptions %}
+    _sub_{{ sub.ident }}: Arc<Subscription<{{ sub.rust_type }}>>,
+{% endfor %}
+{% for srv in service_servers %}
+    _srv_{{ srv.ident }}: Option<Arc<rclrs::Service<{{ srv.rust_type }}>>>,
+{% endfor %}
+}

--- a/nodl_generator_rust/package.xml
+++ b/nodl_generator_rust/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>nodl_generator_rust</name>
+  <version>0.1.0</version>
+  <description>CMake macro to generate rclrs node scaffolding from a NoDL file.</description>
+  <maintainer email="emerson@polymathrobotics.com">Emerson Knapp</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>nodl_rclrs</depend>
+  <depend>python3-jinja2</depend>
+  <depend>python3-yaml</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/nodl_generator_rust/scripts/nodl_generate_rust
+++ b/nodl_generator_rust/scripts/nodl_generate_rust
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+"""Generate an rclrs node scaffolding module (.rs) from a NoDL YAML file."""
+from nodl_generator_rust.generator import main
+
+if __name__ == '__main__':
+    main()

--- a/nodl_generator_rust/test/test_generator.py
+++ b/nodl_generator_rust/test/test_generator.py
@@ -1,0 +1,212 @@
+"""Unit tests for nodl_generator_rust — no rclrs or live ROS required."""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from nodl_generator_rust.generator import (
+    _build_context,
+    _default_expr,
+    _qos_call,
+    _ros_type_to_crate,
+    _ros_type_to_rust,
+    _to_pascal,
+    _to_snake,
+)
+
+
+# ---------------------------------------------------------------------------
+# Name helpers
+# ---------------------------------------------------------------------------
+
+def test_to_snake_strips_leading_slash():
+    assert _to_snake('/scan') == 'scan'
+
+
+def test_to_snake_replaces_slashes():
+    assert _to_snake('/my/long/topic') == 'my_long_topic'
+
+
+def test_to_pascal():
+    assert _to_pascal('my_node') == 'MyNode'
+
+
+# ---------------------------------------------------------------------------
+# ROS type helpers
+# ---------------------------------------------------------------------------
+
+def test_ros_type_to_rust():
+    assert _ros_type_to_rust('sensor_msgs/msg/LaserScan') == 'sensor_msgs::msg::LaserScan'
+
+
+def test_ros_type_to_crate():
+    assert _ros_type_to_crate('sensor_msgs/msg/LaserScan') == 'sensor_msgs'
+
+
+# ---------------------------------------------------------------------------
+# QoS
+# ---------------------------------------------------------------------------
+
+def test_qos_call_none_defaults_to_reliable_10():
+    result = _qos_call(None)
+    assert 'reliable' in result
+    assert '10' in result
+
+
+def test_qos_call_best_effort():
+    result = _qos_call({'history': 'KEEP_LAST', 'depth': 5, 'reliability': 'BEST_EFFORT'})
+    assert 'BEST_EFFORT' in result
+    assert '5' in result
+
+
+def test_qos_call_keep_all():
+    result = _qos_call({'history': 'KEEP_ALL', 'reliability': 'RELIABLE'})
+    assert 'ALL' in result
+
+
+def test_qos_call_transient_local():
+    result = _qos_call({'history': 'KEEP_LAST', 'depth': 10, 'reliability': 'RELIABLE', 'durability': 'TRANSIENT_LOCAL'})
+    assert 'TRANSIENT_LOCAL' in result
+
+
+# ---------------------------------------------------------------------------
+# Default value expressions
+# ---------------------------------------------------------------------------
+
+def test_default_expr_double():
+    assert _default_expr('double', 10.0) == '10.0_f64'
+
+
+def test_default_expr_int():
+    assert _default_expr('int', 42) == '42_i64'
+
+
+def test_default_expr_bool_true():
+    assert _default_expr('bool', True) == 'true'
+
+
+def test_default_expr_string():
+    assert _default_expr('string', 'hello') == '"hello".to_string()'
+
+
+def test_default_expr_none_returns_none():
+    assert _default_expr('double', None) is None
+
+
+def test_default_expr_string_array():
+    result = _default_expr('string_array', ['a', 'b'])
+    assert 'vec!' in result
+
+
+# ---------------------------------------------------------------------------
+# Context builder
+# ---------------------------------------------------------------------------
+
+_FULL_NODL = {
+    'nodl_version': 2,
+    'publishers': [
+        {'name': '/scan', 'type': 'sensor_msgs/msg/LaserScan',
+         'qos': {'history': 'SYSTEM_DEFAULT', 'reliability': 'SYSTEM_DEFAULT'}},
+        {'name': '/cloud', 'type': 'sensor_msgs/msg/PointCloud2',
+         'qos': {'history': 'KEEP_LAST', 'depth': 5, 'reliability': 'BEST_EFFORT'}},
+    ],
+    'subscriptions': [
+        {'name': '/cmd_vel', 'type': 'geometry_msgs/msg/Twist',
+         'qos': {'history': 'SYSTEM_DEFAULT', 'reliability': 'SYSTEM_DEFAULT'}},
+    ],
+    'service_servers': [
+        {'name': '/reset', 'type': 'std_srvs/srv/Trigger'},
+    ],
+    'service_clients': [
+        {'name': '/set_mode', 'type': 'std_srvs/srv/SetBool'},
+    ],
+    'parameters': {
+        'rate': {'type': 'double', 'default_value': 10.0},
+        'label': {'type': 'string'},
+        'enabled': {'type': 'bool', 'default_value': True, 'read_only': True},
+    },
+}
+
+
+def test_context_struct_name():
+    ctx = _build_context(_FULL_NODL, 'my_sensor_node')
+    assert ctx['struct_name'] == 'MySensorNode'
+
+
+def test_context_publishers_count():
+    ctx = _build_context(_FULL_NODL, 'my_sensor_node')
+    assert len(ctx['publishers']) == 2
+
+
+def test_context_publisher_ident():
+    ctx = _build_context(_FULL_NODL, 'my_sensor_node')
+    assert ctx['publishers'][0]['ident'] == 'scan'
+
+
+def test_context_subscriptions_builder_method():
+    ctx = _build_context(_FULL_NODL, 'my_sensor_node')
+    assert ctx['subscriptions'][0]['builder_method'] == 'on_cmd_vel'
+
+
+def test_context_service_servers_builder_method():
+    ctx = _build_context(_FULL_NODL, 'my_sensor_node')
+    assert ctx['service_servers'][0]['builder_method'] == 'on_reset'
+
+
+def test_context_parameters_has_default():
+    ctx = _build_context(_FULL_NODL, 'my_sensor_node')
+    by_name = {p['name']: p for p in ctx['parameters']}
+    assert by_name['rate']['has_default'] is True
+    assert by_name['label']['has_default'] is False
+
+
+def test_context_parameters_read_only():
+    ctx = _build_context(_FULL_NODL, 'my_sensor_node')
+    by_name = {p['name']: p for p in ctx['parameters']}
+    assert by_name['enabled']['read_only'] is True
+    assert by_name['rate']['read_only'] is False
+
+
+def test_context_crates_collected():
+    ctx = _build_context(_FULL_NODL, 'my_sensor_node')
+    assert 'sensor_msgs' in ctx['crates']
+    assert 'geometry_msgs' in ctx['crates']
+    assert 'std_srvs' in ctx['crates']
+
+
+def test_context_empty_nodl():
+    ctx = _build_context({}, 'empty_node')
+    assert ctx['publishers'] == []
+    assert ctx['parameters'] == []
+    assert ctx['crates'] == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end render smoke test
+# ---------------------------------------------------------------------------
+
+def test_render_produces_valid_rust_fragment(tmp_path):
+    import jinja2
+    templates_dir = Path(__file__).parent.parent / 'nodl_generator_rust' / 'templates'
+    assert templates_dir.exists(), f"Templates dir not found: {templates_dir}"
+    loader = jinja2.FileSystemLoader(str(templates_dir))
+    env = jinja2.Environment(loader=loader, trim_blocks=True, lstrip_blocks=True)
+    ctx = _build_context(_FULL_NODL, 'my_sensor_node')
+    output = env.get_template('node_nodl.rs.jinja2').render(**ctx)
+
+    # Structural checks on the generated Rust source
+    assert 'pub struct MySensorNodeNodl' in output
+    assert 'pub struct MySensorNodeBuilder' in output
+    assert 'pub struct MySensorNodeParams' in output
+    assert 'pub struct MySensorNodePublishers' in output
+    assert 'pub struct MySensorNodeClients' in output
+    assert 'TOPIC_SCAN' in output
+    assert 'TOPIC_CMD_VEL' in output
+    assert 'SERVICE_RESET' in output
+    assert 'on_cmd_vel' in output
+    assert 'on_reset' in output
+    assert 'declare_params' in output
+    assert '10.0_f64' in output       # rate default
+    assert 'Option<String>' in output  # label has no default

--- a/nodl_rclrs/CMakeLists.txt
+++ b/nodl_rclrs/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.16)
+project(nodl_rclrs)
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cargo REQUIRED)
+
+ament_cargo_build_package()
+
+ament_package()

--- a/nodl_rclrs/Cargo.toml
+++ b/nodl_rclrs/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "nodl_rclrs"
+version = "0.1.0"
+edition = "2021"
+description = "Rust runtime support for NoDL-generated node code"
+license = "Apache-2.0"
+
+[dependencies]
+rclrs = "*"

--- a/nodl_rclrs/package.xml
+++ b/nodl_rclrs/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>nodl_rclrs</name>
+  <version>0.1.0</version>
+  <description>Rust runtime support crate for NoDL-generated node code.</description>
+  <maintainer email="emerson@polymathrobotics.com">Emerson Knapp</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cargo</buildtool_depend>
+
+  <depend>rclrs</depend>
+
+  <export>
+    <build_type>ament_cargo</build_type>
+  </export>
+</package>

--- a/nodl_rclrs/src/lib.rs
+++ b/nodl_rclrs/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod qos;
+
+pub use qos::profile_from_nodl;

--- a/nodl_rclrs/src/qos.rs
+++ b/nodl_rclrs/src/qos.rs
@@ -1,0 +1,49 @@
+use rclrs::{QoSProfile, QoSReliabilityPolicy, QoSDurabilityPolicy, QoSHistoryPolicy};
+
+/// Build a QoSProfile from the scalar values that nodl_generator_rust embeds
+/// into generated code.  Generated callers pass string literals so there is
+/// no heap allocation on the hot path.
+pub fn profile_from_nodl(
+    history: &str,   // "N" (depth) or "ALL"
+    reliability: &str, // "RELIABLE" | "BEST_EFFORT"
+    durability: &str,  // "TRANSIENT_LOCAL" | "VOLATILE" | ""
+) -> QoSProfile {
+    let hist = if history == "ALL" {
+        QoSHistoryPolicy::KeepAll
+    } else {
+        let depth: usize = history.parse().unwrap_or(10);
+        QoSHistoryPolicy::KeepLast { depth }
+    };
+
+    let rel = if reliability == "BEST_EFFORT" {
+        QoSReliabilityPolicy::BestEffort
+    } else {
+        QoSReliabilityPolicy::Reliable
+    };
+
+    let dur = if durability == "TRANSIENT_LOCAL" {
+        QoSDurabilityPolicy::TransientLocal
+    } else {
+        QoSDurabilityPolicy::Volatile
+    };
+
+    QoSProfile {
+        history: hist,
+        reliability: rel,
+        durability: dur,
+        ..QoSProfile::default()
+    }
+}
+
+/// Shorthand constants for generated code.
+pub fn reliable(depth: usize) -> QoSProfile {
+    profile_from_nodl(&depth.to_string(), "RELIABLE", "VOLATILE")
+}
+
+pub fn best_effort(depth: usize) -> QoSProfile {
+    profile_from_nodl(&depth.to_string(), "BEST_EFFORT", "VOLATILE")
+}
+
+pub fn sensor_data() -> QoSProfile {
+    best_effort(5)
+}


### PR DESCRIPTION
- nodl_generator_rust: jinja2-based generator that emits Rust code for a NoDL-described node, plus a CMake macro (nodl_generate_rust) for downstream packages
- nodl_rclrs: small rclrs-side runtime crate, currently providing QoS conversion helpers used by the generated code

Independent of the C++ generator and other features.