### PR TITLE
Add nodl_rclpy: Python runtime helpers for NoDL-described nodes

### DIFF
--- a/nodl_rclpy/nodl_rclpy/__init__.py
+++ b/nodl_rclpy/nodl_rclpy/__init__.py
@@ -1,0 +1,5 @@
+from nodl_rclpy.lifecycle_node import NodlLifecycleNode
+from nodl_rclpy.node import NodlNode
+from nodl_rclpy.params import NodlParameterListener, NodlParams
+
+__all__ = ['NodlNode', 'NodlLifecycleNode', 'NodlParameterListener', 'NodlParams']

--- a/nodl_rclpy/nodl_rclpy/_setup.py
+++ b/nodl_rclpy/nodl_rclpy/_setup.py
@@ -1,0 +1,56 @@
+"""Wire up a node from a NodlDocument: publishers, subscriptions, services, parameters."""
+from __future__ import annotations
+
+from nodl.models import NodlDocument
+from nodl_rclpy._support import (
+    import_ros_type,
+    qos_from_spec,
+    service_to_identifier,
+    topic_to_identifier,
+)
+from nodl_rclpy.params import NodlParameterListener
+
+
+def setup_nodl(node, doc: NodlDocument) -> None:
+    """Attach publishers, subscriptions, service clients/servers, and parameters to node."""
+
+    if doc.parameters:
+        node.param_listener_ = NodlParameterListener(node, doc.parameters)
+        node.params_ = node.param_listener_.get_params()
+
+    for pub_spec in (doc.publishers or []):
+        msg_type = import_ros_type(pub_spec.type)
+        attr = 'pub_' + topic_to_identifier(pub_spec.topic) + '_'
+        setattr(node, attr, node.create_publisher(msg_type, pub_spec.topic, qos_from_spec(pub_spec.qos)))
+
+    for sub_spec in (doc.subscriptions or []):
+        msg_type = import_ros_type(sub_spec.type)
+        ident = topic_to_identifier(sub_spec.topic)
+        callback = getattr(node, 'on_' + ident, None)
+        if callback is None:
+            node.get_logger().warning(
+                f"No method 'on_{ident}' for subscription '{sub_spec.topic}'"
+            )
+            continue
+        attr = 'sub_' + ident + '_'
+        setattr(node, attr, node.create_subscription(
+            msg_type, sub_spec.topic, callback, qos_from_spec(sub_spec.qos)
+        ))
+
+    for srv_spec in (doc.service_servers or []):
+        srv_type = import_ros_type(srv_spec.type)
+        ident = service_to_identifier(srv_spec.name)
+        callback = getattr(node, 'on_' + ident, None)
+        if callback is None:
+            node.get_logger().warning(
+                f"No method 'on_{ident}' for service server '{srv_spec.name}'"
+            )
+            continue
+        attr = 'srv_' + ident + '_'
+        setattr(node, attr, node.create_service(srv_type, srv_spec.name, callback))
+
+    for cli_spec in (doc.service_clients or []):
+        srv_type = import_ros_type(cli_spec.type)
+        ident = service_to_identifier(cli_spec.name)
+        attr = 'cli_' + ident + '_'
+        setattr(node, attr, node.create_client(srv_type, cli_spec.name))

--- a/nodl_rclpy/nodl_rclpy/_support.py
+++ b/nodl_rclpy/nodl_rclpy/_support.py
@@ -1,0 +1,76 @@
+"""Internal helpers: topic/service identifiers, QoS conversion, dynamic type import."""
+from __future__ import annotations
+
+import importlib
+from typing import Optional
+
+from rclpy.qos import (
+    DurabilityPolicy,
+    HistoryPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
+
+from nodl.models import QoS as NodlQoS
+
+
+def topic_to_identifier(topic: str) -> str:
+    """'/my/long/topic' -> 'my_long_topic'"""
+    return topic.lstrip('/').replace('/', '_')
+
+
+def service_to_identifier(name: str) -> str:
+    """'/my/service' -> 'my_service'"""
+    return name.lstrip('/').replace('/', '_')
+
+
+def qos_from_spec(qos: Optional[NodlQoS]) -> QoSProfile:
+    if qos is None:
+        return QoSProfile(depth=10)
+
+    if qos.history == 'ALL':
+        history = HistoryPolicy.KEEP_ALL
+        depth = 0
+    else:
+        history = HistoryPolicy.KEEP_LAST
+        depth = int(qos.history)
+
+    reliability = (
+        ReliabilityPolicy.RELIABLE
+        if qos.reliability == 'RELIABLE'
+        else ReliabilityPolicy.BEST_EFFORT
+    )
+    durability = (
+        DurabilityPolicy.TRANSIENT_LOCAL
+        if qos.durability == 'TRANSIENT_LOCAL'
+        else DurabilityPolicy.VOLATILE
+    )
+
+    return QoSProfile(
+        history=history,
+        depth=depth,
+        reliability=reliability,
+        durability=durability,
+    )
+
+
+def import_ros_type(ros_type: str):
+    """Import a ROS message/service type from a slash-separated string.
+
+    'std_msgs/msg/String' -> std_msgs.msg.String
+    """
+    parts = ros_type.split('/')
+    if len(parts) < 2:
+        raise ValueError(f'Invalid ROS type string: {ros_type!r}')
+    module_path = '.'.join(parts[:-1])
+    class_name = parts[-1]
+    try:
+        module = importlib.import_module(module_path)
+    except ModuleNotFoundError as exc:
+        raise ImportError(f'Cannot import ROS type {ros_type!r}: {exc}') from exc
+    try:
+        return getattr(module, class_name)
+    except AttributeError as exc:
+        raise ImportError(
+            f'Type {class_name!r} not found in module {module_path!r}'
+        ) from exc

--- a/nodl_rclpy/nodl_rclpy/lifecycle_node.py
+++ b/nodl_rclpy/nodl_rclpy/lifecycle_node.py
@@ -1,0 +1,34 @@
+"""NodlLifecycleNode: rclpy.lifecycle.LifecycleNode initialized from a NoDL document."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+from rclpy.lifecycle import LifecycleNode
+
+from nodl.models import NodlDocument
+from nodl_rclpy._setup import setup_nodl
+from nodl_rclpy.node import _load_doc
+
+
+class NodlLifecycleNode(LifecycleNode):
+    """rclpy.lifecycle.LifecycleNode base class initialized from a NoDL document.
+
+    Same interface as NodlNode; use this when the node participates in the
+    ROS 2 managed-node lifecycle.
+    """
+
+    def __init__(
+        self,
+        nodl_source: Union[str, Path, dict, NodlDocument],
+        node_name: str | None = None,
+        **kwargs,
+    ):
+        doc = _load_doc(nodl_source)
+        name = node_name or (doc.node.name if doc.node else None)
+        if not name:
+            raise ValueError(
+                'node_name must be supplied when the NoDL document has no node.name'
+            )
+        super().__init__(name, **kwargs)
+        setup_nodl(self, doc)

--- a/nodl_rclpy/nodl_rclpy/node.py
+++ b/nodl_rclpy/nodl_rclpy/node.py
@@ -1,0 +1,50 @@
+"""NodlNode: rclpy.node.Node initialized from a NoDL document."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+import rclpy.node
+
+from nodl.models import NodlDocument
+from nodl.schema import load_nodl
+from nodl_rclpy._setup import setup_nodl
+
+
+def _load_doc(source: Union[str, Path, dict, NodlDocument]) -> NodlDocument:
+    if isinstance(source, NodlDocument):
+        return source
+    if isinstance(source, dict):
+        return NodlDocument.model_validate(source)
+    with open(source) as f:
+        return load_nodl(f)
+
+
+class NodlNode(rclpy.node.Node):
+    """rclpy.node.Node base class initialized from a NoDL document.
+
+    Publishers, subscriptions, service clients/servers, and parameters are
+    created at construction time from the NoDL spec.  Subscription and service
+    server callbacks are resolved by looking for an on_<identifier> method on
+    the subclass instance.
+
+    The nodl_source argument accepts:
+      - a file path (str or Path) to a .nodl.yaml file
+      - a plain dict matching the NoDL schema
+      - a NodlDocument instance
+    """
+
+    def __init__(
+        self,
+        nodl_source: Union[str, Path, dict, NodlDocument],
+        node_name: str | None = None,
+        **kwargs,
+    ):
+        doc = _load_doc(nodl_source)
+        name = node_name or (doc.node.name if doc.node else None)
+        if not name:
+            raise ValueError(
+                'node_name must be supplied when the NoDL document has no node.name'
+            )
+        super().__init__(name, **kwargs)
+        setup_nodl(self, doc)

--- a/nodl_rclpy/nodl_rclpy/params.py
+++ b/nodl_rclpy/nodl_rclpy/params.py
@@ -1,0 +1,95 @@
+"""Runtime parameter listener and typed params snapshot.
+
+Analogous to the ParamListener / Params pair produced by generate_parameter_library,
+but implemented entirely at runtime without code generation.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Dict
+
+from rcl_interfaces.msg import ParameterDescriptor, ParameterType, SetParametersResult
+from rclpy.exceptions import ParameterUninitializedException
+from rclpy.parameter import Parameter as RclpyParameter
+
+from nodl.models import Parameter
+
+if TYPE_CHECKING:
+    import rclpy.node
+
+
+# Maps NoDL type string to rcl_interfaces ParameterType int (used in descriptors).
+_NODL_TO_PARAM_TYPE: Dict[str, int] = {
+    'bool': ParameterType.PARAMETER_BOOL,
+    'int': ParameterType.PARAMETER_INTEGER,
+    'double': ParameterType.PARAMETER_DOUBLE,
+    'string': ParameterType.PARAMETER_STRING,
+    'byte_array': ParameterType.PARAMETER_BYTE_ARRAY,
+    'bool_array': ParameterType.PARAMETER_BOOL_ARRAY,
+    'int_array': ParameterType.PARAMETER_INTEGER_ARRAY,
+    'double_array': ParameterType.PARAMETER_DOUBLE_ARRAY,
+    'string_array': ParameterType.PARAMETER_STRING_ARRAY,
+}
+
+# Maps NoDL type string to rclpy Parameter.Type enum (used when declaring without a default).
+_NODL_TO_RCLPY_TYPE: Dict[str, RclpyParameter.Type] = {
+    'bool': RclpyParameter.Type.BOOL,
+    'int': RclpyParameter.Type.INTEGER,
+    'double': RclpyParameter.Type.DOUBLE,
+    'string': RclpyParameter.Type.STRING,
+    'byte_array': RclpyParameter.Type.BYTE_ARRAY,
+    'bool_array': RclpyParameter.Type.BOOL_ARRAY,
+    'int_array': RclpyParameter.Type.INTEGER_ARRAY,
+    'double_array': RclpyParameter.Type.DOUBLE_ARRAY,
+    'string_array': RclpyParameter.Type.STRING_ARRAY,
+}
+
+
+class NodlParams(SimpleNamespace):
+    """Typed snapshot of declared NoDL parameters, accessible as attributes.
+
+    Constructed by NodlParameterListener.get_params().  Attributes correspond
+    to parameter names; values are Python-typed (float, int, bool, str, list).
+    """
+
+
+class NodlParameterListener:
+    """Declares NoDL parameters on a node and maintains a live snapshot.
+
+    Usage mirrors generate_parameter_library's ParamListener::get_params():
+
+        self.param_listener_ = NodlParameterListener(self, doc.parameters)
+        self.params_ = self.param_listener_.get_params()
+    """
+
+    def __init__(self, node: 'rclpy.node.Node', parameters: Dict[str, Parameter]):
+        self._node = node
+        self._snapshot: dict = {}
+
+        for name, spec in parameters.items():
+            descriptor = ParameterDescriptor(
+                description=spec.description or '',
+                read_only=bool(spec.read_only),
+                type=_NODL_TO_PARAM_TYPE[spec.type],
+            )
+            if spec.default_value is not None:
+                node.declare_parameter(name, spec.default_value, descriptor)
+            else:
+                node.declare_parameter(name, _NODL_TO_RCLPY_TYPE[spec.type], descriptor)
+
+            try:
+                self._snapshot[name] = node.get_parameter(name).value
+            except ParameterUninitializedException:
+                self._snapshot[name] = None
+
+        node.add_on_set_parameters_callback(self._on_set_parameters)
+
+    def _on_set_parameters(self, params):
+        for p in params:
+            if p.name in self._snapshot:
+                self._snapshot[p.name] = p.value
+        return SetParametersResult(successful=True)
+
+    def get_params(self) -> NodlParams:
+        """Return a snapshot of current parameter values."""
+        return NodlParams(**self._snapshot)

--- a/nodl_rclpy/package.xml
+++ b/nodl_rclpy/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>nodl_rclpy</name>
+  <version>0.1.0</version>
+  <description>NoDL runtime base node for Python rclpy nodes.</description>
+  <maintainer email="emerson@polymathrobotics.com">Emerson Knapp</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <depend>nodl</depend>
+  <depend>rclpy</depend>
+  <depend>rcl_interfaces</depend>
+
+  <test_depend>python3-pytest</test_depend>
+  <test_depend>std_msgs</test_depend>
+  <test_depend>std_srvs</test_depend>
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_pep257</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/nodl_rclpy/setup.cfg
+++ b/nodl_rclpy/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/nodl_rclpy
+[install]
+install_scripts=$base/lib/nodl_rclpy

--- a/nodl_rclpy/setup.py
+++ b/nodl_rclpy/setup.py
@@ -1,0 +1,21 @@
+from setuptools import find_packages, setup
+
+package_name = 'nodl_rclpy'
+
+setup(
+    name=package_name,
+    version='0.1.0',
+    packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/ament_index/resource_index/packages', ['resource/nodl_rclpy']),
+        ('share/' + package_name, ['package.xml']),
+    ],
+    install_requires=['setuptools'],
+    tests_require=['pytest'],
+    zip_safe=True,
+    maintainer='Emerson Knapp',
+    maintainer_email='emerson@polymathrobotics.com',
+    description='NoDL runtime base node for Python rclpy nodes.',
+    license='Apache License 2.0',
+    entry_points={},
+)

--- a/nodl_rclpy/test/test_lifecycle_node.py
+++ b/nodl_rclpy/test/test_lifecycle_node.py
@@ -1,0 +1,70 @@
+"""Integration tests for NodlLifecycleNode."""
+import pytest
+import rclpy
+
+from std_msgs.msg import String
+
+from nodl_rclpy import NodlLifecycleNode
+
+
+@pytest.fixture(autouse=True)
+def rclpy_context():
+    rclpy.init()
+    yield
+    rclpy.shutdown()
+
+
+_NODL_FULL = {
+    'node': {'name': 'lc_test_node'},
+    'parameters': {
+        'rate': {'type': 'double', 'default_value': 5.0},
+    },
+    'publishers': [
+        {'topic': '/lc_out', 'type': 'std_msgs/msg/String'},
+    ],
+    'subscriptions': [
+        {'topic': '/lc_in', 'type': 'std_msgs/msg/String'},
+    ],
+}
+
+
+class ConcreteLifecycleNode(NodlLifecycleNode):
+    def __init__(self):
+        super().__init__(_NODL_FULL)
+
+    def on_lc_in(self, msg: String):
+        pass
+
+
+def test_lifecycle_node_name():
+    node = ConcreteLifecycleNode()
+    assert node.get_name() == 'lc_test_node'
+    node.destroy_node()
+
+
+def test_lifecycle_node_has_publisher():
+    node = ConcreteLifecycleNode()
+    assert hasattr(node, 'pub_lc_out_')
+    assert node.pub_lc_out_ is not None
+    node.destroy_node()
+
+
+def test_lifecycle_node_has_subscription():
+    node = ConcreteLifecycleNode()
+    assert hasattr(node, 'sub_lc_in_')
+    assert node.sub_lc_in_ is not None
+    node.destroy_node()
+
+
+def test_lifecycle_node_params():
+    node = ConcreteLifecycleNode()
+    assert hasattr(node, 'params_')
+    assert node.params_.rate == pytest.approx(5.0)
+    node.destroy_node()
+
+
+def test_lifecycle_node_is_lifecycle():
+    from rclpy.lifecycle import LifecycleNode
+    node = ConcreteLifecycleNode()
+    assert isinstance(node, LifecycleNode)
+    node.destroy_node()

--- a/nodl_rclpy/test/test_node.py
+++ b/nodl_rclpy/test/test_node.py
@@ -1,0 +1,180 @@
+"""Integration tests for NodlNode."""
+import pytest
+import rclpy
+
+from std_msgs.msg import String
+
+from nodl_rclpy import NodlNode
+
+
+@pytest.fixture(autouse=True)
+def rclpy_context():
+    rclpy.init()
+    yield
+    rclpy.shutdown()
+
+
+_NODL_FULL = {
+    'node': {'name': 'test_node'},
+    'parameters': {
+        'publish_rate': {'type': 'double', 'default_value': 10.0},
+        'frame_id': {'type': 'string', 'default_value': 'base_link'},
+        'enabled': {'type': 'bool', 'default_value': True, 'read_only': True},
+    },
+    'publishers': [
+        {'topic': '/output', 'type': 'std_msgs/msg/String',
+         'qos': {'history': 10, 'reliability': 'RELIABLE'}},
+    ],
+    'subscriptions': [
+        {'topic': '/input', 'type': 'std_msgs/msg/String',
+         'qos': {'history': 5, 'reliability': 'BEST_EFFORT'}},
+    ],
+}
+
+_NODL_MINIMAL = {
+    'node': {'name': 'minimal_node'},
+}
+
+
+class ConcreteNode(NodlNode):
+    def __init__(self, nodl=_NODL_FULL):
+        super().__init__(nodl)
+        self.input_count = 0
+
+    def on_input(self, msg: String):
+        self.input_count += 1
+
+
+class MinimalNode(NodlNode):
+    def __init__(self):
+        super().__init__(_NODL_MINIMAL)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+def test_node_name_from_nodl():
+    node = ConcreteNode()
+    assert node.get_name() == 'test_node'
+    node.destroy_node()
+
+
+def test_node_name_override():
+    node = NodlNode(_NODL_MINIMAL, node_name='overridden')
+    assert node.get_name() == 'overridden'
+    node.destroy_node()
+
+
+def test_no_name_raises():
+    with pytest.raises(ValueError):
+        NodlNode({'publishers': []})
+
+
+def test_dict_source():
+    node = MinimalNode()
+    assert node.get_name() == 'minimal_node'
+    node.destroy_node()
+
+
+# ---------------------------------------------------------------------------
+# Publishers
+# ---------------------------------------------------------------------------
+
+def test_publisher_exists():
+    node = ConcreteNode()
+    assert hasattr(node, 'pub_output_')
+    assert node.pub_output_ is not None
+    node.destroy_node()
+
+
+def test_publisher_correct_type():
+    node = ConcreteNode()
+    assert node.pub_output_.msg_type is String
+    node.destroy_node()
+
+
+# ---------------------------------------------------------------------------
+# Subscriptions
+# ---------------------------------------------------------------------------
+
+def test_subscription_exists():
+    node = ConcreteNode()
+    assert hasattr(node, 'sub_input_')
+    assert node.sub_input_ is not None
+    node.destroy_node()
+
+
+def test_subscription_missing_callback_skipped(caplog):
+    import logging
+
+    class NoCallbackNode(NodlNode):
+        def __init__(self):
+            super().__init__(_NODL_FULL)
+
+    with caplog.at_level(logging.WARNING):
+        node = NoCallbackNode()
+    assert not hasattr(node, 'sub_input_')
+    node.destroy_node()
+
+
+# ---------------------------------------------------------------------------
+# Parameters
+# ---------------------------------------------------------------------------
+
+def test_params_attribute_exists():
+    node = ConcreteNode()
+    assert hasattr(node, 'params_')
+    node.destroy_node()
+
+
+def test_param_listener_attribute_exists():
+    node = ConcreteNode()
+    assert hasattr(node, 'param_listener_')
+    node.destroy_node()
+
+
+def test_default_param_values():
+    node = ConcreteNode()
+    assert node.params_.publish_rate == pytest.approx(10.0)
+    assert node.params_.frame_id == 'base_link'
+    assert node.params_.enabled is True
+    node.destroy_node()
+
+
+def test_params_declared_on_node():
+    node = ConcreteNode()
+    assert node.has_parameter('publish_rate')
+    assert node.has_parameter('frame_id')
+    assert node.has_parameter('enabled')
+    node.destroy_node()
+
+
+def test_read_only_param():
+    node = ConcreteNode()
+    desc = node.describe_parameter('enabled')
+    assert desc.read_only is True
+    node.destroy_node()
+
+
+def test_no_params_section_no_listener():
+    node = MinimalNode()
+    assert not hasattr(node, 'param_listener_')
+    assert not hasattr(node, 'params_')
+    node.destroy_node()
+
+
+# ---------------------------------------------------------------------------
+# File path source
+# ---------------------------------------------------------------------------
+
+def test_file_path_source(tmp_path):
+    nodl_file = tmp_path / 'my_node.nodl.yaml'
+    nodl_file.write_text(
+        'nodl_version: "1"\n'
+        'node:\n'
+        '  name: file_node\n'
+    )
+    node = NodlNode(nodl_file)
+    assert node.get_name() == 'file_node'
+    node.destroy_node()

--- a/nodl_rclpy/test/test_params.py
+++ b/nodl_rclpy/test/test_params.py
@@ -1,0 +1,77 @@
+"""Tests for NodlParameterListener and NodlParams."""
+import pytest
+import rclpy
+
+from nodl_rclpy.params import NodlParameterListener, NodlParams
+from nodl.models import Parameter
+
+
+@pytest.fixture(autouse=True)
+def rclpy_context():
+    rclpy.init()
+    yield
+    rclpy.shutdown()
+
+
+def _make_node(name='test_params_node'):
+    return rclpy.create_node(name)
+
+
+_PARAMS_SCHEMA = {
+    'rate': Parameter(type='double', default_value=10.0, description='Publish rate'),
+    'frame_id': Parameter(type='string', default_value='base_link'),
+    'enabled': Parameter(type='bool', default_value=True, read_only=True),
+}
+
+
+def test_listener_declares_parameters():
+    node = _make_node()
+    NodlParameterListener(node, _PARAMS_SCHEMA)
+    assert node.has_parameter('rate')
+    assert node.has_parameter('frame_id')
+    assert node.has_parameter('enabled')
+    node.destroy_node()
+
+
+def test_get_params_returns_nodl_params():
+    node = _make_node()
+    listener = NodlParameterListener(node, _PARAMS_SCHEMA)
+    params = listener.get_params()
+    assert isinstance(params, NodlParams)
+    node.destroy_node()
+
+
+def test_params_default_values():
+    node = _make_node()
+    listener = NodlParameterListener(node, _PARAMS_SCHEMA)
+    params = listener.get_params()
+    assert params.rate == pytest.approx(10.0)
+    assert params.frame_id == 'base_link'
+    assert params.enabled is True
+    node.destroy_node()
+
+
+def test_read_only_parameter():
+    from rcl_interfaces.msg import ParameterType
+    node = _make_node()
+    NodlParameterListener(node, _PARAMS_SCHEMA)
+    desc = node.describe_parameter('enabled')
+    assert desc.read_only is True
+    node.destroy_node()
+
+
+def test_snapshot_updates_on_set_parameter():
+    node = _make_node()
+    listener = NodlParameterListener(node, _PARAMS_SCHEMA)
+    node.set_parameters([rclpy.parameter.Parameter('rate', value=20.0)])
+    params = listener.get_params()
+    assert params.rate == pytest.approx(20.0)
+    node.destroy_node()
+
+
+def test_no_default_value_declares_by_type():
+    schema = {'count': Parameter(type='int')}
+    node = _make_node()
+    NodlParameterListener(node, schema)
+    assert node.has_parameter('count')
+    node.destroy_node()

--- a/nodl_rclpy/test/test_support.py
+++ b/nodl_rclpy/test/test_support.py
@@ -1,0 +1,100 @@
+"""Unit tests for _support helpers — no rclpy required."""
+import pytest
+
+from nodl_rclpy._support import (
+    import_ros_type,
+    qos_from_spec,
+    service_to_identifier,
+    topic_to_identifier,
+)
+from nodl.models import QoS as NodlQoS
+
+
+# ---------------------------------------------------------------------------
+# topic_to_identifier / service_to_identifier
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('topic,expected', [
+    ('/scan', 'scan'),
+    ('/my/long/topic', 'my_long_topic'),
+    ('relative', 'relative'),
+    ('/a/b', 'a_b'),
+])
+def test_topic_to_identifier(topic, expected):
+    assert topic_to_identifier(topic) == expected
+
+
+@pytest.mark.parametrize('name,expected', [
+    ('/set_bool', 'set_bool'),
+    ('/robot/reset', 'robot_reset'),
+    ('plain', 'plain'),
+])
+def test_service_to_identifier(name, expected):
+    assert service_to_identifier(name) == expected
+
+
+# ---------------------------------------------------------------------------
+# qos_from_spec
+# ---------------------------------------------------------------------------
+
+def test_qos_default_when_none():
+    qos = qos_from_spec(None)
+    assert qos.depth == 10
+
+
+def test_qos_reliable():
+    from rclpy.qos import ReliabilityPolicy
+    spec = NodlQoS(history=5, reliability='RELIABLE')
+    qos = qos_from_spec(spec)
+    assert qos.reliability == ReliabilityPolicy.RELIABLE
+    assert qos.depth == 5
+
+
+def test_qos_best_effort():
+    from rclpy.qos import ReliabilityPolicy
+    spec = NodlQoS(history=5, reliability='BEST_EFFORT')
+    qos = qos_from_spec(spec)
+    assert qos.reliability == ReliabilityPolicy.BEST_EFFORT
+
+
+def test_qos_keep_all():
+    from rclpy.qos import HistoryPolicy
+    spec = NodlQoS(history='ALL', reliability='RELIABLE')
+    qos = qos_from_spec(spec)
+    assert qos.history == HistoryPolicy.KEEP_ALL
+
+
+def test_qos_transient_local():
+    from rclpy.qos import DurabilityPolicy
+    spec = NodlQoS(history=10, reliability='RELIABLE', durability='TRANSIENT_LOCAL')
+    qos = qos_from_spec(spec)
+    assert qos.durability == DurabilityPolicy.TRANSIENT_LOCAL
+
+
+# ---------------------------------------------------------------------------
+# import_ros_type
+# ---------------------------------------------------------------------------
+
+def test_import_ros_type_msg():
+    from std_msgs.msg import String
+    assert import_ros_type('std_msgs/msg/String') is String
+
+
+def test_import_ros_type_srv():
+    from std_srvs.srv import SetBool
+    assert import_ros_type('std_srvs/srv/SetBool') is SetBool
+
+
+def test_import_ros_type_invalid_module():
+    with pytest.raises(ImportError):
+        import_ros_type('nonexistent_pkg/msg/Foo')
+
+
+def test_import_ros_type_invalid_class():
+    with pytest.raises(ImportError):
+        import_ros_type('std_msgs/msg/NoSuchType')
+
+
+def test_import_ros_type_bad_string():
+    with pytest.raises(ValueError):
+        import_ros_type('bare_name')


### PR DESCRIPTION
Loads .nodl.yaml files and applies declared parameters, publishers, subscriptions, and lifecycle structure to an rclpy Node, so a node's runtime interface follows its declared NoDL description.

Modules:
- node, lifecycle_node: NoDL-aware Node / LifecycleNode wrappers
- params: parameter declaration helpers
- _setup, _support: internal binding/lookup helpers

Independent of codegen and ros2 CLI features.