### PR TITLE
Add ament_nodl and the fragments composition feature

### DIFF
--- a/ament_nodl/CMakeLists.txt
+++ b/ament_nodl/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.16)
+project(ament_nodl)
+
+find_package(ament_cmake REQUIRED)
+
+install(FILES
+  cmake/ament_nodl_register_fragment.cmake
+  cmake/ament_nodl_register_node.cmake
+  DESTINATION share/${PROJECT_NAME}/cmake)
+
+install(FILES resource/ament_nodl
+  DESTINATION share/ament_index/resource_index/packages)
+install(FILES package.xml
+  DESTINATION share/${PROJECT_NAME})
+
+ament_package(CONFIG_EXTRAS "ament_nodl-extras.cmake.in")

--- a/ament_nodl/ament_nodl-extras.cmake.in
+++ b/ament_nodl/ament_nodl-extras.cmake.in
@@ -1,0 +1,2 @@
+include("${CMAKE_CURRENT_LIST_DIR}/ament_nodl_register_fragment.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/ament_nodl_register_node.cmake")

--- a/ament_nodl/cmake/ament_nodl_register_fragment.cmake
+++ b/ament_nodl/cmake/ament_nodl_register_fragment.cmake
@@ -1,0 +1,56 @@
+# ament_nodl_register_fragment(name
+#   FILE <path>
+#   [PACKAGE <pkg>]    # defaults to ${PROJECT_NAME}
+# )
+#
+# Registers a NoDL fragment in the ament resource index under resource type
+# 'nodl_fragments', keyed as '<package>__<name>'.
+#
+# The fragment YAML content is stored as the resource value so that consumers
+# can retrieve it via:
+#   ament_index_python.packages.get_resource('nodl_fragments', '<pkg>__<name>')
+#
+# In NoDL files, reference this fragment as:
+#   ref: nodl://<package>/<name>
+#
+# Example:
+#   ament_nodl_register_fragment(tf_listener
+#     FILE nodl/tf_listener.nodl.yaml
+#   )
+#
+function(ament_nodl_register_fragment fragment_name)
+  cmake_parse_arguments(_ANF "" "FILE;PACKAGE" "" ${ARGN})
+
+  if(NOT _ANF_FILE)
+    message(FATAL_ERROR "ament_nodl_register_fragment: FILE is required")
+  endif()
+  if(NOT _ANF_PACKAGE)
+    set(_ANF_PACKAGE "${PROJECT_NAME}")
+  endif()
+
+  get_filename_component(_abs_file "${_ANF_FILE}" ABSOLUTE
+    BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  if(NOT EXISTS "${_abs_file}")
+    message(WARNING
+      "ament_nodl_register_fragment: file not found at configure time: ${_abs_file}")
+  endif()
+
+  # Read the NoDL file content at configure time and embed it in the marker.
+  file(READ "${_abs_file}" _nodl_content)
+
+  set(_resource_key "${_ANF_PACKAGE}__${fragment_name}")
+  set(_marker_dir
+    "${CMAKE_CURRENT_BINARY_DIR}/ament_nodl/nodl_fragments")
+  file(MAKE_DIRECTORY "${_marker_dir}")
+  file(WRITE "${_marker_dir}/${_resource_key}" "${_nodl_content}")
+
+  install(
+    FILES "${_marker_dir}/${_resource_key}"
+    DESTINATION "share/ament_index/resource_index/nodl_fragments")
+
+  # Also install the source file for human reference.
+  install(
+    FILES "${_abs_file}"
+    DESTINATION "share/${_ANF_PACKAGE}/nodl/fragments")
+endfunction()

--- a/ament_nodl/cmake/ament_nodl_register_node.cmake
+++ b/ament_nodl/cmake/ament_nodl_register_node.cmake
@@ -1,0 +1,57 @@
+# ament_nodl_register_node(executable
+#   FILE <path>
+#   [PACKAGE <pkg>]    # defaults to ${PROJECT_NAME}
+# )
+#
+# Registers a NoDL composition root (node description file) in the ament
+# resource index under resource type 'nodl_nodes', keyed as
+# '<package>__<executable>'.
+#
+# This allows tools like nodl_test and nodl_docgen to discover the NoDL
+# spec for any executable by package and name without requiring hardcoded
+# paths.
+#
+# The NoDL file content is stored as the resource value so that consumers
+# can retrieve it via:
+#   ament_index_python.packages.get_resource('nodl_nodes', '<pkg>__<exe>')
+#
+# Example:
+#   ament_nodl_register_node(my_node
+#     FILE nodl/my_node.nodl.yaml
+#   )
+#
+function(ament_nodl_register_node executable_name)
+  cmake_parse_arguments(_ANN "" "FILE;PACKAGE" "" ${ARGN})
+
+  if(NOT _ANN_FILE)
+    message(FATAL_ERROR "ament_nodl_register_node: FILE is required")
+  endif()
+  if(NOT _ANN_PACKAGE)
+    set(_ANN_PACKAGE "${PROJECT_NAME}")
+  endif()
+
+  get_filename_component(_abs_file "${_ANN_FILE}" ABSOLUTE
+    BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  if(NOT EXISTS "${_abs_file}")
+    message(WARNING
+      "ament_nodl_register_node: file not found at configure time: ${_abs_file}")
+  endif()
+
+  file(READ "${_abs_file}" _nodl_content)
+
+  set(_resource_key "${_ANN_PACKAGE}__${executable_name}")
+  set(_marker_dir
+    "${CMAKE_CURRENT_BINARY_DIR}/ament_nodl/nodl_nodes")
+  file(MAKE_DIRECTORY "${_marker_dir}")
+  file(WRITE "${_marker_dir}/${_resource_key}" "${_nodl_content}")
+
+  install(
+    FILES "${_marker_dir}/${_resource_key}"
+    DESTINATION "share/ament_index/resource_index/nodl_nodes")
+
+  # Also install the source file under the package share directory.
+  install(
+    FILES "${_abs_file}"
+    DESTINATION "share/${_ANN_PACKAGE}/nodl")
+endfunction()

--- a/ament_nodl/package.xml
+++ b/ament_nodl/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ament_nodl</name>
+  <version>0.1.0</version>
+  <description>CMake macros for registering NoDL node descriptions and fragments with the ament index.</description>
+  <maintainer email="emerson@polymathrobotics.com">Emerson Knapp</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/nodl_schema/nodl_schema/__init__.py
+++ b/nodl_schema/nodl_schema/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """NoDL schema, in-memory models, and validation helpers."""
 
+from nodl_schema.resolve import LayeredDocument, resolve
 from nodl_schema.validator import dump_nodl, load_nodl, load_schema, validate
 
-__all__ = ['dump_nodl', 'load_nodl', 'load_schema', 'validate']
+__all__ = ['LayeredDocument', 'dump_nodl', 'load_nodl', 'load_schema', 'resolve', 'validate']

--- a/nodl_schema/nodl_schema/models.py
+++ b/nodl_schema/nodl_schema/models.py
@@ -14,6 +14,15 @@ except ImportError:
     from pydantic import BaseModel, Extra, Field, conint, constr
 
 
+class Base(Enum):
+    """
+    Built-in ROS 2 base node type this node inherits from.
+    """
+
+    node = 'node'
+    lifecycle_node = 'lifecycle_node'
+
+
 class ScalarType(Enum):
     """
     Scalar types:
@@ -46,6 +55,24 @@ class ArrayType(Enum):
     int_array = 'int_array'
     double_array = 'double_array'
     string_array = 'string_array'
+
+
+class FragmentRef(BaseModel):
+    """
+    Reference to a NoDL fragment.
+    """
+
+    class Config:
+        extra = Extra.forbid
+
+    ref: str = Field(
+        ...,
+        description="'nodl://pkg/name' for ament-index fragments, or a relative file path.\n",
+    )
+    name: Optional[str] = Field(
+        None,
+        description='Optional label for this fragment in documentation and merge order.',
+    )
 
 
 class History(Enum):
@@ -425,6 +452,11 @@ class NodlDocument(BaseModel):
 
     nodl_version: int = Field(2, const=True, description='NoDL schema major version this document targets.')
     description: Optional[str] = Field(None, description='Human-readable description of what this node does.')
+    base: Optional[Base] = Field(None, description='Built-in ROS 2 base node type this node inherits from.')
+    fragments: Optional[list[FragmentRef]] = Field(
+        None,
+        description='NoDL fragments composed into this node (single-level, not recursive).',
+    )
     parameters: Optional[dict[str, ParameterDefinition]] = Field(
         None,
         description='ROS parameters declared by this node, keyed by parameter name.\nParameter shape is borrowed from generate_parameter_library\n(see parameter.schema.yaml).\n',

--- a/nodl_schema/nodl_schema/resolve.py
+++ b/nodl_schema/nodl_schema/resolve.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Resolution of NoDL composition (base + fragments) into a LayeredDocument."""
+
+from __future__ import annotations
+
+import importlib.resources as ir
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from nodl_schema.models import (
+    ActionEndpoint,
+    NodlDocument,
+    ParameterDefinition,
+    ServiceEndpoint,
+    TopicEndpoint,
+)
+
+_BUILTIN_BASES = frozenset(['node', 'lifecycle_node'])
+
+
+def _load_builtin(base: str) -> NodlDocument:
+    from nodl_schema.validator import load_nodl
+    path = ir.files('nodl_schema') / 'schemas' / 'fragments' / f'{base}.nodl.yaml'
+    return load_nodl(path.read_text(encoding='utf-8'))
+
+
+def _load_ament_fragment(pkg: str, name: str) -> NodlDocument:
+    try:
+        from ament_index_python.packages import get_resource
+    except ImportError as exc:
+        raise ImportError('ament_index_python is required to resolve nodl:// URIs') from exc
+    # Key format mirrors ament_nodl_register_fragment: pkg__name
+    resource_key = f'{pkg}__{name}'
+    try:
+        content, _ = get_resource('nodl_fragments', resource_key)
+    except KeyError:
+        raise FileNotFoundError(
+            f'NoDL fragment not found in ament index: {pkg}/{name} '
+            f'(looked up as nodl_fragments/{resource_key})'
+        )
+    from nodl_schema.validator import load_nodl
+    return load_nodl(content)
+
+
+def _resolve_ref(ref: str, source_path: Optional[Path] = None) -> NodlDocument:
+    if ref.startswith('nodl://'):
+        rest = ref[len('nodl://'):]
+        parts = rest.split('/', 1)
+        if len(parts) != 2:
+            raise ValueError(f'Invalid nodl:// URI: {ref!r} -- expected nodl://pkg/name')
+        return _load_ament_fragment(parts[0], parts[1])
+    if source_path is None:
+        raise ValueError(f'Cannot resolve relative fragment ref {ref!r} without a source path')
+    full_path = (source_path.parent / ref).resolve()
+    if not full_path.exists():
+        raise FileNotFoundError(f'Fragment file not found: {full_path}')
+    from nodl_schema.validator import load_nodl
+    return load_nodl(full_path.read_text(encoding='utf-8'))
+
+
+@dataclass
+class LayeredDocument:
+    """A NoDL document with its resolved composition layers, keyed by label."""
+
+    main: NodlDocument
+    base: Optional[NodlDocument] = None
+    base_name: Optional[str] = None
+    fragments: Dict[str, NodlDocument] = field(default_factory=dict)
+
+    def merged(self) -> NodlDocument:
+        """Merge all layers into a flat NodlDocument.
+
+        Layers applied in order: base -> named fragments (insertion order) -> main.
+        Later layers win on duplicate names.
+        """
+        layers: List[NodlDocument] = []
+        if self.base is not None:
+            layers.append(self.base)
+        layers.extend(self.fragments.values())
+        layers.append(self.main)
+
+        publishers: Dict[str, TopicEndpoint] = {}
+        subscriptions: Dict[str, TopicEndpoint] = {}
+        service_servers: Dict[str, ServiceEndpoint] = {}
+        service_clients: Dict[str, ServiceEndpoint] = {}
+        action_servers: Dict[str, ActionEndpoint] = {}
+        action_clients: Dict[str, ActionEndpoint] = {}
+        parameters: Dict[str, ParameterDefinition] = {}
+
+        for doc in layers:
+            for ep in (doc.publishers or []):
+                publishers[ep.name] = ep
+            for ep in (doc.subscriptions or []):
+                subscriptions[ep.name] = ep
+            for ep in (doc.service_servers or []):
+                service_servers[ep.name] = ep
+            for ep in (doc.service_clients or []):
+                service_clients[ep.name] = ep
+            for ep in (doc.action_servers or []):
+                action_servers[ep.name] = ep
+            for ep in (doc.action_clients or []):
+                action_clients[ep.name] = ep
+            for param_name, param in (doc.parameters or {}).items():
+                parameters[param_name] = param
+
+        return NodlDocument(
+            nodl_version=self.main.nodl_version,
+            parameters=parameters or None,
+            publishers=list(publishers.values()) or None,
+            subscriptions=list(subscriptions.values()) or None,
+            service_servers=list(service_servers.values()) or None,
+            service_clients=list(service_clients.values()) or None,
+            action_servers=list(action_servers.values()) or None,
+            action_clients=list(action_clients.values()) or None,
+        )
+
+
+def resolve(doc: NodlDocument, source_path: Optional[Path] = None) -> LayeredDocument:
+    """Resolve a NodlDocument's base and fragments into a LayeredDocument.
+
+    source_path: filesystem path to the NoDL file, used to resolve relative refs.
+    Fragments are single-level only -- fragment files are not themselves resolved.
+    """
+    # doc.base is an enum on pydantic v2 and may be either enum or string on v1
+    # depending on how the document was constructed. Normalize to the string value.
+    base_name: Optional[str] = None
+    if doc.base is not None:
+        base_name = doc.base.value if hasattr(doc.base, 'value') else doc.base
+
+    base_doc: Optional[NodlDocument] = None
+    if base_name is not None:
+        if base_name not in _BUILTIN_BASES:
+            raise ValueError(f'Unknown base {base_name!r}. Must be one of: {sorted(_BUILTIN_BASES)}')
+        base_doc = _load_builtin(base_name)
+
+    fragment_docs: Dict[str, NodlDocument] = {}
+    for frag_ref in (doc.fragments or []):
+        label = frag_ref.name or frag_ref.ref
+        fragment_docs[label] = _resolve_ref(frag_ref.ref, source_path=source_path)
+
+    return LayeredDocument(
+        main=doc,
+        base=base_doc,
+        base_name=base_name,
+        fragments=fragment_docs,
+    )

--- a/nodl_schema/nodl_schema/schemas/fragments/lifecycle_node.nodl.yaml
+++ b/nodl_schema/nodl_schema/schemas/fragments/lifecycle_node.nodl.yaml
@@ -1,0 +1,26 @@
+nodl_version: 2
+parameters:
+  use_sim_time:
+    type: bool
+    default_value: false
+    description: Use simulation (clock) time instead of wall time
+
+service_servers:
+  - name: ~/change_state
+    type: lifecycle_msgs/srv/ChangeState
+  - name: ~/get_state
+    type: lifecycle_msgs/srv/GetState
+  - name: ~/get_available_states
+    type: lifecycle_msgs/srv/GetAvailableStates
+  - name: ~/get_available_transitions
+    type: lifecycle_msgs/srv/GetAvailableTransitions
+  - name: ~/get_transition_graph
+    type: lifecycle_msgs/srv/GetTransitionGraph
+
+publishers:
+  - name: ~/transition_event
+    type: lifecycle_msgs/msg/TransitionEvent
+    qos:
+      history: KEEP_LAST
+      depth: 10
+      reliability: RELIABLE

--- a/nodl_schema/nodl_schema/schemas/fragments/node.nodl.yaml
+++ b/nodl_schema/nodl_schema/schemas/fragments/node.nodl.yaml
@@ -1,0 +1,6 @@
+nodl_version: 2
+parameters:
+  use_sim_time:
+    type: bool
+    default_value: false
+    description: Use simulation (clock) time instead of wall time

--- a/nodl_schema/nodl_schema/schemas/nodl.schema.yaml
+++ b/nodl_schema/nodl_schema/schemas/nodl.schema.yaml
@@ -28,6 +28,17 @@ properties:
     type: string
     description: Human-readable description of what this node does.
 
+  base:
+    type: string
+    enum: [node, lifecycle_node]
+    description: Built-in ROS 2 base node type this node inherits from.
+
+  fragments:
+    type: array
+    description: NoDL fragments composed into this node (single-level, not recursive).
+    items:
+      $ref: '#/definitions/fragment_ref'
+
   parameters:
     type: object
     description: |
@@ -74,6 +85,20 @@ properties:
       $ref: '#/definitions/action_endpoint'
 
 definitions:
+  fragment_ref:
+    type: object
+    description: Reference to a NoDL fragment.
+    required: [ref]
+    additionalProperties: false
+    properties:
+      ref:
+        type: string
+        description: |
+          'nodl://pkg/name' for ament-index fragments, or a relative file path.
+      name:
+        type: string
+        description: Optional label for this fragment in documentation and merge order.
+
   rosName:
     type: string
     description: |

--- a/nodl_schema/setup.py
+++ b/nodl_schema/setup.py
@@ -8,7 +8,7 @@ setup(
     name=package_name,
     version='0.0.0',
     packages=[package_name],
-    package_data={package_name: ['schemas/*.yaml']},
+    package_data={package_name: ['schemas/*.yaml', 'schemas/fragments/*.yaml']},
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
@@ -17,6 +17,13 @@ setup(
             [
                 'nodl_schema/schemas/nodl.schema.yaml',
                 'nodl_schema/schemas/parameter.schema.yaml',
+            ],
+        ),
+        (
+            'share/' + package_name + '/schemas/fragments',
+            [
+                'nodl_schema/schemas/fragments/node.nodl.yaml',
+                'nodl_schema/schemas/fragments/lifecycle_node.nodl.yaml',
             ],
         ),
     ],

--- a/nodl_schema/test/test_resolve.py
+++ b/nodl_schema/test/test_resolve.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for nodl_schema.resolve -- no ament_index or live ROS required."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from nodl_schema.models import FragmentRef, NodlDocument, ParameterDefinition, QosProfile, TopicEndpoint
+from nodl_schema.resolve import resolve
+
+_SYS_QOS = QosProfile(history='SYSTEM_DEFAULT', reliability='SYSTEM_DEFAULT')
+
+
+# ---------------------------------------------------------------------------
+# Built-in base resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_no_base_or_fragments():
+    doc = NodlDocument(nodl_version=2)
+    layered = resolve(doc)
+    assert layered.base is None
+    assert layered.fragments == {}
+    assert layered.merged() == NodlDocument(nodl_version=2)
+
+
+def test_resolve_base_node_loads_use_sim_time():
+    doc = NodlDocument(nodl_version=2, base='node')
+    layered = resolve(doc)
+    assert layered.base is not None
+    assert layered.base_name == 'node'
+    merged = layered.merged()
+    assert merged.parameters is not None
+    assert 'use_sim_time' in merged.parameters
+    p = merged.parameters['use_sim_time']
+    assert (p.type.value if hasattr(p.type, 'value') else p.type) == 'bool'
+
+
+def test_resolve_base_lifecycle_node_has_use_sim_time():
+    doc = NodlDocument(nodl_version=2, base='lifecycle_node')
+    merged = resolve(doc).merged()
+    assert 'use_sim_time' in (merged.parameters or {})
+
+
+def test_resolve_base_lifecycle_node_has_change_state_service():
+    merged = resolve(NodlDocument(nodl_version=2, base='lifecycle_node')).merged()
+    names = [s.name for s in (merged.service_servers or [])]
+    assert '~/change_state' in names
+
+
+def test_resolve_base_lifecycle_node_has_transition_event_publisher():
+    merged = resolve(NodlDocument(nodl_version=2, base='lifecycle_node')).merged()
+    topics = [p.name for p in (merged.publishers or [])]
+    assert '~/transition_event' in topics
+
+
+def test_resolve_unknown_base_raises():
+    # Pydantic rejects unknown bases at model construction time.
+    with pytest.raises(Exception):
+        NodlDocument(nodl_version=2, base='unknown_base')
+
+
+# ---------------------------------------------------------------------------
+# Fragment resolution -- relative path
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_relative_fragment(tmp_path: Path):
+    frag_file = tmp_path / 'my_frag.nodl.yaml'
+    frag_file.write_text(
+        textwrap.dedent("""\
+        nodl_version: 2
+        publishers:
+          - name: /extra
+            type: std_msgs/msg/String
+            qos:
+              history: SYSTEM_DEFAULT
+              reliability: SYSTEM_DEFAULT
+    """)
+    )
+
+    doc = NodlDocument(
+        nodl_version=2,
+        fragments=[FragmentRef(ref='my_frag.nodl.yaml', name='extra')],
+    )
+    layered = resolve(doc, source_path=tmp_path / 'root.nodl.yaml')
+    assert 'extra' in layered.fragments
+    topics = [p.name for p in (layered.merged().publishers or [])]
+    assert '/extra' in topics
+
+
+def test_resolve_relative_fragment_missing_raises(tmp_path: Path):
+    doc = NodlDocument(nodl_version=2, fragments=[FragmentRef(ref='nonexistent.nodl.yaml')])
+    with pytest.raises(FileNotFoundError):
+        resolve(doc, source_path=tmp_path / 'root.nodl.yaml')
+
+
+def test_resolve_relative_fragment_without_source_raises():
+    doc = NodlDocument(nodl_version=2, fragments=[FragmentRef(ref='./something.nodl.yaml')])
+    with pytest.raises(ValueError, match='source path'):
+        resolve(doc)
+
+
+# ---------------------------------------------------------------------------
+# LayeredDocument.merged() -- layer precedence
+# ---------------------------------------------------------------------------
+
+
+def test_merged_main_wins_over_base():
+    """Main document's parameter overrides the base's."""
+    doc = NodlDocument(
+        nodl_version=2,
+        base='node',
+        parameters={'use_sim_time': ParameterDefinition(type='bool', default_value=True)},
+    )
+    merged = resolve(doc).merged()
+    # Main sets default_value=True; base has default_value=False
+    assert merged.parameters['use_sim_time'].default_value is True
+
+
+def test_merged_fragment_wins_over_base(tmp_path: Path):
+    frag_file = tmp_path / 'frag.nodl.yaml'
+    frag_file.write_text(
+        textwrap.dedent("""\
+        nodl_version: 2
+        parameters:
+          use_sim_time:
+            type: bool
+            default_value: true
+    """)
+    )
+    doc = NodlDocument(
+        nodl_version=2,
+        base='node',
+        fragments=[FragmentRef(ref='frag.nodl.yaml', name='frag')],
+    )
+    merged = resolve(doc, source_path=tmp_path / 'root.nodl.yaml').merged()
+    assert merged.parameters['use_sim_time'].default_value is True
+
+
+def test_merged_combines_publishers_from_all_layers(tmp_path: Path):
+    frag_file = tmp_path / 'frag.nodl.yaml'
+    frag_file.write_text(
+        textwrap.dedent("""\
+        nodl_version: 2
+        publishers:
+          - name: /from_frag
+            type: std_msgs/msg/String
+            qos:
+              history: SYSTEM_DEFAULT
+              reliability: SYSTEM_DEFAULT
+    """)
+    )
+    doc = NodlDocument(
+        nodl_version=2,
+        publishers=[TopicEndpoint(name='/from_main', type='std_msgs/msg/String', qos=_SYS_QOS)],
+        fragments=[FragmentRef(ref='frag.nodl.yaml', name='f')],
+    )
+    merged = resolve(doc, source_path=tmp_path / 'root.nodl.yaml').merged()
+    topics = {p.name for p in (merged.publishers or [])}
+    assert '/from_main' in topics
+    assert '/from_frag' in topics
+
+
+def test_fragment_label_defaults_to_ref(tmp_path: Path):
+    frag_file = tmp_path / 'f.nodl.yaml'
+    frag_file.write_text(
+        textwrap.dedent("""\
+        nodl_version: 2
+        publishers:
+          - name: /t
+            type: std_msgs/msg/String
+            qos:
+              history: SYSTEM_DEFAULT
+              reliability: SYSTEM_DEFAULT
+    """)
+    )
+    doc = NodlDocument(nodl_version=2, fragments=[FragmentRef(ref='f.nodl.yaml')])
+    layered = resolve(doc, source_path=tmp_path / 'root.nodl.yaml')
+    assert 'f.nodl.yaml' in layered.fragments

--- a/nodl_schema/test/test_schema.py
+++ b/nodl_schema/test/test_schema.py
@@ -235,14 +235,26 @@ def test_string_nodl_version_rejected():
         validate({'nodl_version': '2'})
 
 
-def test_fragments_no_longer_allowed():
-    with pytest.raises(ValidationError):
-        validate({'nodl_version': 2, 'fragments': [{'ref': 'nodl://pkg/x'}]})
+def test_base_node_accepted():
+    validate({'nodl_version': 2, 'base': 'node'})
 
 
-def test_base_no_longer_allowed():
+def test_base_lifecycle_node_accepted():
+    validate({'nodl_version': 2, 'base': 'lifecycle_node'})
+
+
+def test_base_unknown_rejected():
     with pytest.raises(ValidationError):
-        validate({'nodl_version': 2, 'base': 'lifecycle_node'})
+        validate({'nodl_version': 2, 'base': 'unknown_base'})
+
+
+def test_fragments_accepted():
+    validate({'nodl_version': 2, 'fragments': [{'ref': 'nodl://pkg/x'}]})
+
+
+def test_fragment_missing_ref_rejected():
+    with pytest.raises(ValidationError):
+        validate({'nodl_version': 2, 'fragments': [{'name': 'no_ref'}]})
 
 
 def test_invalid_parameter_type():


### PR DESCRIPTION
ament_nodl:
  CMake macros (ament_nodl_register_node, ament_nodl_register_fragment)
  that let packages publish their .nodl.yaml files into the ament index
  under the nodl_nodes and nodl_fragments keys, so the resolver can find
  them via nodl:// URIs.

Fragments / base composition:
  - Schema: re-introduces the top-level 'base' (enum of node /
    lifecycle_node) and 'fragments' (array of fragment_refs) properties,
    plus the fragment_ref definition. Generated models pick these up
    automatically.
  - nodl_schema.resolve: resolves a NodlDocument's base + fragments into
    a LayeredDocument that can be flattened with .merged(). Base resolves
    to bundled fragment yamls; fragment refs resolve via relative file
    path or 'nodl://pkg/name' through the ament index.
  - Bundled fragments: nodl_schema/schemas/fragments/{node,lifecycle_node}.nodl.yaml
    declare the use_sim_time parameter and (for lifecycle) the standard
    transition services and event publisher.
  - Tests: test_resolve.py covers no-base/no-fragments, both bases,
    relative-fragment success/missing, fragment-without-source error,
    and layer precedence (main > fragments > base).

Both packages are kept separate from the schema/validate landing so this
PR can be reviewed independently.