### PR TITLE
Add nodl_docgen: Sphinx-based documentation from NoDL descriptions

### DIFF
--- a/nodl_docgen/CMakeLists.txt
+++ b/nodl_docgen/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.16)
+project(nodl_docgen)
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+# Install the Python package so 'nodl_docgen.sphinx_ext' is importable.
+ament_python_install_package(${PROJECT_NAME})
+
+# Install the CLI script.
+install(PROGRAMS scripts/nodl_docgen
+  DESTINATION lib/nodl_docgen)
+
+# Install the cmake macro file.
+install(FILES cmake/nodl_docgen.cmake
+  DESTINATION share/${PROJECT_NAME}/cmake)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_generator test/test_generator.py)
+  ament_add_pytest_test(test_cli test/test_cli.py)
+  ament_add_pytest_test(test_sphinx_ext test/test_sphinx_ext.py)
+endif()
+
+ament_package(CONFIG_EXTRAS "nodl_docgen-extras.cmake.in")

--- a/nodl_docgen/cmake/nodl_docgen.cmake
+++ b/nodl_docgen/cmake/nodl_docgen.cmake
@@ -1,0 +1,57 @@
+# nodl_docgen(target nodl_file)
+#
+# Generates an RST documentation file from a NoDL interface description.
+#
+# target      - Name for the cmake custom target; also used as the output filename
+#               (<target>.rst).
+# nodl_file   - Path to the .nodl.yaml file (relative to caller's CMakeLists.txt).
+#
+# The generated RST is placed in ${CMAKE_CURRENT_BINARY_DIR}/nodl_doc/<target>.rst
+# and installed to share/<package>/doc/.
+#
+# Example:
+#   nodl_docgen(my_node nodl/my_node.nodl.yaml)
+#   # Produces: share/<package>/doc/my_node.rst
+#   # Include in your Sphinx docs with:
+#   #   .. include:: /path/to/install/share/<package>/doc/my_node.rst
+#   # Or add to toctree.
+#
+macro(nodl_docgen target nodl_file)
+  get_filename_component(_nodl_file_abs "${nodl_file}" ABSOLUTE
+    BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  set(_out_dir "${CMAKE_CURRENT_BINARY_DIR}/nodl_doc")
+  set(_rst_out "${_out_dir}/${target}.rst")
+
+  if(DEFINED ENV{PYTHONPATH})
+    set(_full_pythonpath "${_NODL_DOCGEN_EXTRA_PYTHONPATH}:$ENV{PYTHONPATH}")
+  else()
+    set(_full_pythonpath "${_NODL_DOCGEN_EXTRA_PYTHONPATH}")
+  endif()
+
+  add_custom_command(
+    OUTPUT "${_rst_out}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${_out_dir}"
+    COMMAND ${CMAKE_COMMAND} -E env
+      "PYTHONPATH=${_full_pythonpath}"
+      "${Python3_EXECUTABLE}"
+      "${_NODL_DOCGEN_SCRIPT}"
+      --nodl-file "${_nodl_file_abs}"
+      --output "${_rst_out}"
+    DEPENDS
+      "${_nodl_file_abs}"
+      "${_NODL_DOCGEN_SCRIPT}"
+    COMMENT "nodl_docgen: generating ${target}.rst from ${nodl_file}"
+    VERBATIM
+  )
+
+  add_custom_target(${target}_nodl_doc ALL DEPENDS "${_rst_out}")
+
+  if(DEFINED PROJECT_NAME)
+    install(
+      FILES "${_rst_out}"
+      DESTINATION share/${PROJECT_NAME}/doc
+      OPTIONAL
+    )
+  endif()
+endmacro()

--- a/nodl_docgen/nodl_docgen-extras.cmake.in
+++ b/nodl_docgen/nodl_docgen-extras.cmake.in
@@ -1,0 +1,23 @@
+# Locate the installed nodl_docgen script.
+set(_NODL_DOCGEN_SCRIPT
+  "@PACKAGE_PREFIX_DIR@/lib/nodl_docgen/nodl_docgen")
+
+# Build a PYTHONPATH that includes site-packages from all ament prefix dirs so
+# nodl and nodl_docgen are importable when the cmake custom command runs.
+set(_NODL_DOCGEN_EXTRA_PYTHONPATH "")
+foreach(_prefix IN LISTS CMAKE_PREFIX_PATH AMENT_PREFIX_PATH)
+  file(GLOB _site_pkgs "${_prefix}/lib/python*/site-packages")
+  foreach(_sp IN LISTS _site_pkgs)
+    if(IS_DIRECTORY "${_sp}")
+      if(_NODL_DOCGEN_EXTRA_PYTHONPATH)
+        set(_NODL_DOCGEN_EXTRA_PYTHONPATH "${_NODL_DOCGEN_EXTRA_PYTHONPATH}:${_sp}")
+      else()
+        set(_NODL_DOCGEN_EXTRA_PYTHONPATH "${_sp}")
+      endif()
+    endif()
+  endforeach()
+endforeach()
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+include("${CMAKE_CURRENT_LIST_DIR}/nodl_docgen.cmake")

--- a/nodl_docgen/nodl_docgen/__init__.py
+++ b/nodl_docgen/nodl_docgen/__init__.py
@@ -1,0 +1,3 @@
+from nodl_docgen._generator import generate_rst
+
+__all__ = ['generate_rst']

--- a/nodl_docgen/nodl_docgen/_generator.py
+++ b/nodl_docgen/nodl_docgen/_generator.py
@@ -1,0 +1,140 @@
+"""Generate RST documentation from a NodlDocument."""
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from nodl.models import NodlDocument, QoS
+
+
+def _qos_str(qos: Optional[QoS]) -> str:
+    if qos is None:
+        return 'default'
+    parts = []
+    parts.append('Reliable' if qos.reliability == 'RELIABLE' else 'Best effort')
+    if qos.history == 'ALL':
+        parts.append('keep all')
+    else:
+        parts.append(f'depth {qos.history}')
+    if qos.durability == 'TRANSIENT_LOCAL':
+        parts.append('transient local')
+    return ' · '.join(parts)
+
+
+def _list_table(
+    headers: List[str],
+    rows: List[Tuple[str, ...]],
+    widths: Optional[List[int]] = None,
+    title: str = '',
+) -> str:
+    if widths is None:
+        w = 100 // len(headers)
+        widths = [w] * len(headers)
+
+    lines = [f'.. list-table:: {title}' if title else '.. list-table::']
+    lines.append('   :header-rows: 1')
+    lines.append(f'   :widths: {" ".join(str(w) for w in widths)}')
+    lines.append('')
+
+    lines.append(f'   * - {headers[0]}')
+    for h in headers[1:]:
+        lines.append(f'     - {h}')
+
+    for row in rows:
+        lines.append(f'   * - {row[0]}')
+        for cell in row[1:]:
+            lines.append(f'     - {cell}')
+
+    return '\n'.join(lines)
+
+
+def _section(title: str, underline_char: str = '-') -> str:
+    return f'{title}\n{underline_char * len(title)}'
+
+
+def generate_rst(doc: NodlDocument) -> str:
+    """Return a complete RST document describing the node interfaces."""
+    node_name = (doc.node.name if doc.node else None) or 'node'
+    parts: List[str] = []
+
+    parts.append(node_name)
+    parts.append('=' * len(node_name))
+    parts.append('')
+
+    if doc.publishers:
+        parts.append(_section('Publishers'))
+        parts.append('')
+        rows = [
+            (f'``{p.topic}``', f'``{p.type}``', _qos_str(p.qos))
+            for p in doc.publishers
+        ]
+        parts.append(_list_table(['Topic', 'Type', 'QoS'], rows, [35, 40, 25]))
+        parts.append('')
+
+    if doc.subscriptions:
+        parts.append(_section('Subscriptions'))
+        parts.append('')
+        rows = [
+            (f'``{s.topic}``', f'``{s.type}``', _qos_str(s.qos))
+            for s in doc.subscriptions
+        ]
+        parts.append(_list_table(['Topic', 'Type', 'QoS'], rows, [35, 40, 25]))
+        parts.append('')
+
+    if doc.parameters:
+        parts.append(_section('Parameters'))
+        parts.append('')
+        rows = []
+        for name, param in doc.parameters.items():
+            default = f'``{param.default_value}``' if param.default_value is not None else ''
+            desc = param.description or ''
+            if param.read_only:
+                desc = (desc + ' *(read-only)*').lstrip()
+            rows.append((f'``{name}``', f'``{param.type}``', default, desc))
+        parts.append(_list_table(
+            ['Name', 'Type', 'Default', 'Description'],
+            rows,
+            [25, 15, 20, 40],
+        ))
+        parts.append('')
+
+    if doc.service_servers:
+        parts.append(_section('Service Servers'))
+        parts.append('')
+        rows = [
+            (f'``{s.name}``', f'``{s.type}``', s.description or '')
+            for s in doc.service_servers
+        ]
+        parts.append(_list_table(['Service', 'Type', 'Description'], rows, [35, 40, 25]))
+        parts.append('')
+
+    if doc.service_clients:
+        parts.append(_section('Service Clients'))
+        parts.append('')
+        rows = [
+            (f'``{c.name}``', f'``{c.type}``', c.description or '')
+            for c in doc.service_clients
+        ]
+        parts.append(_list_table(['Service', 'Type', 'Description'], rows, [35, 40, 25]))
+        parts.append('')
+
+    if doc.action_servers:
+        parts.append(_section('Action Servers'))
+        parts.append('')
+        rows = [
+            (f'``{a.name}``', f'``{a.type}``', a.description or '')
+            for a in doc.action_servers
+        ]
+        parts.append(_list_table(['Action', 'Type', 'Description'], rows, [35, 40, 25]))
+        parts.append('')
+
+    if doc.action_clients:
+        parts.append(_section('Action Clients'))
+        parts.append('')
+        rows = [
+            (f'``{a.name}``', f'``{a.type}``', a.description or '')
+            for a in doc.action_clients
+        ]
+        parts.append(_list_table(['Action', 'Type', 'Description'], rows, [35, 40, 25]))
+        parts.append('')
+
+    return '\n'.join(parts)

--- a/nodl_docgen/nodl_docgen/sphinx_ext.py
+++ b/nodl_docgen/nodl_docgen/sphinx_ext.py
@@ -1,0 +1,83 @@
+"""Sphinx extension providing the ``.. nodl::`` directive.
+
+Usage in conf.py::
+
+    extensions = ['nodl_docgen.sphinx_ext']
+
+Usage in RST::
+
+    .. nodl:: path/to/my_node.nodl.yaml
+
+The path is resolved relative to the directory containing the RST source file.
+
+For rosdoc2 integration, add the extension to the package's Sphinx ``conf.py``
+and use the directive wherever node interface documentation should appear.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from docutils import nodes
+from docutils.statemachine import StringList
+
+from sphinx.util.docutils import SphinxDirective
+
+
+class NodlDirective(SphinxDirective):
+    """Render a NoDL file as RST inline at the directive site."""
+
+    required_arguments = 1
+    optional_arguments = 0
+    has_content = False
+    option_spec = {}
+
+    def run(self) -> List[nodes.Node]:
+        nodl_arg = self.arguments[0]
+
+        # Resolve path relative to the current source file's directory.
+        src_file = Path(self.get_source_info()[0])
+        full_path = (src_file.parent / nodl_arg).resolve()
+
+        if not full_path.exists():
+            msg = self.reporter.error(
+                f'nodl: file not found: {full_path}',
+                line=self.lineno,
+            )
+            return [msg]
+
+        # Register the NoDL file as a dependency so Sphinx rebuilds when it changes.
+        self.env.note_dependency(str(full_path))
+
+        try:
+            from nodl.schema import load_nodl
+            from nodl_docgen._generator import generate_rst
+
+            with open(full_path) as f:
+                doc = load_nodl(f)
+
+            rst_text = generate_rst(doc)
+        except Exception as exc:  # noqa: BLE001
+            msg = self.reporter.error(
+                f'nodl: failed to generate RST from {full_path}: {exc}',
+                line=self.lineno,
+            )
+            return [msg]
+
+        # Parse the generated RST into docutils nodes and return them.
+        container = nodes.section()
+        self.state.nested_parse(
+            StringList(rst_text.splitlines(), source=str(full_path)),
+            self.content_offset,
+            container,
+        )
+        return container.children
+
+
+def setup(app):
+    app.add_directive('nodl', NodlDirective)
+    return {
+        'version': '0.1.0',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/nodl_docgen/package.xml
+++ b/nodl_docgen/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>nodl_docgen</name>
+  <version>0.1.0</version>
+  <description>Documentation generator for ROS 2 node interfaces described in NoDL.</description>
+  <maintainer email="emerson@polymathrobotics.com">Emerson Knapp</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
+
+  <depend>nodl</depend>
+  <depend>python3-sphinx</depend>
+
+  <test_depend>python3-pytest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/nodl_docgen/scripts/nodl_docgen
+++ b/nodl_docgen/scripts/nodl_docgen
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Generate RST documentation from a NoDL file."""
+import argparse
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate RST documentation from a NoDL file.'
+    )
+    parser.add_argument('--nodl-file', required=True, help='Path to .nodl.yaml input file')
+    parser.add_argument('--output', required=True, help='Path to write the generated .rst file')
+    args = parser.parse_args()
+
+    from nodl.schema import load_nodl
+    from nodl_docgen._generator import generate_rst
+
+    with open(args.nodl_file) as f:
+        doc = load_nodl(f)
+
+    rst = generate_rst(doc)
+
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(rst)
+
+
+if __name__ == '__main__':
+    main()

--- a/nodl_docgen/test/test_cli.py
+++ b/nodl_docgen/test/test_cli.py
@@ -1,0 +1,76 @@
+"""Tests for the nodl_docgen CLI script."""
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load the CLI script (no .py extension) as a module.
+_SCRIPT = Path(__file__).parents[1] / 'scripts' / 'nodl_docgen'
+_loader = importlib.machinery.SourceFileLoader('nodl_docgen_cli', str(_SCRIPT))
+_spec = importlib.util.spec_from_loader('nodl_docgen_cli', _loader)
+_cli = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_cli)
+
+
+_NODL_YAML = """\
+nodl_version: "1"
+node:
+  name: test_node
+parameters:
+  rate:
+    type: double
+    default_value: 10.0
+    description: Publish rate
+publishers:
+  - topic: /out
+    type: std_msgs/msg/String
+"""
+
+
+def test_cli_creates_output_file(tmp_path):
+    nodl_file = tmp_path / 'test_node.nodl.yaml'
+    nodl_file.write_text(_NODL_YAML)
+    out_file = tmp_path / 'out' / 'test_node.rst'
+
+    sys.argv = [
+        'nodl_docgen',
+        '--nodl-file', str(nodl_file),
+        '--output', str(out_file),
+    ]
+    _cli.main()
+
+    assert out_file.exists()
+
+
+def test_cli_output_contains_node_name(tmp_path):
+    nodl_file = tmp_path / 'test_node.nodl.yaml'
+    nodl_file.write_text(_NODL_YAML)
+    out_file = tmp_path / 'test_node.rst'
+
+    sys.argv = [
+        'nodl_docgen',
+        '--nodl-file', str(nodl_file),
+        '--output', str(out_file),
+    ]
+    _cli.main()
+
+    rst = out_file.read_text()
+    assert 'test_node' in rst
+    assert '.. list-table::' in rst
+
+
+def test_cli_creates_parent_directories(tmp_path):
+    nodl_file = tmp_path / 'test_node.nodl.yaml'
+    nodl_file.write_text(_NODL_YAML)
+    out_file = tmp_path / 'a' / 'b' / 'c' / 'test_node.rst'
+
+    sys.argv = [
+        'nodl_docgen',
+        '--nodl-file', str(nodl_file),
+        '--output', str(out_file),
+    ]
+    _cli.main()
+
+    assert out_file.exists()

--- a/nodl_docgen/test/test_generator.py
+++ b/nodl_docgen/test/test_generator.py
@@ -1,0 +1,218 @@
+"""Unit tests for the RST generator."""
+import pytest
+
+from nodl.models import NodlDocument, NodeMetadata, Parameter, QoS, TopicEndpoint, ServiceEndpoint
+from nodl_docgen._generator import _qos_str, generate_rst
+
+
+# ---------------------------------------------------------------------------
+# _qos_str
+# ---------------------------------------------------------------------------
+
+def test_qos_str_none():
+    assert _qos_str(None) == 'default'
+
+
+def test_qos_str_reliable():
+    assert _qos_str(QoS(history=10, reliability='RELIABLE')) == 'Reliable · depth 10'
+
+
+def test_qos_str_best_effort():
+    assert _qos_str(QoS(history=5, reliability='BEST_EFFORT')) == 'Best effort · depth 5'
+
+
+def test_qos_str_keep_all():
+    assert _qos_str(QoS(history='ALL', reliability='RELIABLE')) == 'Reliable · keep all'
+
+
+def test_qos_str_transient_local():
+    result = _qos_str(QoS(history=10, reliability='RELIABLE', durability='TRANSIENT_LOCAL'))
+    assert result == 'Reliable · depth 10 · transient local'
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_FULL_DOC = NodlDocument(
+    node=NodeMetadata(name='my_node'),
+    parameters={
+        'rate': Parameter(type='double', default_value=10.0, description='Publish rate in Hz'),
+        'frame_id': Parameter(type='string', default_value='base_link'),
+        'enabled': Parameter(type='bool', default_value=True, read_only=True),
+    },
+    publishers=[
+        TopicEndpoint(
+            topic='/scan',
+            type='sensor_msgs/msg/LaserScan',
+            qos=QoS(history=10, reliability='RELIABLE'),
+        ),
+    ],
+    subscriptions=[
+        TopicEndpoint(topic='/cmd', type='std_msgs/msg/String'),
+    ],
+    service_servers=[
+        ServiceEndpoint(name='/reset', type='std_srvs/srv/Trigger', description='Reset the node'),
+    ],
+    service_clients=[
+        ServiceEndpoint(name='/set_mode', type='std_srvs/srv/SetBool'),
+    ],
+)
+
+_MINIMAL_DOC = NodlDocument(node=NodeMetadata(name='bare_node'))
+
+
+# ---------------------------------------------------------------------------
+# Title
+# ---------------------------------------------------------------------------
+
+def test_title_is_node_name():
+    rst = generate_rst(_FULL_DOC)
+    assert 'my_node\n=======' in rst
+
+
+def test_title_underline_matches_length():
+    doc = NodlDocument(node=NodeMetadata(name='a_longer_name'))
+    rst = generate_rst(doc)
+    assert 'a_longer_name\n=============' in rst
+
+
+def test_fallback_title_when_no_node():
+    rst = generate_rst(NodlDocument())
+    assert rst.startswith('node\n====')
+
+
+# ---------------------------------------------------------------------------
+# Publishers
+# ---------------------------------------------------------------------------
+
+def test_publishers_section_present():
+    rst = generate_rst(_FULL_DOC)
+    assert 'Publishers\n----------' in rst
+
+
+def test_publishers_topic_in_output():
+    rst = generate_rst(_FULL_DOC)
+    assert '``/scan``' in rst
+
+
+def test_publishers_type_in_output():
+    rst = generate_rst(_FULL_DOC)
+    assert '``sensor_msgs/msg/LaserScan``' in rst
+
+
+def test_publishers_qos_in_output():
+    rst = generate_rst(_FULL_DOC)
+    assert 'Reliable · depth 10' in rst
+
+
+def test_no_publishers_section_when_empty():
+    rst = generate_rst(_MINIMAL_DOC)
+    assert 'Publishers' not in rst
+
+
+# ---------------------------------------------------------------------------
+# Subscriptions
+# ---------------------------------------------------------------------------
+
+def test_subscriptions_section_present():
+    rst = generate_rst(_FULL_DOC)
+    assert 'Subscriptions\n-------------' in rst
+
+
+def test_subscriptions_default_qos_label():
+    rst = generate_rst(_FULL_DOC)
+    # /cmd has no QoS spec
+    assert 'default' in rst
+
+
+def test_no_subscriptions_section_when_empty():
+    rst = generate_rst(_MINIMAL_DOC)
+    assert 'Subscriptions' not in rst
+
+
+# ---------------------------------------------------------------------------
+# Parameters
+# ---------------------------------------------------------------------------
+
+def test_parameters_section_present():
+    rst = generate_rst(_FULL_DOC)
+    assert 'Parameters\n----------' in rst
+
+
+def test_parameter_name_in_output():
+    rst = generate_rst(_FULL_DOC)
+    assert '``rate``' in rst
+
+
+def test_parameter_type_in_output():
+    rst = generate_rst(_FULL_DOC)
+    assert '``double``' in rst
+
+
+def test_parameter_default_in_output():
+    rst = generate_rst(_FULL_DOC)
+    assert '``10.0``' in rst
+
+
+def test_parameter_description_in_output():
+    rst = generate_rst(_FULL_DOC)
+    assert 'Publish rate in Hz' in rst
+
+
+def test_read_only_annotation():
+    rst = generate_rst(_FULL_DOC)
+    assert '*(read-only)*' in rst
+
+
+def test_no_parameters_section_when_empty():
+    rst = generate_rst(_MINIMAL_DOC)
+    assert 'Parameters' not in rst
+
+
+# ---------------------------------------------------------------------------
+# Service servers / clients
+# ---------------------------------------------------------------------------
+
+def test_service_server_section_present():
+    rst = generate_rst(_FULL_DOC)
+    assert 'Service Servers\n---------------' in rst
+
+
+def test_service_server_name_in_output():
+    rst = generate_rst(_FULL_DOC)
+    assert '``/reset``' in rst
+
+
+def test_service_server_description_in_output():
+    rst = generate_rst(_FULL_DOC)
+    assert 'Reset the node' in rst
+
+
+def test_service_client_section_present():
+    rst = generate_rst(_FULL_DOC)
+    assert 'Service Clients\n---------------' in rst
+
+
+def test_service_client_name_in_output():
+    rst = generate_rst(_FULL_DOC)
+    assert '``/set_mode``' in rst
+
+
+# ---------------------------------------------------------------------------
+# list-table structure
+# ---------------------------------------------------------------------------
+
+def test_list_table_directive_present():
+    rst = generate_rst(_FULL_DOC)
+    assert '.. list-table::' in rst
+
+
+def test_list_table_header_rows():
+    rst = generate_rst(_FULL_DOC)
+    assert ':header-rows: 1' in rst
+
+
+def test_list_table_widths_present():
+    rst = generate_rst(_FULL_DOC)
+    assert ':widths:' in rst

--- a/nodl_docgen/test/test_sphinx_ext.py
+++ b/nodl_docgen/test/test_sphinx_ext.py
@@ -1,0 +1,90 @@
+"""Tests for the Sphinx extension."""
+import pytest
+
+sphinx = pytest.importorskip('sphinx')
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from docutils import nodes
+from docutils.parsers.rst import Parser
+from docutils.frontend import OptionParser
+from docutils.utils import new_document
+
+from nodl_docgen import sphinx_ext
+
+
+_NODL_YAML = """\
+nodl_version: "1"
+node:
+  name: ext_test_node
+publishers:
+  - topic: /out
+    type: std_msgs/msg/String
+"""
+
+
+def _make_directive_mock(nodl_path: str, src_file: Path):
+    """Return a minimally-mocked NodlDirective instance."""
+    directive = MagicMock(spec=sphinx_ext.NodlDirective)
+    directive.arguments = [nodl_path]
+    directive.content_offset = 0
+    directive.lineno = 1
+    directive.reporter = MagicMock()
+    directive.reporter.error.return_value = nodes.system_message()
+    directive.env = MagicMock()
+    directive.env.docdir = str(src_file.parent)
+    directive.get_source_info.return_value = (str(src_file), 1)
+    directive.state = MagicMock()
+
+    # Capture nested_parse output by actually running the RST through docutils.
+    def fake_nested_parse(string_list, offset, container):
+        parser = Parser()
+        settings = OptionParser(components=(Parser,)).get_default_values()
+        doc = new_document('<test>', settings)
+        parser.parse('\n'.join(string_list), doc)
+        container.children.extend(doc.children)
+
+    directive.state.nested_parse.side_effect = fake_nested_parse
+    return directive
+
+
+def test_directive_produces_nodes(tmp_path):
+    nodl_file = tmp_path / 'ext_test_node.nodl.yaml'
+    nodl_file.write_text(_NODL_YAML)
+    fake_src = tmp_path / 'index.rst'
+
+    directive = _make_directive_mock(nodl_file.name, fake_src)
+    result = sphinx_ext.NodlDirective.run(directive)
+
+    assert len(result) > 0
+    assert any(isinstance(n, nodes.section) or isinstance(n, nodes.title) for n in result)
+
+
+def test_directive_missing_file_returns_error(tmp_path):
+    fake_src = tmp_path / 'index.rst'
+    directive = _make_directive_mock('nonexistent.nodl.yaml', fake_src)
+
+    result = sphinx_ext.NodlDirective.run(directive)
+
+    directive.reporter.error.assert_called_once()
+
+
+def test_directive_registers_dependency(tmp_path):
+    nodl_file = tmp_path / 'ext_test_node.nodl.yaml'
+    nodl_file.write_text(_NODL_YAML)
+    fake_src = tmp_path / 'index.rst'
+
+    directive = _make_directive_mock(nodl_file.name, fake_src)
+    sphinx_ext.NodlDirective.run(directive)
+
+    directive.env.note_dependency.assert_called_once()
+
+
+def test_setup_registers_directive():
+    app = MagicMock()
+    result = sphinx_ext.setup(app)
+
+    app.add_directive.assert_called_once_with('nodl', sphinx_ext.NodlDirective)
+    assert 'version' in result
+    assert result['parallel_read_safe'] is True


### PR DESCRIPTION
Renders Markdown/reST documentation for the parameters, topics, services, and actions declared in a .nodl.yaml. Ships:

- nodl_docgen CLI for one-off rendering
- sphinx extension so docs builds can pull NoDL content inline
- CMake macro (nodl_docgen) for build-time generation

Independent of code generation and runtime helpers.