### PR TITLE
Add nodl_generator_cpp: C++ code generation from NoDL descriptions

### DIFF
--- a/nodl_generator_cpp/CMakeLists.txt
+++ b/nodl_generator_cpp/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.16)
+project(nodl_generator_cpp)
+
+find_package(ament_cmake REQUIRED)
+
+install(
+  PROGRAMS scripts/nodl_generate_cpp
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(
+  DIRECTORY templates/
+  DESTINATION share/${PROJECT_NAME}/templates
+)
+
+install(
+  FILES cmake/nodl_generate_cpp.cmake
+  DESTINATION share/${PROJECT_NAME}/cmake
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_generator test/test_generator.py)
+endif()
+
+ament_package(
+  CONFIG_EXTRAS "nodl_generator_cpp-extras.cmake.in"
+)

--- a/nodl_generator_cpp/cmake/nodl_generate_cpp.cmake
+++ b/nodl_generator_cpp/cmake/nodl_generate_cpp.cmake
@@ -1,0 +1,71 @@
+# nodl_generate_cpp(target nodl_file [LIFECYCLE])
+#
+# Generates an rclcpp (or rclcpp_lifecycle) base-node class from a NoDL file
+# and creates a library target the caller can link against.
+#
+# target      - CMake target name; used for the generated class name and
+#               the generate_parameter_library namespace.
+# nodl_file   - Path to the .nodl.yaml file (relative to caller's CMakeLists.txt)
+# LIFECYCLE   - If set, the generated base inherits rclcpp_lifecycle::LifecycleNode
+#
+macro(nodl_generate_cpp target nodl_file)
+  cmake_parse_arguments(_NGL "LIFECYCLE" "" "" ${ARGN})
+
+  get_filename_component(_nodl_file_abs "${nodl_file}" ABSOLUTE
+    BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  set(_gen_dir "${CMAKE_CURRENT_BINARY_DIR}/nodl_generated/${target}")
+  file(MAKE_DIRECTORY "${_gen_dir}")
+
+  set(_lifecycle_arg "")
+  if(_NGL_LIFECYCLE)
+    set(_lifecycle_arg "--lifecycle")
+  endif()
+
+  set(_hpp_out "${_gen_dir}/${target}.hpp")
+  set(_cpp_out "${_gen_dir}/${target}.cpp")
+
+  # Prepend the extra Python paths so generate_parameter_library_py is importable.
+  if(DEFINED ENV{PYTHONPATH})
+    set(_full_pythonpath "${_NODL_GENERATOR_CPP_EXTRA_PYTHONPATH}:$ENV{PYTHONPATH}")
+  else()
+    set(_full_pythonpath "${_NODL_GENERATOR_CPP_EXTRA_PYTHONPATH}")
+  endif()
+
+  add_custom_command(
+    OUTPUT "${_hpp_out}" "${_cpp_out}"
+    COMMAND ${CMAKE_COMMAND} -E env
+      "PYTHONPATH=${_full_pythonpath}"
+      "${Python3_EXECUTABLE}"
+      "${_NODL_GENERATOR_CPP_SCRIPT}"
+      --nodl-file "${_nodl_file_abs}"
+      --output-dir "${_gen_dir}"
+      --target-name "${target}"
+      --templates-dir "${_NODL_GENERATOR_CPP_TEMPLATES_DIR}"
+      ${_lifecycle_arg}
+    DEPENDS
+      "${_nodl_file_abs}"
+      "${_NODL_GENERATOR_CPP_SCRIPT}"
+    COMMENT "nodl_generate_cpp: generating ${target} from ${nodl_file}"
+    VERBATIM
+  )
+
+  add_library(${target} "${_hpp_out}" "${_cpp_out}")
+  target_include_directories(${target} PUBLIC
+    "$<BUILD_INTERFACE:${_gen_dir}>"
+    "$<INSTALL_INTERFACE:include/${target}>"
+  )
+
+  # Always link against rclcpp, rclcpp_lifecycle, and the genparamlib runtime
+  # deps.  rclcpp_lifecycle is always needed because the generate_parameter_library
+  # generated header unconditionally includes lifecycle_node.hpp.
+  target_link_libraries(${target} PUBLIC
+    rclcpp::rclcpp
+    rclcpp_lifecycle::rclcpp_lifecycle
+    fmt::fmt
+    rsl::rsl
+    tcb_span::tcb_span
+    tl::expected
+    tl_expected::tl_expected
+  )
+endmacro()

--- a/nodl_generator_cpp/nodl_generator_cpp-extras.cmake.in
+++ b/nodl_generator_cpp/nodl_generator_cpp-extras.cmake.in
@@ -1,0 +1,37 @@
+# generated from nodl_generator_cpp/nodl_generator_cpp-extras.cmake.in
+
+get_filename_component(_NODL_GENERATOR_CPP_INSTALL_DIR "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+
+set(_NODL_GENERATOR_CPP_SCRIPT
+  "${_NODL_GENERATOR_CPP_INSTALL_DIR}/lib/nodl_generator_cpp/nodl_generate_cpp")
+set(_NODL_GENERATOR_CPP_TEMPLATES_DIR
+  "${_NODL_GENERATOR_CPP_INSTALL_DIR}/share/nodl_generator_cpp/templates")
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+# Pull in generate_parameter_library and its runtime deps (fmt, rsl, tcb_span, tl_expected).
+find_package(generate_parameter_library REQUIRED)
+
+# Build a PYTHONPATH that includes site-packages from every prefix in the cmake
+# search path plus AMENT_PREFIX_PATH.  This makes generate_parameter_library_py
+# importable when the generator script runs at build time.
+set(_nodl_pythonpath_dirs "")
+set(_nodl_search_prefixes ${CMAKE_PREFIX_PATH})
+if(DEFINED ENV{AMENT_PREFIX_PATH})
+  string(REPLACE ":" ";" _ament_prefixes "$ENV{AMENT_PREFIX_PATH}")
+  list(APPEND _nodl_search_prefixes ${_ament_prefixes})
+endif()
+list(REMOVE_DUPLICATES _nodl_search_prefixes)
+
+foreach(_prefix ${_nodl_search_prefixes})
+  foreach(_pyver "python3.12" "python3.11" "python3.10" "python3.9")
+    set(_site "${_prefix}/lib/${_pyver}/site-packages")
+    if(EXISTS "${_site}")
+      list(APPEND _nodl_pythonpath_dirs "${_site}")
+    endif()
+  endforeach()
+endforeach()
+list(REMOVE_DUPLICATES _nodl_pythonpath_dirs)
+string(JOIN ":" _NODL_GENERATOR_CPP_EXTRA_PYTHONPATH ${_nodl_pythonpath_dirs})
+
+include("${CMAKE_CURRENT_LIST_DIR}/nodl_generate_cpp.cmake")

--- a/nodl_generator_cpp/package.xml
+++ b/nodl_generator_cpp/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>nodl_generator_cpp</name>
+  <version>0.1.0</version>
+  <description>CMake macro to generate an rclcpp base-node class from a NoDL file.</description>
+  <maintainer email="emerson@polymathrobotics.com">Emerson Knapp</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>generate_parameter_library</depend>
+  <depend>python3-jinja2</depend>
+  <depend>python3-yaml</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/nodl_generator_cpp/scripts/nodl_generate_cpp
+++ b/nodl_generator_cpp/scripts/nodl_generate_cpp
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Generate an rclcpp base-node class (.hpp + .cpp) from a NoDL YAML file.
+
+The parameters section of the NoDL document is treated as a
+generate_parameter_library YAML schema.  The generator calls
+generate_parameter_library_py directly to produce the typed parameter header,
+then renders the node base class templates that reference it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Name utilities
+# ---------------------------------------------------------------------------
+
+def _camel_to_snake(name: str) -> str:
+    s = re.sub(r'([A-Z]+)([A-Z][a-z])', r'\1_\2', name)
+    s = re.sub(r'([a-z0-9])([A-Z])', r'\1_\2', s)
+    return s.lower()
+
+
+def _snake_to_pascal(name: str) -> str:
+    return ''.join(part.capitalize() for part in name.split('_') if part)
+
+
+def _topic_to_identifier(topic: str) -> str:
+    return re.sub(r'[^a-zA-Z0-9]+', '_', topic.strip('/')).strip('_')
+
+
+# ---------------------------------------------------------------------------
+# ROS type utilities
+# ---------------------------------------------------------------------------
+
+def _ros_type_to_cpp(ros_type: str) -> str:
+    """sensor_msgs/msg/Image -> sensor_msgs::msg::Image"""
+    return ros_type.replace('/', '::')
+
+
+def _ros_type_to_include(ros_type: str) -> str:
+    """sensor_msgs/msg/Image -> sensor_msgs/msg/image.hpp"""
+    parts = ros_type.split('/')
+    parts[-1] = _camel_to_snake(parts[-1])
+    return '/'.join(parts) + '.hpp'
+
+
+# ---------------------------------------------------------------------------
+# QoS utilities
+# ---------------------------------------------------------------------------
+
+def _qos_to_cpp(qos: dict | None) -> str:
+    if not qos:
+        return 'rclcpp::QoS(10)'
+    history = qos.get('history', 'SYSTEM_DEFAULT')
+    depth = qos.get('depth', 10)
+    if history == 'KEEP_ALL':
+        base = 'rclcpp::QoS(rclcpp::KeepAll())'
+    elif history == 'SYSTEM_DEFAULT':
+        base = 'rclcpp::SystemDefaultsQoS()'
+    else:  # KEEP_LAST
+        base = f'rclcpp::QoS({int(depth)})'
+    rel = qos.get('reliability')
+    if rel == 'BEST_EFFORT':
+        base += '.best_effort()'
+    elif rel == 'RELIABLE':
+        base += '.reliable()'
+    dur = qos.get('durability')
+    if dur == 'TRANSIENT_LOCAL':
+        base += '.transient_local()'
+    elif dur == 'VOLATILE':
+        base += '.durability_volatile()'
+    return base
+
+
+# ---------------------------------------------------------------------------
+# generate_parameter_library integration
+# ---------------------------------------------------------------------------
+
+def _write_params_yaml(yaml_path: Path, namespace: str, parameters: dict) -> None:
+    """Write a generate_parameter_library-compatible YAML file.
+
+    The NoDL parameters sub-schema is treated as identical to the
+    generate_parameter_library schema (type, default_value, description,
+    read_only, additional_constraints, validation are all passed through).
+    """
+    try:
+        import yaml
+    except ImportError:
+        sys.exit('PyYAML is required')
+
+    with yaml_path.open('w') as f:
+        yaml.dump({namespace: parameters}, f, default_flow_style=False)
+
+
+def _generate_params_header(params_hpp: Path, params_yaml: Path) -> None:
+    """Call generate_parameter_library_py to produce the typed parameter header."""
+    try:
+        from generate_parameter_library_py.generate_cpp_header import run
+    except ImportError:
+        sys.exit(
+            'generate_parameter_library_py is not importable.\n'
+            'Ensure the package is built and your PYTHONPATH includes its '
+            'site-packages directory.'
+        )
+    run(str(params_hpp), str(params_yaml))
+
+
+# ---------------------------------------------------------------------------
+# Template rendering context
+# ---------------------------------------------------------------------------
+
+def _build_context(nodl_data: dict, target_name: str, lifecycle: bool) -> dict:
+    node_name = target_name
+    class_name = _snake_to_pascal(target_name) + 'Base'
+
+    base_class = (
+        'rclcpp_lifecycle::LifecycleNode' if lifecycle else 'rclcpp::Node'
+    )
+
+    includes: list[str] = []
+    if lifecycle:
+        includes.append('rclcpp_lifecycle/lifecycle_node.hpp')
+        includes.append('rclcpp_lifecycle/lifecycle_publisher.hpp')
+    else:
+        includes.append('rclcpp/rclcpp.hpp')
+
+    parameters: dict = nodl_data.get('parameters') or {}
+    has_params = bool(parameters)
+    params_namespace = target_name
+
+    publishers = []
+    for pub in (nodl_data.get('publishers') or []):
+        ros_type = pub['type']
+        cpp_type = _ros_type_to_cpp(ros_type)
+        inc = _ros_type_to_include(ros_type)
+        if inc not in includes:
+            includes.append(inc)
+        topic_name = pub['name']
+        ident = _topic_to_identifier(topic_name)
+        pub_type = (
+            f'rclcpp_lifecycle::LifecyclePublisher<{cpp_type}>'
+            if lifecycle else
+            f'rclcpp::Publisher<{cpp_type}>'
+        )
+        publishers.append({
+            'topic': topic_name,
+            'cpp_type': cpp_type,
+            'pub_type': pub_type,
+            'member_name': f'pub_{ident}_',
+            'qos_cpp': _qos_to_cpp(pub.get('qos')),
+        })
+
+    subscriptions = []
+    for sub in (nodl_data.get('subscriptions') or []):
+        ros_type = sub['type']
+        cpp_type = _ros_type_to_cpp(ros_type)
+        inc = _ros_type_to_include(ros_type)
+        if inc not in includes:
+            includes.append(inc)
+        topic_name = sub['name']
+        ident = _topic_to_identifier(topic_name)
+        subscriptions.append({
+            'topic': topic_name,
+            'cpp_type': cpp_type,
+            'member_name': f'sub_{ident}_',
+            'callback_name': f'on_{ident}',
+            'qos_cpp': _qos_to_cpp(sub.get('qos')),
+        })
+
+    service_servers = []
+    for srv in (nodl_data.get('service_servers') or []):
+        ros_type = srv['type']
+        cpp_type = _ros_type_to_cpp(ros_type)
+        inc = _ros_type_to_include(ros_type)
+        if inc not in includes:
+            includes.append(inc)
+        ident = _topic_to_identifier(srv['name'])
+        service_servers.append({
+            'name': srv['name'],
+            'cpp_type': cpp_type,
+            'member_name': f'srv_{ident}_',
+            'callback_name': f'on_{ident}',
+        })
+
+    service_clients = []
+    for cli in (nodl_data.get('service_clients') or []):
+        ros_type = cli['type']
+        cpp_type = _ros_type_to_cpp(cli['type'])
+        inc = _ros_type_to_include(ros_type)
+        if inc not in includes:
+            includes.append(inc)
+        ident = _topic_to_identifier(cli['name'])
+        service_clients.append({
+            'name': cli['name'],
+            'cpp_type': cpp_type,
+            'member_name': f'cli_{ident}_',
+        })
+
+    return {
+        'class_name': class_name,
+        'node_name': node_name,
+        'base_class': base_class,
+        'lifecycle': lifecycle,
+        'includes': includes,
+        'has_params': has_params,
+        'params_namespace': params_namespace,
+        'publishers': publishers,
+        'subscriptions': subscriptions,
+        'service_servers': service_servers,
+        'service_clients': service_clients,
+        'target_name': target_name,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Template rendering
+# ---------------------------------------------------------------------------
+
+def _render(templates_dir: Path, template_name: str, context: dict) -> str:
+    try:
+        import jinja2
+    except ImportError:
+        sys.exit('jinja2 is required')
+    loader = jinja2.FileSystemLoader(str(templates_dir))
+    env = jinja2.Environment(loader=loader, trim_blocks=True, lstrip_blocks=True)
+    return env.get_template(template_name).render(**context)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--nodl-file', required=True)
+    parser.add_argument('--output-dir', required=True)
+    parser.add_argument('--target-name', required=True)
+    parser.add_argument('--templates-dir', required=True)
+    parser.add_argument('--lifecycle', action='store_true')
+    args = parser.parse_args()
+
+    try:
+        import yaml
+    except ImportError:
+        sys.exit('PyYAML is required')
+
+    nodl_path = Path(args.nodl_file)
+    if not nodl_path.exists():
+        sys.exit(f'NoDL file not found: {nodl_path}')
+
+    with nodl_path.open() as f:
+        nodl_data = yaml.safe_load(f) or {}
+
+    templates_dir = Path(args.templates_dir)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    context = _build_context(nodl_data, args.target_name, args.lifecycle)
+
+    if context['has_params']:
+        params_yaml = output_dir / f'{args.target_name}_params.yaml'
+        params_hpp = output_dir / f'{args.target_name}_params.hpp'
+        _write_params_yaml(params_yaml, args.target_name, nodl_data['parameters'])
+        _generate_params_header(params_hpp, params_yaml)
+
+    hpp_text = _render(templates_dir, 'node.hpp.jinja2', context)
+    cpp_text = _render(templates_dir, 'node.cpp.jinja2', context)
+
+    (output_dir / f'{args.target_name}.hpp').write_text(hpp_text)
+    (output_dir / f'{args.target_name}.cpp').write_text(cpp_text)
+
+
+if __name__ == '__main__':
+    main()

--- a/nodl_generator_cpp/templates/node.cpp.jinja2
+++ b/nodl_generator_cpp/templates/node.cpp.jinja2
@@ -1,0 +1,48 @@
+// GENERATED FILE — do not edit. Regenerated from NoDL by nodl_generator_cpp.
+#include "{{ target_name }}.hpp"
+
+{{ class_name }}::{{ class_name }}(const rclcpp::NodeOptions & options)
+: {{ base_class }}("{{ node_name }}", options)
+{% if has_params %}
+, param_listener_(get_node_parameters_interface())
+, params_(param_listener_.get_params())
+{% endif %}
+{
+{% if publishers %}
+  // Create publishers
+{% for pub in publishers %}
+  {{ pub.member_name }} = this->create_publisher<{{ pub.cpp_type }}>(
+    "{{ pub.topic }}", {{ pub.qos_cpp }});
+{% endfor %}
+
+{% endif %}
+{% if subscriptions %}
+  // Create subscriptions
+{% for sub in subscriptions %}
+  {{ sub.member_name }} = this->create_subscription<{{ sub.cpp_type }}>(
+    "{{ sub.topic }}", {{ sub.qos_cpp }},
+    [this]({{ sub.cpp_type }}::ConstSharedPtr msg) { this->{{ sub.callback_name }}(msg); });
+{% endfor %}
+
+{% endif %}
+{% if service_servers %}
+  // Create service servers
+{% for srv in service_servers %}
+  {{ srv.member_name }} = this->create_service<{{ srv.cpp_type }}>(
+    "{{ srv.name }}",
+    [this](
+      {{ srv.cpp_type }}::Request::SharedPtr req,
+      {{ srv.cpp_type }}::Response::SharedPtr res)
+    {
+      this->{{ srv.callback_name }}(req, res);
+    });
+{% endfor %}
+
+{% endif %}
+{% if service_clients %}
+  // Create service clients
+{% for cli in service_clients %}
+  {{ cli.member_name }} = this->create_client<{{ cli.cpp_type }}>("{{ cli.name }}");
+{% endfor %}
+{% endif %}
+}

--- a/nodl_generator_cpp/templates/node.hpp.jinja2
+++ b/nodl_generator_cpp/templates/node.hpp.jinja2
@@ -1,0 +1,71 @@
+// GENERATED FILE — do not edit. Regenerated from NoDL by nodl_generator_cpp.
+#pragma once
+
+#include <memory>
+
+{% for inc in includes %}
+#include <{{ inc }}>
+{% endfor %}
+{% if has_params %}
+#include "{{ target_name }}_params.hpp"
+{% endif %}
+
+class {{ class_name }} : public {{ base_class }}
+{
+public:
+  explicit {{ class_name }}(const rclcpp::NodeOptions & options = rclcpp::NodeOptions{});
+
+  virtual ~{{ class_name }}() = default;
+
+protected:
+{% if has_params %}
+  // --- Parameters (via generate_parameter_library) ---
+  // Declared in initialization order: listener first, then params.
+  {{ params_namespace }}::ParamListener param_listener_;
+  {{ params_namespace }}::Params params_;
+
+{% endif %}
+{% if publishers %}
+  // --- Publishers ---
+{% for pub in publishers %}
+  {{ pub.pub_type }}::SharedPtr {{ pub.member_name }};
+{% endfor %}
+
+{% endif %}
+{% if subscriptions %}
+  // --- Subscription callbacks (pure virtual; implement in derived class) ---
+{% for sub in subscriptions %}
+  virtual void {{ sub.callback_name }}({{ sub.cpp_type }}::ConstSharedPtr msg) = 0;
+{% endfor %}
+
+{% endif %}
+{% if service_servers %}
+  // --- Service server callbacks (pure virtual; implement in derived class) ---
+{% for srv in service_servers %}
+  virtual void {{ srv.callback_name }}(
+    {{ srv.cpp_type }}::Request::SharedPtr request,
+    {{ srv.cpp_type }}::Response::SharedPtr response) = 0;
+{% endfor %}
+
+{% endif %}
+{% if service_clients %}
+  // --- Service clients ---
+{% for cli in service_clients %}
+  rclcpp::Client<{{ cli.cpp_type }}>::SharedPtr {{ cli.member_name }};
+{% endfor %}
+
+{% endif %}
+private:
+{% if subscriptions %}
+  // --- Subscriptions ---
+{% for sub in subscriptions %}
+  rclcpp::Subscription<{{ sub.cpp_type }}>::SharedPtr {{ sub.member_name }};
+{% endfor %}
+{% endif %}
+{% if service_servers %}
+  // --- Service servers ---
+{% for srv in service_servers %}
+  rclcpp::Service<{{ srv.cpp_type }}>::SharedPtr {{ srv.member_name }};
+{% endfor %}
+{% endif %}
+};

--- a/nodl_generator_cpp/test/test_generator.py
+++ b/nodl_generator_cpp/test/test_generator.py
@@ -1,0 +1,330 @@
+"""Unit tests for the nodl_generate_cpp Python generator."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load the generator script as a module (it has no .py extension).
+_SCRIPT = Path(__file__).parents[1] / 'scripts' / 'nodl_generate_cpp'
+_loader = importlib.machinery.SourceFileLoader('nodl_generate_cpp', str(_SCRIPT))
+_spec = importlib.util.spec_from_loader('nodl_generate_cpp', _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+camel_to_snake = _mod._camel_to_snake
+snake_to_pascal = _mod._snake_to_pascal
+topic_to_identifier = _mod._topic_to_identifier
+ros_type_to_cpp = _mod._ros_type_to_cpp
+ros_type_to_include = _mod._ros_type_to_include
+qos_to_cpp = _mod._qos_to_cpp
+build_context = _mod._build_context
+
+
+# ---------------------------------------------------------------------------
+# Name conversions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('name,expected', [
+    ('Image', 'image'),
+    ('LaserScan', 'laser_scan'),
+    ('PointCloud2', 'point_cloud2'),
+    ('NavSatFix', 'nav_sat_fix'),
+    ('String', 'string'),
+])
+def test_camel_to_snake(name, expected):
+    assert camel_to_snake(name) == expected
+
+
+@pytest.mark.parametrize('name,expected', [
+    ('my_node', 'MyNode'),
+    ('test', 'Test'),
+    ('foo_bar_baz', 'FooBarBaz'),
+])
+def test_snake_to_pascal(name, expected):
+    assert snake_to_pascal(name) == expected
+
+
+@pytest.mark.parametrize('topic,expected', [
+    ('/scan', 'scan'),
+    ('/my/long/topic', 'my_long_topic'),
+    ('relative', 'relative'),
+    ('/a/b', 'a_b'),
+])
+def test_topic_to_identifier(topic, expected):
+    assert topic_to_identifier(topic) == expected
+
+
+# ---------------------------------------------------------------------------
+# Type conversions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('ros_type,expected_cpp', [
+    ('sensor_msgs/msg/Image', 'sensor_msgs::msg::Image'),
+    ('std_msgs/msg/String', 'std_msgs::msg::String'),
+    ('std_srvs/srv/SetBool', 'std_srvs::srv::SetBool'),
+])
+def test_ros_type_to_cpp(ros_type, expected_cpp):
+    assert ros_type_to_cpp(ros_type) == expected_cpp
+
+
+@pytest.mark.parametrize('ros_type,expected_include', [
+    ('sensor_msgs/msg/Image', 'sensor_msgs/msg/image.hpp'),
+    ('sensor_msgs/msg/LaserScan', 'sensor_msgs/msg/laser_scan.hpp'),
+    ('sensor_msgs/msg/PointCloud2', 'sensor_msgs/msg/point_cloud2.hpp'),
+    ('std_msgs/msg/String', 'std_msgs/msg/string.hpp'),
+])
+def test_ros_type_to_include(ros_type, expected_include):
+    assert ros_type_to_include(ros_type) == expected_include
+
+
+# ---------------------------------------------------------------------------
+# qos_to_cpp
+# ---------------------------------------------------------------------------
+
+def test_qos_to_cpp_default():
+    assert qos_to_cpp(None) == 'rclcpp::QoS(10)'
+
+
+def test_qos_to_cpp_reliable():
+    result = qos_to_cpp({'history': 'KEEP_LAST', 'depth': 10, 'reliability': 'RELIABLE'})
+    assert result == 'rclcpp::QoS(10).reliable()'
+
+
+def test_qos_to_cpp_best_effort():
+    result = qos_to_cpp({'history': 'KEEP_LAST', 'depth': 5, 'reliability': 'BEST_EFFORT'})
+    assert result == 'rclcpp::QoS(5).best_effort()'
+
+
+def test_qos_to_cpp_keep_all():
+    result = qos_to_cpp({'history': 'KEEP_ALL', 'reliability': 'RELIABLE'})
+    assert result == 'rclcpp::QoS(rclcpp::KeepAll()).reliable()'
+
+
+def test_qos_to_cpp_system_default():
+    result = qos_to_cpp({'history': 'SYSTEM_DEFAULT', 'reliability': 'RELIABLE'})
+    assert result == 'rclcpp::SystemDefaultsQoS().reliable()'
+
+
+def test_qos_to_cpp_transient_local():
+    result = qos_to_cpp({
+        'history': 'KEEP_LAST',
+        'depth': 10,
+        'reliability': 'RELIABLE',
+        'durability': 'TRANSIENT_LOCAL',
+    })
+    assert result == 'rclcpp::QoS(10).reliable().transient_local()'
+
+
+# ---------------------------------------------------------------------------
+# build_context
+# ---------------------------------------------------------------------------
+
+_MINIMAL_NODL = {
+    'nodl_version': 2,
+}
+
+_FULL_NODL = {
+    'nodl_version': 2,
+    'parameters': {
+        'rate': {'type': 'double', 'default_value': 5.0},
+        'name': {'type': 'string', 'read_only': True},
+    },
+    'publishers': [
+        {
+            'name': '/scan',
+            'type': 'sensor_msgs/msg/LaserScan',
+            'qos': {'history': 'KEEP_LAST', 'depth': 10, 'reliability': 'RELIABLE'},
+        }
+    ],
+    'subscriptions': [
+        {
+            'name': '/cmd',
+            'type': 'std_msgs/msg/String',
+            'qos': {'history': 'SYSTEM_DEFAULT', 'reliability': 'SYSTEM_DEFAULT'},
+        }
+    ],
+}
+
+
+def test_build_context_class_name():
+    ctx = build_context(_MINIMAL_NODL, 'my_node', lifecycle=False)
+    assert ctx['class_name'] == 'MyNodeBase'
+
+
+def test_build_context_node_name():
+    ctx = build_context(_FULL_NODL, 'test_node', lifecycle=False)
+    assert ctx['node_name'] == 'test_node'
+
+
+def test_build_context_base_class_regular():
+    ctx = build_context(_MINIMAL_NODL, 'x', lifecycle=False)
+    assert ctx['base_class'] == 'rclcpp::Node'
+
+
+def test_build_context_base_class_lifecycle():
+    ctx = build_context(_MINIMAL_NODL, 'x', lifecycle=True)
+    assert ctx['base_class'] == 'rclcpp_lifecycle::LifecycleNode'
+
+
+def test_build_context_includes_rclcpp():
+    ctx = build_context(_MINIMAL_NODL, 'x', lifecycle=False)
+    assert 'rclcpp/rclcpp.hpp' in ctx['includes']
+
+
+def test_build_context_includes_lifecycle():
+    ctx = build_context(_MINIMAL_NODL, 'x', lifecycle=True)
+    assert 'rclcpp_lifecycle/lifecycle_node.hpp' in ctx['includes']
+
+
+def test_build_context_has_params_true():
+    ctx = build_context(_FULL_NODL, 'test_node', lifecycle=False)
+    assert ctx['has_params'] is True
+
+
+def test_build_context_has_params_false_when_no_parameters():
+    ctx = build_context(_MINIMAL_NODL, 'my_node', lifecycle=False)
+    assert ctx['has_params'] is False
+
+
+def test_build_context_params_namespace():
+    ctx = build_context(_FULL_NODL, 'test_node', lifecycle=False)
+    assert ctx['params_namespace'] == 'test_node'
+
+
+def test_build_context_publishers():
+    ctx = build_context(_FULL_NODL, 'test_node', lifecycle=False)
+    assert len(ctx['publishers']) == 1
+    pub = ctx['publishers'][0]
+    assert pub['topic'] == '/scan'
+    assert pub['cpp_type'] == 'sensor_msgs::msg::LaserScan'
+    assert pub['member_name'] == 'pub_scan_'
+    assert 'sensor_msgs/msg/laser_scan.hpp' in ctx['includes']
+
+
+def test_build_context_subscriptions():
+    ctx = build_context(_FULL_NODL, 'test_node', lifecycle=False)
+    assert len(ctx['subscriptions']) == 1
+    sub = ctx['subscriptions'][0]
+    assert sub['topic'] == '/cmd'
+    assert sub['cpp_type'] == 'std_msgs::msg::String'
+    assert sub['member_name'] == 'sub_cmd_'
+    assert sub['callback_name'] == 'on_cmd'
+
+
+def test_build_context_no_duplicate_includes():
+    nodl = {
+        'nodl_version': 2,
+        'publishers': [
+            {'name': '/a', 'type': 'std_msgs/msg/String', 'qos': {'history': 'SYSTEM_DEFAULT', 'reliability': 'SYSTEM_DEFAULT'}},
+            {'name': '/b', 'type': 'std_msgs/msg/String', 'qos': {'history': 'SYSTEM_DEFAULT', 'reliability': 'SYSTEM_DEFAULT'}},
+        ]
+    }
+    ctx = build_context(nodl, 'x', lifecycle=False)
+    assert ctx['includes'].count('std_msgs/msg/string.hpp') == 1
+
+
+def test_build_context_empty_nodl():
+    ctx = build_context({}, 'my_target', lifecycle=False)
+    assert ctx['class_name'] == 'MyTargetBase'
+    assert ctx['has_params'] is False
+    assert ctx['publishers'] == []
+    assert ctx['subscriptions'] == []
+
+
+# ---------------------------------------------------------------------------
+# _write_params_yaml
+# ---------------------------------------------------------------------------
+
+def test_write_params_yaml_structure(tmp_path):
+    import yaml
+
+    params = {
+        'rate': {'type': 'double', 'default_value': 5.0},
+        'label': {'type': 'string', 'read_only': True},
+    }
+    out = tmp_path / 'test_params.yaml'
+    _mod._write_params_yaml(out, 'my_node', params)
+    data = yaml.safe_load(out.read_text())
+    assert 'my_node' in data
+    assert data['my_node']['rate']['type'] == 'double'
+    assert data['my_node']['label']['read_only'] is True
+
+
+# ---------------------------------------------------------------------------
+# Template rendering (requires jinja2)
+# ---------------------------------------------------------------------------
+
+jinja2 = pytest.importorskip('jinja2')
+
+_TEMPLATES_DIR = Path(__file__).parents[1] / 'templates'
+
+
+def _render(template_name: str, context: dict) -> str:
+    loader = jinja2.FileSystemLoader(str(_TEMPLATES_DIR))
+    env = jinja2.Environment(loader=loader, trim_blocks=True, lstrip_blocks=True)
+    return env.get_template(template_name).render(**context)
+
+
+def test_render_hpp_contains_class():
+    ctx = build_context(_FULL_NODL, 'test_node', lifecycle=False)
+    hpp = _render('node.hpp.jinja2', ctx)
+    assert 'class TestNodeBase' in hpp
+    assert 'public rclcpp::Node' in hpp
+    assert 'pub_scan_' in hpp
+    assert 'on_cmd' in hpp
+    assert 'virtual void on_cmd' in hpp
+
+
+def test_render_hpp_params_via_genparamlib():
+    ctx = build_context(_FULL_NODL, 'test_node', lifecycle=False)
+    hpp = _render('node.hpp.jinja2', ctx)
+    assert 'test_node_params.hpp' in hpp
+    assert 'test_node::ParamListener param_listener_' in hpp
+    assert 'test_node::Params params_' in hpp
+
+
+def test_render_cpp_uses_param_listener():
+    ctx = build_context(_FULL_NODL, 'test_node', lifecycle=False)
+    cpp = _render('node.cpp.jinja2', ctx)
+    assert 'TestNodeBase::TestNodeBase' in cpp
+    # Initializer list — not assignment in body
+    assert ', param_listener_(get_node_parameters_interface())' in cpp
+    assert ', params_(param_listener_.get_params())' in cpp
+    assert 'create_publisher' in cpp
+    assert 'create_subscription' in cpp
+    assert 'on_cmd' in cpp
+
+
+def test_render_cpp_no_declare_parameter():
+    """Parameters are handled by generate_parameter_library, not inline calls."""
+    ctx = build_context(_FULL_NODL, 'test_node', lifecycle=False)
+    cpp = _render('node.cpp.jinja2', ctx)
+    assert 'declare_parameter' not in cpp
+
+
+def test_render_hpp_lifecycle():
+    nodl = {'nodl_version': 2}
+    ctx = build_context(nodl, 'my_node', lifecycle=True)
+    hpp = _render('node.hpp.jinja2', ctx)
+    assert 'rclcpp_lifecycle::LifecycleNode' in hpp
+
+
+def test_render_hpp_no_params_section_when_empty():
+    ctx = build_context({}, 'empty_node', lifecycle=False)
+    hpp = _render('node.hpp.jinja2', ctx)
+    assert 'params_' not in hpp
+    assert 'ParamListener' not in hpp
+    assert 'Publishers' not in hpp
+    assert 'Subscriptions' not in hpp
+
+
+def test_render_cpp_no_param_listener_when_no_params():
+    ctx = build_context(_MINIMAL_NODL, 'my_node', lifecycle=False)
+    cpp = _render('node.cpp.jinja2', ctx)
+    assert 'ParamListener' not in cpp
+    assert 'get_params' not in cpp

--- a/test_nodl_generator_cpp/CMakeLists.txt
+++ b/test_nodl_generator_cpp/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
+project(test_nodl_generator_cpp)
+
+find_package(ament_cmake REQUIRED)
+find_package(nodl_generator_cpp REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+
+# Generate the base class from the NoDL file
+nodl_generate_cpp(test_node nodl/test_node.nodl.yaml)
+target_include_directories(test_node SYSTEM PUBLIC ${std_msgs_INCLUDE_DIRS})
+target_link_libraries(test_node PUBLIC ${std_msgs_LIBRARIES})
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_generated_node test/test_generated_node.cpp)
+  target_link_libraries(test_generated_node test_node)
+endif()
+
+ament_package()

--- a/test_nodl_generator_cpp/nodl/test_node.nodl.yaml
+++ b/test_nodl_generator_cpp/nodl/test_node.nodl.yaml
@@ -1,0 +1,28 @@
+nodl_version: 2
+parameters:
+  publish_rate:
+    type: double
+    default_value: 10.0
+    description: Publish rate in Hz
+  frame_id:
+    type: string
+    default_value: base_link
+    description: Frame ID for published messages
+  enabled:
+    type: bool
+    default_value: true
+    read_only: true
+publishers:
+  - name: /output
+    type: std_msgs/msg/String
+    qos:
+      history: KEEP_LAST
+      depth: 10
+      reliability: RELIABLE
+subscriptions:
+  - name: /input
+    type: std_msgs/msg/String
+    qos:
+      history: KEEP_LAST
+      depth: 5
+      reliability: BEST_EFFORT

--- a/test_nodl_generator_cpp/package.xml
+++ b/test_nodl_generator_cpp/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>test_nodl_generator_cpp</name>
+  <version>0.1.0</version>
+  <description>End-to-end test for nodl_generator_cpp macro.</description>
+  <maintainer email="emerson@polymathrobotics.com">Emerson Knapp</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>nodl_generator_cpp</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/test_nodl_generator_cpp/test/test_generated_node.cpp
+++ b/test_nodl_generator_cpp/test/test_generated_node.cpp
@@ -1,0 +1,71 @@
+#include "test_node.hpp"
+
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+
+// Minimal concrete subclass.  Re-exports protected members as public so the
+// tests can verify them directly.
+class ConcreteTestNode : public TestNodeBase
+{
+public:
+  using TestNodeBase::TestNodeBase;
+
+  // Re-export protected members for white-box testing
+  using TestNodeBase::params_;
+  using TestNodeBase::pub_output_;
+
+  int input_count{0};
+
+protected:
+  void on_input(std_msgs::msg::String::ConstSharedPtr /*msg*/) override
+  {
+    ++input_count;
+  }
+};
+
+class GeneratedNodeTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { rclcpp::init(0, nullptr); }
+  void TearDown() override { rclcpp::shutdown(); }
+};
+
+TEST_F(GeneratedNodeTest, NodeNameMatchesNodlFile)
+{
+  auto node = std::make_shared<ConcreteTestNode>();
+  EXPECT_STREQ(node->get_name(), "test_node");
+}
+
+TEST_F(GeneratedNodeTest, PublisherExists)
+{
+  auto node = std::make_shared<ConcreteTestNode>();
+  ASSERT_NE(node->pub_output_, nullptr);
+}
+
+TEST_F(GeneratedNodeTest, DefaultParameterValues)
+{
+  auto node = std::make_shared<ConcreteTestNode>();
+  // Params struct is populated by generate_parameter_library at construction
+  EXPECT_DOUBLE_EQ(node->params_.publish_rate, 10.0);
+  EXPECT_EQ(node->params_.frame_id, std::string("base_link"));
+  EXPECT_TRUE(node->params_.enabled);
+}
+
+TEST_F(GeneratedNodeTest, ParametersDeclaredOnNode)
+{
+  auto node = std::make_shared<ConcreteTestNode>();
+  EXPECT_TRUE(node->has_parameter("publish_rate"));
+  EXPECT_TRUE(node->has_parameter("frame_id"));
+  EXPECT_TRUE(node->has_parameter("enabled"));
+}
+
+TEST_F(GeneratedNodeTest, ReadOnlyParameterIsReadOnly)
+{
+  auto node = std::make_shared<ConcreteTestNode>();
+  auto desc = node->describe_parameter("enabled");
+  EXPECT_TRUE(desc.read_only);
+}


### PR DESCRIPTION
Generates C++ headers and sources for a NoDL-described node: publisher/subscription handles, parameter declarations, service / action clients and servers. Uses generate_parameter_library for parameter codegen.

- nodl_generator_cpp: jinja2 templates + nodl_generate_cpp script, CMake macro (nodl_generate_cpp) for integration in downstream packages
- test_nodl_generator_cpp: integration test exercising the macro against test_node.nodl.yaml

Independent of the rust generator, rclpy helpers, and docgen.