### PR TITLE
Add nodl describe: graph introspection and Node.msg conversion

### DIFF
--- a/nodl/nodl/conversion.py
+++ b/nodl/nodl/conversion.py
@@ -1,0 +1,269 @@
+"""Convert rosgraph_msgs.msg.Node to a NoDL document."""
+
+from __future__ import annotations
+
+from rcl_interfaces.msg import ParameterType
+from rcl_interfaces.msg import ParameterValue as RosParameterValue
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, LivelinessPolicy, ReliabilityPolicy
+
+from nodl.models import (
+    ActionEndpoint,
+    NodlDocument,
+    Parameter,
+    QoS,
+    ServiceEndpoint,
+    TopicEndpoint,
+)
+
+# Maps rcl_interfaces ParameterType constant -> NoDL type string
+_PARAM_TYPE_NAMES: dict[int, str | None] = {
+    ParameterType.PARAMETER_NOT_SET: None,
+    ParameterType.PARAMETER_BOOL: 'bool',
+    ParameterType.PARAMETER_INTEGER: 'int',
+    ParameterType.PARAMETER_DOUBLE: 'double',
+    ParameterType.PARAMETER_STRING: 'string',
+    ParameterType.PARAMETER_BYTE_ARRAY: None,  # not supported by generate_parameter_library
+    ParameterType.PARAMETER_BOOL_ARRAY: 'bool_array',
+    ParameterType.PARAMETER_INTEGER_ARRAY: 'int_array',
+    ParameterType.PARAMETER_DOUBLE_ARRAY: 'double_array',
+    ParameterType.PARAMETER_STRING_ARRAY: 'string_array',
+}
+
+# Maps rcl_interfaces ParameterType constant -> ParameterValue attribute name
+_PARAM_VALUE_FIELDS: dict[int, str] = {
+    ParameterType.PARAMETER_BOOL: 'bool_value',
+    ParameterType.PARAMETER_INTEGER: 'integer_value',
+    ParameterType.PARAMETER_DOUBLE: 'double_value',
+    ParameterType.PARAMETER_STRING: 'string_value',
+    ParameterType.PARAMETER_BYTE_ARRAY: 'byte_array_value',
+    ParameterType.PARAMETER_BOOL_ARRAY: 'bool_array_value',
+    ParameterType.PARAMETER_INTEGER_ARRAY: 'integer_array_value',
+    ParameterType.PARAMETER_DOUBLE_ARRAY: 'double_array_value',
+    ParameterType.PARAMETER_STRING_ARRAY: 'string_array_value',
+}
+
+# Suffixes of services that every rclcpp/rclpy node automatically creates
+_INTERNAL_PARAM_SERVICE_SUFFIXES = frozenset([
+    'describe_parameters',
+    'get_parameters',
+    'get_parameter_types',
+    'list_parameters',
+    'set_parameters',
+    'set_parameters_atomically',
+])
+
+# Topics automatically published by every rclcpp/rclpy node
+_INTERNAL_TOPICS = frozenset([
+    '/rosout',
+    '/parameter_events',
+])
+
+
+_INT64_MAX = 2**63 - 1  # ROS uses this to represent "infinite" / no-deadline
+
+
+def _duration_to_ns(duration) -> int | None:
+    """Convert a builtin_interfaces/Duration to nanoseconds.
+
+    Returns None for both zero (unset) and INT64_MAX (ROS infinite sentinel).
+    """
+    total_ns = duration.sec * 1_000_000_000 + duration.nanosec
+    if total_ns == 0 or total_ns >= _INT64_MAX:
+        return None
+    return total_ns
+
+
+def _qos_to_model(qos) -> QoS:
+    """Convert a rosgraph_msgs.msg.QoSProfile to a QoS model.
+
+    Always returns a QoS; unknown/unrecognized policies map to SYSTEM_DEFAULT.
+    """
+    kwargs: dict = {}
+
+    try:
+        h = HistoryPolicy(qos.history)
+        if h is HistoryPolicy.KEEP_LAST:
+            kwargs['history'] = 'KEEP_LAST'
+            kwargs['depth'] = max(1, qos.depth)
+        elif h is HistoryPolicy.KEEP_ALL:
+            kwargs['history'] = 'KEEP_ALL'
+        else:
+            kwargs['history'] = 'SYSTEM_DEFAULT'
+    except ValueError:
+        kwargs['history'] = 'SYSTEM_DEFAULT'
+
+    try:
+        r = ReliabilityPolicy(qos.reliability)
+        if r is ReliabilityPolicy.RELIABLE:
+            kwargs['reliability'] = 'RELIABLE'
+        elif r is ReliabilityPolicy.BEST_EFFORT:
+            kwargs['reliability'] = 'BEST_EFFORT'
+        else:
+            kwargs['reliability'] = 'SYSTEM_DEFAULT'
+    except ValueError:
+        kwargs['reliability'] = 'SYSTEM_DEFAULT'
+
+    try:
+        d = DurabilityPolicy(qos.durability)
+        if d is DurabilityPolicy.TRANSIENT_LOCAL:
+            kwargs['durability'] = 'TRANSIENT_LOCAL'
+        elif d is DurabilityPolicy.VOLATILE:
+            kwargs['durability'] = 'VOLATILE'
+    except ValueError:
+        pass
+
+    deadline_ns = _duration_to_ns(qos.deadline)
+    if deadline_ns is not None:
+        kwargs['deadline_ns'] = deadline_ns
+
+    lifespan_ns = _duration_to_ns(qos.lifespan)
+    if lifespan_ns is not None:
+        kwargs['lifespan_ns'] = lifespan_ns
+
+    try:
+        lv = LivelinessPolicy(qos.liveliness)
+        if lv is LivelinessPolicy.AUTOMATIC:
+            kwargs['liveliness'] = 'AUTOMATIC'
+        elif lv is LivelinessPolicy.MANUAL_BY_TOPIC:
+            kwargs['liveliness'] = 'MANUAL_BY_TOPIC'
+    except ValueError:
+        pass
+
+    lease_ns = _duration_to_ns(qos.liveliness_lease_duration)
+    if lease_ns is not None:
+        kwargs['liveliness_lease_duration_ns'] = lease_ns
+
+    return QoS(**kwargs)
+
+
+def _is_internal_service(name: str) -> bool:
+    """Return True if the service name is an internal node service."""
+    suffix = name.rsplit('/', 1)[-1]
+    if suffix in _INTERNAL_PARAM_SERVICE_SUFFIXES:
+        return True
+    if '/_action/' in name:
+        return True
+    return False
+
+
+def _is_internal_topic(name: str) -> bool:
+    """Return True if the topic is an internal node topic."""
+    if name in _INTERNAL_TOPICS:
+        return True
+    if '/_action/' in name:
+        return True
+    return False
+
+
+def _parse_fqn(fqn: str) -> tuple[str, str]:
+    """Split a fully-qualified node name into (namespace, short_name)."""
+    idx = fqn.rfind('/')
+    if idx <= 0:
+        return '/', fqn.lstrip('/')
+    return fqn[:idx], fqn[idx + 1:]
+
+
+def _reconstruct_action_type(action_msg) -> str:
+    """Extract the action type string from an Action.msg.
+
+    The send_goal request type name is stored as the action type directly
+    when produced by nodl.describe, or may have a '_SendGoal' suffix when
+    produced by other tools.
+    """
+    type_name = action_msg.send_goal.request_type.name
+    if type_name.endswith('_SendGoal'):
+        return type_name[:-len('_SendGoal')]
+    return type_name
+
+
+def to_nodl(node_msg, *, assume_current_as_default: bool = False) -> NodlDocument:
+    """Convert a rosgraph_msgs.msg.Node to a NodlDocument.
+
+    assume_current_as_default: if True, treat current parameter values as
+        the default_value field in the output.
+    """
+    # Parameters
+    param_map: dict[str, Parameter] = {}
+    if node_msg.parameters:
+        values_by_name: dict[str, object] = {}
+        if (
+            assume_current_as_default
+            and node_msg.parameter_values
+            and len(node_msg.parameter_values) == len(node_msg.parameters)
+        ):
+            for desc, val in zip(node_msg.parameters, node_msg.parameter_values):
+                field = _PARAM_VALUE_FIELDS.get(val.type)
+                if field:
+                    values_by_name[desc.name] = getattr(val, field)
+
+        for desc in node_msg.parameters:
+            type_name = _PARAM_TYPE_NAMES.get(desc.type)
+            if type_name is None:
+                continue
+
+            param_map[desc.name] = Parameter(
+                type=type_name,
+                description=desc.description or None,
+                read_only=True if desc.read_only else None,
+                additional_constraints=desc.additional_constraints or None,
+                default_value=values_by_name.get(desc.name),
+            )
+
+    # Publishers
+    publishers = [
+        TopicEndpoint(
+            name=topic.name,
+            type=topic.type.name,
+            qos=_qos_to_model(topic.qos),
+        )
+        for topic in node_msg.publishers
+        if not _is_internal_topic(topic.name)
+    ]
+
+    # Subscriptions
+    subscriptions = [
+        TopicEndpoint(
+            name=topic.name,
+            type=topic.type.name,
+            qos=_qos_to_model(topic.qos),
+        )
+        for topic in node_msg.subscriptions
+        if not _is_internal_topic(topic.name)
+    ]
+
+    # Service servers
+    service_servers = [
+        ServiceEndpoint(name=srv.name, type=srv.request_type.name)
+        for srv in node_msg.service_servers
+        if not _is_internal_service(srv.name)
+    ]
+
+    # Service clients
+    service_clients = [
+        ServiceEndpoint(name=srv.name, type=srv.request_type.name)
+        for srv in node_msg.service_clients
+        if not _is_internal_service(srv.name)
+    ]
+
+    # Action servers
+    action_servers = [
+        ActionEndpoint(name=action.name, type=_reconstruct_action_type(action))
+        for action in node_msg.action_servers
+    ]
+
+    # Action clients
+    action_clients = [
+        ActionEndpoint(name=action.name, type=_reconstruct_action_type(action))
+        for action in node_msg.action_clients
+    ]
+
+    return NodlDocument(
+        nodl_version=2,
+        parameters=param_map or None,
+        publishers=publishers or None,
+        subscriptions=subscriptions or None,
+        service_servers=service_servers or None,
+        service_clients=service_clients or None,
+        action_servers=action_servers or None,
+        action_clients=action_clients or None,
+    )

--- a/nodl/nodl/describe.py
+++ b/nodl/nodl/describe.py
@@ -1,0 +1,223 @@
+"""Graph introspection to produce a rosgraph_msgs.msg.Node representation."""
+
+from __future__ import annotations
+
+import time
+
+import rclpy
+import rclpy.executors
+from builtin_interfaces.msg import Duration
+from rcl_interfaces.srv import DescribeParameters, ListParameters
+from rosgraph_msgs.msg import Action, InterfaceType
+from rosgraph_msgs.msg import Node as NodeMsg
+from rosgraph_msgs.msg import QoSProfile as RosQoS
+from rosgraph_msgs.msg import Service, Topic
+
+
+def _ns_to_duration(ns: int) -> Duration:
+    return Duration(sec=ns // 1_000_000_000, nanosec=ns % 1_000_000_000)
+
+
+def _rclpy_qos_to_ros_qos(rclpy_qos) -> RosQoS:
+    """Convert rclpy.qos.QoSProfile to rosgraph_msgs.msg.QoSProfile."""
+    q = RosQoS()
+    q.history = rclpy_qos.history.value
+    q.depth = rclpy_qos.depth
+    q.reliability = rclpy_qos.reliability.value
+    q.durability = rclpy_qos.durability.value
+    q.liveliness = rclpy_qos.liveliness.value
+    q.deadline = _ns_to_duration(rclpy_qos.deadline.nanoseconds)
+    q.lifespan = _ns_to_duration(rclpy_qos.lifespan.nanoseconds)
+    q.liveliness_lease_duration = _ns_to_duration(rclpy_qos.liveliness_lease_duration.nanoseconds)
+    return q
+
+
+def _get_topic_qos(
+    node, topic_name: str, node_name: str, node_namespace: str, is_publisher: bool
+) -> RosQoS:
+    """Return RosQoS for a specific node's topic endpoint, or a default if not found."""
+    fqn = f'{node_namespace}/{node_name}'.replace('//', '/')
+    infos = (
+        node.get_publishers_info_by_topic(topic_name)
+        if is_publisher
+        else node.get_subscriptions_info_by_topic(topic_name)
+    )
+    for info in infos:
+        info_fqn = f'{info.node_namespace}/{info.node_name}'.replace('//', '/')
+        if info_fqn == fqn:
+            return _rclpy_qos_to_ros_qos(info.qos_profile)
+    return RosQoS()
+
+
+def _call_service_sync(node, client, request, timeout_sec: float = 5.0):
+    """Make a synchronous service call, returning the result or None on timeout."""
+    if not client.wait_for_service(timeout_sec=timeout_sec):
+        return None
+    future = client.call_async(request)
+    rclpy.spin_until_future_complete(node, future, timeout_sec=timeout_sec)
+    return future.result()
+
+
+def _get_parameters(node, target_node_fqn: str) -> tuple[list, list]:
+    """Fetch ParameterDescriptors from a running node via its parameter services."""
+    list_client = node.create_client(ListParameters, f'{target_node_fqn}/list_parameters')
+    response = _call_service_sync(node, list_client, ListParameters.Request())
+    node.destroy_client(list_client)
+
+    if response is None:
+        return [], []
+
+    param_names = list(response.result.names)
+    if not param_names:
+        return [], []
+
+    describe_client = node.create_client(
+        DescribeParameters, f'{target_node_fqn}/describe_parameters'
+    )
+    req = DescribeParameters.Request()
+    req.names = param_names
+    desc_response = _call_service_sync(node, describe_client, req)
+    node.destroy_client(describe_client)
+
+    if desc_response is None:
+        return [], []
+
+    return list(desc_response.descriptors), []
+
+
+def _spin_briefly(node, duration_sec: float) -> None:
+    """Spin briefly to allow graph discovery to settle."""
+    executor = rclpy.executors.SingleThreadedExecutor()
+    executor.add_node(node)
+    deadline = time.time() + duration_sec
+    while time.time() < deadline:
+        executor.spin_once(timeout_sec=0.1)
+    executor.remove_node(node)
+
+
+def describe(node_name: str, *, discovery_timeout_sec: float = 2.0) -> NodeMsg:
+    """Introspect a running ROS 2 node and return a rosgraph_msgs.msg.Node.
+
+    node_name: fully qualified node name, e.g. '/my_ns/my_node' or '/my_node'.
+    discovery_timeout_sec: time to wait for graph discovery before introspecting.
+
+    Raises RuntimeError if the node is not found in the graph.
+    Initializes rclpy if not already initialized; shuts it down only if this
+    call initialized it.
+    """
+    node_name = node_name if node_name.startswith('/') else f'/{node_name}'
+
+    idx = node_name.rfind('/')
+    if idx <= 0:
+        namespace = '/'
+        short_name = node_name.lstrip('/')
+    else:
+        namespace = node_name[:idx]
+        short_name = node_name[idx + 1:]
+
+    initialized_here = not rclpy.ok()
+    if initialized_here:
+        rclpy.init()
+
+    introspect_node = rclpy.create_node('_nodl_describer')
+    try:
+        _spin_briefly(introspect_node, discovery_timeout_sec)
+
+        known = introspect_node.get_node_names_and_namespaces()
+        if (short_name, namespace) not in known:
+            raise RuntimeError(
+                f"Node '{node_name}' not found in the graph. "
+                f"Available: {[(n, ns) for n, ns in known]}"
+            )
+
+        publishers = [
+            Topic(
+                name=topic,
+                type=InterfaceType(name=types[0] if types else ''),
+                qos=_get_topic_qos(introspect_node, topic, short_name, namespace, True),
+            )
+            for topic, types in introspect_node.get_publisher_names_and_types_by_node(
+                short_name, namespace
+            )
+        ]
+
+        subscriptions = [
+            Topic(
+                name=topic,
+                type=InterfaceType(name=types[0] if types else ''),
+                qos=_get_topic_qos(introspect_node, topic, short_name, namespace, False),
+            )
+            for topic, types in introspect_node.get_subscriber_names_and_types_by_node(
+                short_name, namespace
+            )
+        ]
+
+        action_server_info = introspect_node.get_action_server_names_and_types_by_node(
+            short_name, namespace
+        )
+        action_client_info = introspect_node.get_action_client_names_and_types_by_node(
+            short_name, namespace
+        )
+
+        action_servers = [
+            Action(
+                name=action_name,
+                send_goal=Service(
+                    request_type=InterfaceType(name=types[0] if types else '')
+                ),
+            )
+            for action_name, types in action_server_info
+        ]
+
+        action_clients = [
+            Action(
+                name=action_name,
+                send_goal=Service(
+                    request_type=InterfaceType(name=types[0] if types else '')
+                ),
+            )
+            for action_name, types in action_client_info
+        ]
+
+        service_servers = [
+            Service(
+                name=srv_name,
+                request_type=InterfaceType(name=types[0] if types else ''),
+                response_type=InterfaceType(name=types[0] if types else ''),
+            )
+            for srv_name, types in introspect_node.get_service_names_and_types_by_node(
+                short_name, namespace
+            )
+            if '/_action/' not in srv_name
+        ]
+
+        service_clients = [
+            Service(
+                name=srv_name,
+                request_type=InterfaceType(name=types[0] if types else ''),
+                response_type=InterfaceType(name=types[0] if types else ''),
+            )
+            for srv_name, types in introspect_node.get_client_names_and_types_by_node(
+                short_name, namespace
+            )
+            if '/_action/' not in srv_name
+        ]
+
+        parameters, parameter_values = _get_parameters(introspect_node, node_name)
+
+        return NodeMsg(
+            name=node_name,
+            parameters=parameters,
+            parameter_values=parameter_values,
+            publishers=publishers,
+            subscriptions=subscriptions,
+            service_servers=service_servers,
+            service_clients=service_clients,
+            action_servers=action_servers,
+            action_clients=action_clients,
+        )
+
+    finally:
+        introspect_node.destroy_node()
+        if initialized_here:
+            rclpy.shutdown()

--- a/nodl/package.xml
+++ b/nodl/package.xml
@@ -12,10 +12,16 @@
   <depend>python3-yaml</depend>
   <depend>python3-jsonschema</depend>
   <depend>python3-pydantic</depend>
+  <depend>rosgraph_msgs</depend>
+  <depend>rcl_interfaces</depend>
+  <depend>rclpy</depend>
 
   <test_depend>python3-pytest</test_depend>
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_pep257</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/nodl/test/test_conversion.py
+++ b/nodl/test/test_conversion.py
@@ -1,0 +1,501 @@
+"""Unit tests for NoDL Node.msg conversion.
+
+Uses lightweight dataclass mocks so no ROS environment is required.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+import pytest
+
+from nodl.conversion import (
+    _duration_to_ns,
+    _is_internal_service,
+    _is_internal_topic,
+    _parse_fqn,
+    _qos_to_model,
+    _reconstruct_action_type,
+    to_nodl,
+)
+from nodl.models import NodlDocument
+
+
+# ---------------------------------------------------------------------------
+# Minimal message mocks
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Duration:
+    sec: int = 0
+    nanosec: int = 0
+
+
+@dataclass
+class QoSProfile:
+    depth: int = 10
+    history: int = 1          # KEEP_LAST
+    reliability: int = 1      # RELIABLE
+    durability: int = 2       # VOLATILE
+    liveliness: int = 1       # AUTOMATIC
+    deadline: Duration = field(default_factory=Duration)
+    lifespan: Duration = field(default_factory=Duration)
+    liveliness_lease_duration: Duration = field(default_factory=Duration)
+
+
+@dataclass
+class InterfaceType:
+    name: str = ''
+
+
+@dataclass
+class Topic:
+    name: str = ''
+    type: InterfaceType = field(default_factory=InterfaceType)
+    qos: QoSProfile = field(default_factory=QoSProfile)
+
+
+@dataclass
+class Service:
+    name: str = ''
+    request_type: InterfaceType = field(default_factory=InterfaceType)
+    response_type: InterfaceType = field(default_factory=InterfaceType)
+    request_qos: QoSProfile = field(default_factory=QoSProfile)
+    response_qos: QoSProfile = field(default_factory=QoSProfile)
+
+
+@dataclass
+class Action:
+    name: str = ''
+    send_goal: Service = field(default_factory=Service)
+    get_result: Service = field(default_factory=Service)
+    cancel_goal: Service = field(default_factory=Service)
+    feedback: Topic = field(default_factory=Topic)
+    status: Topic = field(default_factory=Topic)
+
+
+@dataclass
+class ParameterDescriptor:
+    name: str = ''
+    type: int = 0
+    description: str = ''
+    additional_constraints: str = ''
+    read_only: bool = False
+    dynamic_typing: bool = False
+
+
+@dataclass
+class ParameterValue:
+    type: int = 0
+    bool_value: bool = False
+    integer_value: int = 0
+    double_value: float = 0.0
+    string_value: str = ''
+    byte_array_value: List[int] = field(default_factory=list)
+    bool_array_value: List[bool] = field(default_factory=list)
+    integer_array_value: List[int] = field(default_factory=list)
+    double_array_value: List[float] = field(default_factory=list)
+    string_array_value: List[str] = field(default_factory=list)
+
+
+@dataclass
+class NodeMsg:
+    name: str = '/test_node'
+    parameters: List[ParameterDescriptor] = field(default_factory=list)
+    parameter_values: List[ParameterValue] = field(default_factory=list)
+    publishers: List[Topic] = field(default_factory=list)
+    subscriptions: List[Topic] = field(default_factory=list)
+    service_servers: List[Service] = field(default_factory=list)
+    service_clients: List[Service] = field(default_factory=list)
+    action_servers: List[Action] = field(default_factory=list)
+    action_clients: List[Action] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Helper tests
+# ---------------------------------------------------------------------------
+
+def test_parse_fqn_with_namespace():
+    assert _parse_fqn('/my_ns/my_node') == ('/my_ns', 'my_node')
+
+
+def test_parse_fqn_root_namespace():
+    assert _parse_fqn('/my_node') == ('/', 'my_node')
+
+
+def test_parse_fqn_deep_namespace():
+    assert _parse_fqn('/a/b/c/node') == ('/a/b/c', 'node')
+
+
+def test_is_internal_service_param_services():
+    for suffix in ['list_parameters', 'get_parameters', 'set_parameters',
+                   'describe_parameters', 'get_parameter_types', 'set_parameters_atomically']:
+        assert _is_internal_service(f'/my_node/{suffix}')
+
+
+def test_is_internal_service_action():
+    assert _is_internal_service('/my_node/_action/send_goal')
+    assert _is_internal_service('/my_node/_action/cancel_goal')
+    assert _is_internal_service('/my_node/_action/get_result')
+
+
+def test_is_internal_service_user_service():
+    assert not _is_internal_service('/my_node/do_thing')
+
+
+def test_is_internal_topic_rosout():
+    assert _is_internal_topic('/rosout')
+
+
+def test_is_internal_topic_parameter_events():
+    assert _is_internal_topic('/parameter_events')
+
+
+def test_is_internal_topic_action():
+    assert _is_internal_topic('/my_node/_action/feedback')
+    assert _is_internal_topic('/my_node/_action/status')
+
+
+def test_is_internal_topic_user_topic():
+    assert not _is_internal_topic('/chatter')
+    assert not _is_internal_topic('/my_ns/image')
+
+
+# ---------------------------------------------------------------------------
+# QoS conversion
+# ---------------------------------------------------------------------------
+
+def test_qos_keep_last():
+    qos = QoSProfile(depth=10, history=1)
+    result = _qos_to_model(qos)
+    assert result.history == 'KEEP_LAST'
+    assert result.depth == 10
+
+
+def test_qos_keep_all():
+    qos = QoSProfile(history=2)
+    result = _qos_to_model(qos)
+    assert result.history == 'KEEP_ALL'
+
+
+def test_qos_reliable():
+    qos = QoSProfile(reliability=1)
+    result = _qos_to_model(qos)
+    assert result.reliability == 'RELIABLE'
+
+
+def test_qos_best_effort():
+    qos = QoSProfile(reliability=2)
+    result = _qos_to_model(qos)
+    assert result.reliability == 'BEST_EFFORT'
+
+
+def test_qos_transient_local():
+    qos = QoSProfile(durability=1)
+    result = _qos_to_model(qos)
+    assert result.durability == 'TRANSIENT_LOCAL'
+
+
+def test_qos_volatile():
+    qos = QoSProfile(durability=2)
+    result = _qos_to_model(qos)
+    assert result.durability == 'VOLATILE'
+
+
+def test_qos_deadline_ns():
+    qos = QoSProfile(deadline=Duration(sec=0, nanosec=100_000_000))  # 100ms
+    result = _qos_to_model(qos)
+    assert result.deadline_ns == 100_000_000
+
+
+def test_qos_zero_duration_omitted():
+    qos = QoSProfile(deadline=Duration(sec=0, nanosec=0))
+    result = _qos_to_model(qos)
+    assert result.deadline_ns is None
+
+
+def test_qos_infinite_duration_omitted():
+    int64_max_ns = 2**63 - 1
+    sec = int64_max_ns // 1_000_000_000
+    nanosec = int64_max_ns % 1_000_000_000
+    qos = QoSProfile(deadline=Duration(sec=sec, nanosec=nanosec))
+    result = _qos_to_model(qos)
+    assert result.deadline_ns is None
+
+
+def test_qos_unknown_history_uses_system_default():
+    qos = QoSProfile(history=0)  # SYSTEM_DEFAULT
+    result = _qos_to_model(qos)
+    assert result.history == 'SYSTEM_DEFAULT'
+
+
+def test_qos_unknown_reliability_uses_system_default():
+    qos = QoSProfile(reliability=0)  # SYSTEM_DEFAULT
+    result = _qos_to_model(qos)
+    assert result.reliability == 'SYSTEM_DEFAULT'
+
+
+def test_qos_liveliness_automatic():
+    qos = QoSProfile(liveliness=1)
+    result = _qos_to_model(qos)
+    assert result.liveliness == 'AUTOMATIC'
+
+
+def test_qos_liveliness_manual_by_topic():
+    qos = QoSProfile(liveliness=3)
+    result = _qos_to_model(qos)
+    assert result.liveliness == 'MANUAL_BY_TOPIC'
+
+
+# ---------------------------------------------------------------------------
+# Action type reconstruction
+# ---------------------------------------------------------------------------
+
+def test_reconstruct_action_type_direct():
+    action = Action(
+        name='/navigate',
+        send_goal=Service(request_type=InterfaceType(name='nav2_msgs/action/NavigateToPose')),
+    )
+    assert _reconstruct_action_type(action) == 'nav2_msgs/action/NavigateToPose'
+
+
+def test_reconstruct_action_type_with_send_goal_suffix():
+    action = Action(
+        name='/navigate',
+        send_goal=Service(request_type=InterfaceType(name='nav2_msgs/action/NavigateToPose_SendGoal')),
+    )
+    assert _reconstruct_action_type(action) == 'nav2_msgs/action/NavigateToPose'
+
+
+# ---------------------------------------------------------------------------
+# to_nodl
+# ---------------------------------------------------------------------------
+
+def test_empty_node():
+    msg = NodeMsg(name='/my_node')
+    result = to_nodl(msg)
+    assert isinstance(result, NodlDocument)
+    assert result.nodl_version == 2
+    assert result.publishers is None
+    assert result.parameters is None
+
+
+def test_internal_topics_filtered():
+    msg = NodeMsg(
+        name='/node',
+        publishers=[
+            Topic(name='/rosout', type=InterfaceType('rcl_interfaces/msg/Log')),
+            Topic(name='/parameter_events', type=InterfaceType('rcl_interfaces/msg/ParameterEvent')),
+            Topic(name='/chatter', type=InterfaceType('std_msgs/msg/String')),
+        ],
+    )
+    result = to_nodl(msg)
+    assert len(result.publishers) == 1
+    assert result.publishers[0].name == '/chatter'
+
+
+def test_internal_services_filtered():
+    msg = NodeMsg(
+        name='/node',
+        service_servers=[
+            Service(name='/node/list_parameters',
+                    request_type=InterfaceType('rcl_interfaces/srv/ListParameters')),
+            Service(name='/node/describe_parameters',
+                    request_type=InterfaceType('rcl_interfaces/srv/DescribeParameters')),
+            Service(name='/reset', request_type=InterfaceType('std_srvs/srv/Trigger')),
+        ],
+    )
+    result = to_nodl(msg)
+    assert len(result.service_servers) == 1
+    assert result.service_servers[0].name == '/reset'
+
+
+def test_action_internal_services_filtered():
+    msg = NodeMsg(
+        name='/node',
+        service_servers=[
+            Service(name='/navigate/_action/send_goal',
+                    request_type=InterfaceType('nav2_msgs/action/NavigateToPose')),
+            Service(name='/navigate/_action/cancel_goal',
+                    request_type=InterfaceType('action_msgs/srv/CancelGoal')),
+        ],
+    )
+    result = to_nodl(msg)
+    assert result.service_servers is None
+
+
+def test_publisher_with_qos():
+    qos = QoSProfile(depth=5, history=1, reliability=1, durability=1)
+    msg = NodeMsg(
+        name='/node',
+        publishers=[
+            Topic(name='/cmd_vel', type=InterfaceType('geometry_msgs/msg/Twist'), qos=qos),
+        ],
+    )
+    result = to_nodl(msg)
+    pub = result.publishers[0]
+    assert pub.name == '/cmd_vel'
+    assert pub.type == 'geometry_msgs/msg/Twist'
+    assert pub.qos.history == 'KEEP_LAST'
+    assert pub.qos.depth == 5
+    assert pub.qos.reliability == 'RELIABLE'
+    assert pub.qos.durability == 'TRANSIENT_LOCAL'
+
+
+def test_subscription():
+    msg = NodeMsg(
+        name='/node',
+        subscriptions=[
+            Topic(name='/odom', type=InterfaceType('nav_msgs/msg/Odometry')),
+        ],
+    )
+    result = to_nodl(msg)
+    assert result.subscriptions[0].name == '/odom'
+
+
+def test_parameters_basic_types():
+    descriptors = [
+        ParameterDescriptor(name='flag', type=1),         # bool
+        ParameterDescriptor(name='count', type=2),        # int
+        ParameterDescriptor(name='speed', type=3),        # double
+        ParameterDescriptor(name='label', type=4),        # string
+        ParameterDescriptor(name='raw', type=5),          # byte_array — skipped (unsupported)
+    ]
+    msg = NodeMsg(name='/node', parameters=descriptors)
+    result = to_nodl(msg)
+    assert result.parameters['flag'].type == 'bool'
+    assert result.parameters['count'].type == 'int'
+    assert result.parameters['speed'].type == 'double'
+    assert result.parameters['label'].type == 'string'
+    assert 'raw' not in result.parameters
+
+
+def test_parameter_not_set_skipped():
+    descriptors = [
+        ParameterDescriptor(name='unset', type=0),  # NOT_SET
+        ParameterDescriptor(name='flag', type=1),   # bool
+    ]
+    msg = NodeMsg(name='/node', parameters=descriptors)
+    result = to_nodl(msg)
+    assert 'unset' not in result.parameters
+    assert 'flag' in result.parameters
+
+
+def test_parameter_with_description_and_read_only():
+    desc = ParameterDescriptor(name='max_vel', type=3, description='Max velocity', read_only=True)
+    msg = NodeMsg(name='/node', parameters=[desc])
+    result = to_nodl(msg)
+    p = result.parameters['max_vel']
+    assert p.description == 'Max velocity'
+    assert p.read_only is True
+
+
+def test_parameter_read_only_false_omitted():
+    desc = ParameterDescriptor(name='p', type=4, read_only=False)
+    msg = NodeMsg(name='/node', parameters=[desc])
+    result = to_nodl(msg)
+    assert result.parameters['p'].read_only is None
+
+
+def test_parameter_assume_current_as_default():
+    desc = ParameterDescriptor(name='speed', type=3)  # double
+    val = ParameterValue(type=3, double_value=2.5)
+    msg = NodeMsg(name='/node', parameters=[desc], parameter_values=[val])
+    result = to_nodl(msg, assume_current_as_default=True)
+    assert result.parameters['speed'].default_value == 2.5
+
+
+def test_parameter_values_not_used_by_default():
+    desc = ParameterDescriptor(name='speed', type=3)
+    val = ParameterValue(type=3, double_value=2.5)
+    msg = NodeMsg(name='/node', parameters=[desc], parameter_values=[val])
+    result = to_nodl(msg)
+    assert result.parameters['speed'].default_value is None
+
+
+def test_parameter_values_ignored_if_size_mismatch():
+    desc = ParameterDescriptor(name='speed', type=3)
+    msg = NodeMsg(name='/node', parameters=[desc], parameter_values=[])
+    result = to_nodl(msg, assume_current_as_default=True)
+    assert result.parameters['speed'].default_value is None
+
+
+def test_service_client():
+    msg = NodeMsg(
+        name='/node',
+        service_clients=[
+            Service(name='/remote_trigger', request_type=InterfaceType('std_srvs/srv/Trigger')),
+        ],
+    )
+    result = to_nodl(msg)
+    assert result.service_clients[0].name == '/remote_trigger'
+    assert result.service_clients[0].type == 'std_srvs/srv/Trigger'
+
+
+def test_action_server():
+    action = Action(
+        name='/navigate',
+        send_goal=Service(request_type=InterfaceType(name='nav2_msgs/action/NavigateToPose')),
+    )
+    msg = NodeMsg(name='/node', action_servers=[action])
+    result = to_nodl(msg)
+    assert result.action_servers[0].name == '/navigate'
+    assert result.action_servers[0].type == 'nav2_msgs/action/NavigateToPose'
+
+
+def test_action_client():
+    action = Action(
+        name='/compute',
+        send_goal=Service(request_type=InterfaceType(name='example_interfaces/action/Fibonacci')),
+    )
+    msg = NodeMsg(name='/node', action_clients=[action])
+    result = to_nodl(msg)
+    assert result.action_clients[0].name == '/compute'
+    assert result.action_clients[0].type == 'example_interfaces/action/Fibonacci'
+
+
+def test_empty_sections_omitted():
+    msg = NodeMsg(name='/node')
+    result = to_nodl(msg)
+    for attr in ['publishers', 'subscriptions', 'service_servers',
+                 'service_clients', 'action_servers', 'action_clients', 'parameters']:
+        assert getattr(result, attr) is None
+
+
+def test_to_nodl_output_is_valid_nodl():
+    from nodl.schema import validate
+
+    qos = QoSProfile(depth=10, history=1, reliability=1)
+    msg = NodeMsg(
+        name='/ns/my_node',
+        parameters=[
+            ParameterDescriptor(name='speed', type=3, description='Speed param'),
+        ],
+        publishers=[
+            Topic(name='/cmd_vel', type=InterfaceType('geometry_msgs/msg/Twist'), qos=qos),
+        ],
+        subscriptions=[
+            Topic(name='/odom', type=InterfaceType('nav_msgs/msg/Odometry'), qos=qos),
+        ],
+        service_servers=[
+            Service(name='/reset', request_type=InterfaceType('std_srvs/srv/Trigger')),
+        ],
+        action_servers=[
+            Action(
+                name='/navigate',
+                send_goal=Service(request_type=InterfaceType('nav2_msgs/action/NavigateToPose')),
+            )
+        ],
+    )
+    result = to_nodl(msg)
+    assert isinstance(result, NodlDocument)
+    validate(result.to_dict())  # Must not raise
+
+
+def test_to_dict_excludes_none_fields():
+    msg = NodeMsg(name='/node', parameters=[ParameterDescriptor(name='p', type=4)])
+    result = to_nodl(msg)
+    d = result.to_dict()
+    # read_only was not set (None), so must not appear in dict
+    assert 'read_only' not in d['parameters']['p']

--- a/nodl/test/test_describe_integration.py
+++ b/nodl/test/test_describe_integration.py
@@ -1,0 +1,104 @@
+"""Integration tests for nodl.describe using live rclpy nodes.
+
+These tests require a working ROS 2 environment and are skipped otherwise.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+try:
+    import rclpy
+    import rclpy.executors
+    from rclpy.node import Node
+    _RCLPY_AVAILABLE = True
+except ImportError:
+    _RCLPY_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not _RCLPY_AVAILABLE, reason='rclpy not available'
+)
+
+
+class _SpinThread:
+    """Context manager that spins an rclpy node in a background thread."""
+
+    def __init__(self, node):
+        self._node = node
+        self._executor = rclpy.executors.SingleThreadedExecutor()
+        self._executor.add_node(node)
+        self._thread = threading.Thread(target=self._executor.spin, daemon=True)
+
+    def __enter__(self):
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_):
+        self._executor.shutdown(timeout_sec=1.0)
+
+
+@pytest.fixture(scope='module')
+def ros_context():
+    """Initialize rclpy once for the module and tear it down after."""
+    rclpy.init()
+    yield
+    rclpy.shutdown()
+
+
+@pytest.fixture
+def talker_node(ros_context):
+    """Create a simple node with a publisher and a subscription."""
+    from std_msgs.msg import String
+    node = rclpy.create_node('integration_talker')
+    node.create_publisher(String, '/integration_chatter', 10)
+    node.create_subscription(String, '/integration_input', lambda msg: None, 5)
+    with _SpinThread(node):
+        time.sleep(0.3)  # allow graph discovery
+        yield node
+    node.destroy_node()
+
+
+def test_describe_finds_node(talker_node):
+    from nodl.describe import describe
+
+    node_msg = describe('/integration_talker', discovery_timeout_sec=1.0)
+    assert node_msg.name == '/integration_talker'
+
+
+def test_describe_publishers(talker_node):
+    from nodl.describe import describe
+
+    node_msg = describe('/integration_talker', discovery_timeout_sec=1.0)
+    topic_names = [t.name for t in node_msg.publishers]
+    assert '/integration_chatter' in topic_names
+
+
+def test_describe_subscriptions(talker_node):
+    from nodl.describe import describe
+
+    node_msg = describe('/integration_talker', discovery_timeout_sec=1.0)
+    topic_names = [t.name for t in node_msg.subscriptions]
+    assert '/integration_input' in topic_names
+
+
+def test_describe_to_nodl_valid(talker_node):
+    """Full pipeline: describe -> to_nodl -> validate."""
+    from nodl.conversion import to_nodl
+    from nodl.describe import describe
+    from nodl.models import NodlDocument
+    from nodl.schema import validate
+
+    node_msg = describe('/integration_talker', discovery_timeout_sec=1.0)
+    doc = to_nodl(node_msg)
+    assert isinstance(doc, NodlDocument)
+    validate(doc.to_dict())  # Must not raise
+
+
+def test_describe_node_not_found(ros_context):
+    from nodl.describe import describe
+
+    with pytest.raises(RuntimeError, match='not found'):
+        describe('/nonexistent_node_xyz', discovery_timeout_sec=0.5)

--- a/ros2nodl/ros2nodl/verb/describe.py
+++ b/ros2nodl/ros2nodl/verb/describe.py
@@ -1,0 +1,50 @@
+import sys
+
+from ros2nodl.verb import VerbExtension
+
+
+class DescribeVerb(VerbExtension):
+    """Introspect a running ROS 2 node and output its NoDL description."""
+
+    def add_arguments(self, parser, cli_name):
+        parser.add_argument(
+            'node_name',
+            help='Fully qualified node name to describe (e.g. /my_namespace/my_node).',
+        )
+        parser.add_argument(
+            '--format',
+            choices=['yaml', 'json'],
+            default='yaml',
+            help='Output format (default: yaml).',
+        )
+        parser.add_argument(
+            '--assume-current-as-default',
+            action='store_true',
+            default=False,
+            help='Treat current parameter values as default_value in the output.',
+        )
+        parser.add_argument(
+            '--discovery-timeout',
+            metavar='SEC',
+            type=float,
+            default=2.0,
+            help='Seconds to wait for graph discovery before introspecting (default: 2.0).',
+        )
+
+    def main(self, *, args):
+        from nodl.conversion import to_nodl
+        from nodl.describe import describe
+        from nodl.schema import dump_nodl
+
+        try:
+            node_msg = describe(
+                args.node_name,
+                discovery_timeout_sec=args.discovery_timeout,
+            )
+        except RuntimeError as e:
+            print(f'Error: {e}', file=sys.stderr)
+            return 1
+
+        data = to_nodl(node_msg, assume_current_as_default=args.assume_current_as_default)
+        print(dump_nodl(data, format=args.format), end='')
+        return 0

--- a/ros2nodl/setup.py
+++ b/ros2nodl/setup.py
@@ -26,6 +26,7 @@ setup(
         ],
         'ros2nodl.verb': [
             'validate = ros2nodl.verb.validate:ValidateVerb',
+            'describe = ros2nodl.verb.describe:DescribeVerb',
         ],
     },
 )

--- a/ros2nodl/test/test_verbs.py
+++ b/ros2nodl/test/test_verbs.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import argparse
 import io
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -74,3 +78,90 @@ class TestValidateVerb:
         captured = capsys.readouterr()
         assert 'Valid' in captured.out
 
+
+# ---------------------------------------------------------------------------
+# DescribeVerb
+# ---------------------------------------------------------------------------
+
+class TestDescribeVerb:
+
+    def setup_method(self):
+        from ros2nodl.verb.describe import DescribeVerb
+        self.verb = DescribeVerb()
+
+    def _make_args(self, node_name='/test_node', format='yaml',
+                   assume_current_as_default=False, discovery_timeout=0.5):
+        args = argparse.Namespace()
+        args.node_name = node_name
+        args.format = format
+        args.assume_current_as_default = assume_current_as_default
+        args.discovery_timeout = discovery_timeout
+        return args
+
+    def test_node_not_found_returns_1(self, capsys):
+        with patch('nodl.describe.describe') as mock_describe:
+            mock_describe.side_effect = RuntimeError('not found')
+            args = self._make_args()
+            result = self.verb.main(args=args)
+        assert result == 1
+        captured = capsys.readouterr()
+        assert 'Error' in captured.err
+
+    def test_yaml_output(self, capsys):
+        mock_node_msg = MagicMock()
+        mock_node_msg.name = '/test_node'
+        mock_node_msg.parameters = []
+        mock_node_msg.parameter_values = []
+        mock_node_msg.publishers = []
+        mock_node_msg.subscriptions = []
+        mock_node_msg.service_servers = []
+        mock_node_msg.service_clients = []
+        mock_node_msg.action_servers = []
+        mock_node_msg.action_clients = []
+
+        with patch('nodl.describe.describe', return_value=mock_node_msg):
+            args = self._make_args(format='yaml')
+            result = self.verb.main(args=args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert 'node' in captured.out
+
+    def test_json_output(self, capsys):
+        mock_node_msg = MagicMock()
+        mock_node_msg.name = '/test_node'
+        mock_node_msg.parameters = []
+        mock_node_msg.parameter_values = []
+        mock_node_msg.publishers = []
+        mock_node_msg.subscriptions = []
+        mock_node_msg.service_servers = []
+        mock_node_msg.service_clients = []
+        mock_node_msg.action_servers = []
+        mock_node_msg.action_clients = []
+
+        with patch('nodl.describe.describe', return_value=mock_node_msg):
+            args = self._make_args(format='json')
+            result = self.verb.main(args=args)
+
+        assert result == 0
+        import json
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert 'node' in parsed
+
+    def test_discovery_timeout_passed(self):
+        mock_node_msg = MagicMock()
+        mock_node_msg.name = '/test_node'
+        mock_node_msg.parameters = []
+        mock_node_msg.parameter_values = []
+        mock_node_msg.publishers = []
+        mock_node_msg.subscriptions = []
+        mock_node_msg.service_servers = []
+        mock_node_msg.service_clients = []
+        mock_node_msg.action_servers = []
+        mock_node_msg.action_clients = []
+
+        with patch('nodl.describe.describe', return_value=mock_node_msg) as mock_desc:
+            args = self._make_args(discovery_timeout=3.7)
+            self.verb.main(args=args)
+            mock_desc.assert_called_once_with('/test_node', discovery_timeout_sec=3.7)


### PR DESCRIPTION
Adds the runtime graph-introspection feature on top of the base schema:

- nodl.describe: queries the ROS graph via rclpy to build a Node.msg describing a running node's interfaces
- nodl.conversion: converts between Node.msg and NoDL document form
- ros2nodl describe verb: `ros2 nodl describe <node_name>`
- nodl package.xml regains rclpy/rcl_interfaces/rosgraph_msgs deps and launch_testing test deps

Independent of codegen/runtime helper packages.