### PR TITLE
Add ament_nodl with the register_node CMake macro

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: ros-tooling/action-ros-ci@v0.4
         with:
-          package-name: nodl nodl_schema ros2nodl
+          package-name: ament_nodl nodl nodl_schema ros2nodl test_ament_nodl
           target-ros2-distro: ${{ matrix.ros }}
       - uses: actions/upload-artifact@v4
         if: always()

--- a/ament_nodl/CMakeLists.txt
+++ b/ament_nodl/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+cmake_minimum_required(VERSION 3.22)
+project(ament_nodl)
+
+find_package(ament_cmake REQUIRED)
+
+install(FILES
+  cmake/ament_nodl_register_node.cmake
+  DESTINATION share/${PROJECT_NAME}/cmake)
+
+install(FILES package.xml
+  DESTINATION share/${PROJECT_NAME})
+
+ament_package(CONFIG_EXTRAS "ament_nodl-extras.cmake.in")

--- a/ament_nodl/ament_nodl-extras.cmake.in
+++ b/ament_nodl/ament_nodl-extras.cmake.in
@@ -1,1 +1,6 @@
+# Resolves ${Python3_EXECUTABLE} for the build-time validation step the
+# register_* macros invoke. Downstream packages get this when they call
+# find_package(ament_nodl).
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
 include("${CMAKE_CURRENT_LIST_DIR}/ament_nodl_register_node.cmake")

--- a/ament_nodl/ament_nodl-extras.cmake.in
+++ b/ament_nodl/ament_nodl-extras.cmake.in
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/ament_nodl_register_node.cmake")

--- a/ament_nodl/ament_nodl-extras.cmake.in
+++ b/ament_nodl/ament_nodl-extras.cmake.in
@@ -1,6 +1,4 @@
-# Resolves ${Python3_EXECUTABLE} for the build-time validation step the
-# register_* macros invoke. Downstream packages get this when they call
-# find_package(ament_nodl).
+# Resolves ${Python3_EXECUTABLE} for the build-time validation step the macros invoke.
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 include("${CMAKE_CURRENT_LIST_DIR}/ament_nodl_register_node.cmake")

--- a/ament_nodl/cmake/ament_nodl_register_node.cmake
+++ b/ament_nodl/cmake/ament_nodl_register_node.cmake
@@ -49,6 +49,24 @@ function(ament_nodl_register_node executable_name)
       "ament_nodl_register_node: file not found at configure time: ${_abs_file}")
   endif()
 
+  # Validate the file at build time so authoring errors surface during the
+  # downstream package's build, not at runtime.
+  # ninja/make re-runs this only when ${_abs_file} changes.
+  set(_stamp_dir "${CMAKE_CURRENT_BINARY_DIR}/ament_nodl/nodl_nodes")
+  set(_stamp "${_stamp_dir}/${_ANN_PACKAGE}__${executable_name}.valid.stamp")
+  file(MAKE_DIRECTORY "${_stamp_dir}")
+  add_custom_command(
+    OUTPUT "${_stamp}"
+    DEPENDS "${_abs_file}"
+    COMMAND "${Python3_EXECUTABLE}" -m nodl_schema "${_abs_file}"
+    COMMAND "${CMAKE_COMMAND}" -E touch "${_stamp}"
+    COMMENT "Validating NoDL node ${_ANN_PACKAGE}/${executable_name}"
+    VERBATIM
+  )
+  add_custom_target(_ament_nodl_validate_node_${_ANN_PACKAGE}__${executable_name} ALL
+    DEPENDS "${_stamp}"
+  )
+
   # Both installs reference the source file directly so they pick up its
   # current bytes at install time, not a snapshot from configure time.
   install(

--- a/ament_nodl/cmake/ament_nodl_register_node.cmake
+++ b/ament_nodl/cmake/ament_nodl_register_node.cmake
@@ -32,16 +32,16 @@
 # @public
 #
 function(ament_nodl_register_node executable_name)
-  cmake_parse_arguments(_ANN "" "FILE;PACKAGE" "" ${ARGN})
+  cmake_parse_arguments(_ARGS "" "FILE;PACKAGE" "" ${ARGN})
 
-  if(NOT _ANN_FILE)
+  if(NOT _ARGS_FILE)
     message(FATAL_ERROR "ament_nodl_register_node: FILE is required")
   endif()
-  if(NOT _ANN_PACKAGE)
-    set(_ANN_PACKAGE "${PROJECT_NAME}")
+  if(NOT _ARGS_PACKAGE)
+    set(_ARGS_PACKAGE "${PROJECT_NAME}")
   endif()
 
-  get_filename_component(_abs_file "${_ANN_FILE}" ABSOLUTE
+  get_filename_component(_abs_file "${_ARGS_FILE}" ABSOLUTE
     BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
   if(NOT EXISTS "${_abs_file}")
@@ -49,32 +49,31 @@ function(ament_nodl_register_node executable_name)
       "ament_nodl_register_node: file not found at configure time: ${_abs_file}")
   endif()
 
-  # Validate the file at build time so authoring errors surface during the
-  # downstream package's build, not at runtime.
-  # ninja/make re-runs this only when ${_abs_file} changes.
+  # Validate the file at build time so authoring errors surface when registering, not downstream when consuming.
+  # This only runs when ${_abs_file} changes.
   set(_stamp_dir "${CMAKE_CURRENT_BINARY_DIR}/ament_nodl/nodl_nodes")
-  set(_stamp "${_stamp_dir}/${_ANN_PACKAGE}__${executable_name}.valid.stamp")
+  set(_stamp "${_stamp_dir}/${_ARGS_PACKAGE}__${executable_name}.valid.stamp")
   file(MAKE_DIRECTORY "${_stamp_dir}")
   add_custom_command(
     OUTPUT "${_stamp}"
     DEPENDS "${_abs_file}"
     COMMAND "${Python3_EXECUTABLE}" -m nodl_schema "${_abs_file}"
     COMMAND "${CMAKE_COMMAND}" -E touch "${_stamp}"
-    COMMENT "Validating NoDL node ${_ANN_PACKAGE}/${executable_name}"
+    COMMENT "Validating NoDL node ${_ARGS_PACKAGE}/${executable_name}"
     VERBATIM
   )
-  add_custom_target(_ament_nodl_validate_node_${_ANN_PACKAGE}__${executable_name} ALL
+  add_custom_target(_ament_nodl_validate_node_${_ARGS_PACKAGE}__${executable_name} ALL
     DEPENDS "${_stamp}"
   )
 
-  # Both installs reference the source file directly so they pick up its
-  # current bytes at install time, not a snapshot from configure time.
+  # Install to ament index
   install(
     FILES "${_abs_file}"
     DESTINATION "share/ament_index/resource_index/nodl_nodes"
-    RENAME "${_ANN_PACKAGE}__${executable_name}")
+    RENAME "${_ARGS_PACKAGE}__${executable_name}")
 
+  # Install to package's share directory
   install(
     FILES "${_abs_file}"
-    DESTINATION "share/${_ANN_PACKAGE}/nodl")
+    DESTINATION "share/${_ARGS_PACKAGE}/nodl")
 endfunction()

--- a/ament_nodl/cmake/ament_nodl_register_node.cmake
+++ b/ament_nodl/cmake/ament_nodl_register_node.cmake
@@ -1,26 +1,35 @@
 # SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
 # SPDX-License-Identifier: Apache-2.0
-# ament_nodl_register_node(executable
-#   FILE <path>
-#   [PACKAGE <pkg>]    # defaults to ${PROJECT_NAME}
-# )
 #
-# Registers a NoDL composition root (node description file) in the ament
-# resource index under resource type 'nodl_nodes', keyed as
-# '<package>__<executable>'.
+# Register a NoDL document for an executable in the ament resource index.
 #
-# This allows tools like nodl_test and nodl_docgen to discover the NoDL
-# spec for any executable by package and name without requiring hardcoded
-# paths.
+# Publishes the contents of a NoDL file under the ``nodl_nodes`` resource type.
+# The resource key is ``<package>__<executable>``.
+# Tools like ``nodl_test`` and ``nodl_docgen`` use this to locate the spec by package and executable name.
 #
-# The NoDL file content is stored as the resource value so that consumers
-# can retrieve it via:
+# Consumers retrieve the content via::
+#
 #   ament_index_python.packages.get_resource('nodl_nodes', '<pkg>__<exe>')
 #
-# Example:
+# The source file is also installed under ``share/<package>/nodl/`` for direct filesystem access.
+#
+# Example::
+#
 #   ament_nodl_register_node(my_node
 #     FILE nodl/my_node.nodl.yaml
 #   )
+#
+# :param executable_name: name of the executable this NoDL document describes.
+#   Combined with PACKAGE to form the resource key.
+# :type executable_name: string
+# :param FILE: path to the NoDL file describing the executable's interface.
+#   May be absolute or relative to ``CMAKE_CURRENT_SOURCE_DIR``.
+# :type FILE: string
+# :param PACKAGE: package name to use in the resource key.
+#   Defaults to ``${PROJECT_NAME}``.
+# :type PACKAGE: string
+#
+# @public
 #
 function(ament_nodl_register_node executable_name)
   cmake_parse_arguments(_ANN "" "FILE;PACKAGE" "" ${ARGN})

--- a/ament_nodl/cmake/ament_nodl_register_node.cmake
+++ b/ament_nodl/cmake/ament_nodl_register_node.cmake
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# ament_nodl_register_node(executable
+#   FILE <path>
+#   [PACKAGE <pkg>]    # defaults to ${PROJECT_NAME}
+# )
+#
+# Registers a NoDL composition root (node description file) in the ament
+# resource index under resource type 'nodl_nodes', keyed as
+# '<package>__<executable>'.
+#
+# This allows tools like nodl_test and nodl_docgen to discover the NoDL
+# spec for any executable by package and name without requiring hardcoded
+# paths.
+#
+# The NoDL file content is stored as the resource value so that consumers
+# can retrieve it via:
+#   ament_index_python.packages.get_resource('nodl_nodes', '<pkg>__<exe>')
+#
+# Example:
+#   ament_nodl_register_node(my_node
+#     FILE nodl/my_node.nodl.yaml
+#   )
+#
+function(ament_nodl_register_node executable_name)
+  cmake_parse_arguments(_ANN "" "FILE;PACKAGE" "" ${ARGN})
+
+  if(NOT _ANN_FILE)
+    message(FATAL_ERROR "ament_nodl_register_node: FILE is required")
+  endif()
+  if(NOT _ANN_PACKAGE)
+    set(_ANN_PACKAGE "${PROJECT_NAME}")
+  endif()
+
+  get_filename_component(_abs_file "${_ANN_FILE}" ABSOLUTE
+    BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  if(NOT EXISTS "${_abs_file}")
+    message(WARNING
+      "ament_nodl_register_node: file not found at configure time: ${_abs_file}")
+  endif()
+
+  file(READ "${_abs_file}" _nodl_content)
+
+  set(_resource_key "${_ANN_PACKAGE}__${executable_name}")
+  set(_marker_dir
+    "${CMAKE_CURRENT_BINARY_DIR}/ament_nodl/nodl_nodes")
+  file(MAKE_DIRECTORY "${_marker_dir}")
+  file(WRITE "${_marker_dir}/${_resource_key}" "${_nodl_content}")
+
+  install(
+    FILES "${_marker_dir}/${_resource_key}"
+    DESTINATION "share/ament_index/resource_index/nodl_nodes")
+
+  # Also install the source file under the package share directory.
+  install(
+    FILES "${_abs_file}"
+    DESTINATION "share/${_ANN_PACKAGE}/nodl")
+endfunction()

--- a/ament_nodl/cmake/ament_nodl_register_node.cmake
+++ b/ament_nodl/cmake/ament_nodl_register_node.cmake
@@ -49,19 +49,13 @@ function(ament_nodl_register_node executable_name)
       "ament_nodl_register_node: file not found at configure time: ${_abs_file}")
   endif()
 
-  file(READ "${_abs_file}" _nodl_content)
-
-  set(_resource_key "${_ANN_PACKAGE}__${executable_name}")
-  set(_marker_dir
-    "${CMAKE_CURRENT_BINARY_DIR}/ament_nodl/nodl_nodes")
-  file(MAKE_DIRECTORY "${_marker_dir}")
-  file(WRITE "${_marker_dir}/${_resource_key}" "${_nodl_content}")
-
+  # Both installs reference the source file directly so they pick up its
+  # current bytes at install time, not a snapshot from configure time.
   install(
-    FILES "${_marker_dir}/${_resource_key}"
-    DESTINATION "share/ament_index/resource_index/nodl_nodes")
+    FILES "${_abs_file}"
+    DESTINATION "share/ament_index/resource_index/nodl_nodes"
+    RENAME "${_ANN_PACKAGE}__${executable_name}")
 
-  # Also install the source file under the package share directory.
   install(
     FILES "${_abs_file}"
     DESTINATION "share/${_ANN_PACKAGE}/nodl")

--- a/ament_nodl/package.xml
+++ b/ament_nodl/package.xml
@@ -3,9 +3,11 @@
 <package format="3">
   <name>ament_nodl</name>
   <version>0.1.0</version>
-  <description>CMake macros for registering NoDL node descriptions and fragments with the ament index.</description>
-  <maintainer email="emerson@polymathrobotics.com">Emerson Knapp</maintainer>
-  <license>Apache License 2.0</license>
+  <description>CMake macros for registering NoDL documents with the ament index.</description>
+  <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
+  <license>Apache-2.0</license>
+  <author email="hello@alistairenglish.com">Alistair English</author>
+  <author email="me@emersonknapp.com">Emerson Knapp</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/ament_nodl/package.xml
+++ b/ament_nodl/package.xml
@@ -10,8 +10,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <!-- nodl_schema provides the validator (python -m nodl_schema.validator) -->
-  <!-- that the register_* macros invoke at downstream-build time. -->
   <exec_depend>nodl_schema</exec_depend>
 
   <export>

--- a/ament_nodl/package.xml
+++ b/ament_nodl/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ament_nodl</name>
+  <version>0.1.0</version>
+  <description>CMake macros for registering NoDL node descriptions and fragments with the ament index.</description>
+  <maintainer email="emerson@polymathrobotics.com">Emerson Knapp</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ament_nodl/package.xml
+++ b/ament_nodl/package.xml
@@ -10,6 +10,10 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <!-- nodl_schema provides the validator (python -m nodl_schema.validator) -->
+  <!-- that the register_* macros invoke at downstream-build time. -->
+  <exec_depend>nodl_schema</exec_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/ament_nodl/package.xml
+++ b/ament_nodl/package.xml
@@ -6,7 +6,6 @@
   <description>CMake macros for registering NoDL documents with the ament index.</description>
   <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>
-  <author email="hello@alistairenglish.com">Alistair English</author>
   <author email="me@emersonknapp.com">Emerson Knapp</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/nodl/package.xml
+++ b/nodl/package.xml
@@ -11,6 +11,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>ament_nodl</exec_depend>
   <exec_depend>nodl_schema</exec_depend>
   <exec_depend>ros2nodl</exec_depend>
 

--- a/nodl_schema/nodl_schema/__main__.py
+++ b/nodl_schema/nodl_schema/__main__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Entry point for ``python -m nodl_schema``.
+
+Delegates to nodl_schema.validator.main so the CLI logic lives next to the
+library functions it exercises. Kept as a separate module so ``python -m
+nodl_schema`` does not double-import nodl_schema.validator
+(which __init__.py already pulls in) and emit a RuntimeWarning.
+"""
+
+import sys
+
+from nodl_schema.validator import main
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/nodl_schema/nodl_schema/__main__.py
+++ b/nodl_schema/nodl_schema/__main__.py
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Entry point for ``python -m nodl_schema``.
 
-Delegates to nodl_schema.validator.main so the CLI logic lives next to the
-library functions it exercises. Kept as a separate module so ``python -m
-nodl_schema`` does not double-import nodl_schema.validator
-(which __init__.py already pulls in) and emit a RuntimeWarning.
+Delegates to nodl_schema.validator.main.
 """
 
 import sys

--- a/nodl_schema/nodl_schema/validator.py
+++ b/nodl_schema/nodl_schema/validator.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import importlib.resources as ir
 import json
+from pathlib import Path
 from typing import IO, Union
 
 import yaml
@@ -103,17 +104,15 @@ def main(argv: list[str] | None = None) -> int:
         prog='python -m nodl_schema',
         description='Validate a NoDL file against the schema.',
     )
-    parser.add_argument('file', help='Path to the NoDL file to validate.')
+    parser.add_argument('file', type=Path, help='Path to the NoDL file to validate.')
     args = parser.parse_args(argv)
 
     try:
-        with open(args.file, 'r', encoding='utf-8') as f:
-            data = yaml.safe_load(f)
-        if not isinstance(data, dict):
-            raise ValueError('NoDL document must be a YAML/JSON mapping at the top level')
-        validate(data)
+        with args.file.open('r') as f:
+            load_nodl(f)
     except Exception as exc:
         print(f'{args.file}: {exc}', file=sys.stderr)
         return 1
+
     print(f'{args.file}: ok')
     return 0

--- a/nodl_schema/nodl_schema/validator.py
+++ b/nodl_schema/nodl_schema/validator.py
@@ -87,3 +87,33 @@ def dump_nodl(doc: Union[NodlDocument, dict], *, format: str = 'yaml') -> str:
     if format == 'json':
         return json.dumps(data, indent=2)
     return yaml.dump(data, default_flow_style=False, allow_unicode=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """``python -m nodl_schema <file>`` -- validate a NoDL file.
+
+    Exits 0 on success, 1 on validation failure or I/O error.
+    Designed for invocation from CMake macros (ament_nodl_register_node and
+    siblings) so files are checked at build time, not at runtime.
+    """
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        prog='python -m nodl_schema',
+        description='Validate a NoDL file against the schema.',
+    )
+    parser.add_argument('file', help='Path to the NoDL file to validate.')
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.file, 'r', encoding='utf-8') as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, dict):
+            raise ValueError('NoDL document must be a YAML/JSON mapping at the top level')
+        validate(data)
+    except Exception as exc:
+        print(f'{args.file}: {exc}', file=sys.stderr)
+        return 1
+    print(f'{args.file}: ok')
+    return 0

--- a/nodl_schema/test/test_validator_cli.py
+++ b/nodl_schema/test/test_validator_cli.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ``python -m nodl_schema.validator`` CLI used by build-time hooks."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_VALID = """\
+nodl_version: 2
+publishers:
+  - name: /chatter
+    type: std_msgs/msg/String
+    qos:
+      history: KEEP_LAST
+      depth: 10
+      reliability: RELIABLE
+"""
+
+_INVALID_BAD_PARAM_TYPE = """\
+nodl_version: 2
+parameters:
+  speed:
+    type: not_a_real_type
+"""
+
+_INVALID_NOT_A_MAPPING = '- just a list\n'
+
+
+def _run(file: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, '-m', 'nodl_schema', str(file)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_valid_file_exits_zero(tmp_path: Path):
+    f = tmp_path / 'ok.nodl.yaml'
+    f.write_text(_VALID)
+    result = _run(f)
+    assert result.returncode == 0, result.stderr
+    assert str(f) in result.stdout
+
+
+def test_invalid_schema_exits_one(tmp_path: Path):
+    f = tmp_path / 'bad.nodl.yaml'
+    f.write_text(_INVALID_BAD_PARAM_TYPE)
+    result = _run(f)
+    assert result.returncode == 1
+    # The file path should be in the error so build logs are scannable.
+    assert str(f) in result.stderr
+
+
+def test_non_mapping_exits_one(tmp_path: Path):
+    f = tmp_path / 'list.nodl.yaml'
+    f.write_text(_INVALID_NOT_A_MAPPING)
+    result = _run(f)
+    assert result.returncode == 1
+    assert str(f) in result.stderr
+
+
+def test_missing_file_exits_one(tmp_path: Path):
+    result = _run(tmp_path / 'does_not_exist.nodl.yaml')
+    assert result.returncode == 1
+
+
+def test_json_frontend_supported(tmp_path: Path):
+    f = tmp_path / 'ok.nodl.json'
+    f.write_text('{"nodl_version": 2}\n')
+    result = _run(f)
+    assert result.returncode == 0, result.stderr

--- a/test_ament_nodl/CMakeLists.txt
+++ b/test_ament_nodl/CMakeLists.txt
@@ -14,7 +14,7 @@ ament_nodl_register_node(custom_exe
   FILE test/fixtures/alt_pkg_node.nodl.yaml
   PACKAGE custom_pkg)
 
-# Non-yaml frontend; the macro is extension-agnostic and just copies bytes.
+# Non-yaml frontend. Make sure the macro is extension-agnostic.
 ament_nodl_register_node(json_node FILE test/fixtures/json_node.nodl.json)
 
 if(BUILD_TESTING)

--- a/test_ament_nodl/CMakeLists.txt
+++ b/test_ament_nodl/CMakeLists.txt
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+cmake_minimum_required(VERSION 3.22)
+project(test_ament_nodl)
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_nodl REQUIRED)
+
+# Default PACKAGE resolves to ${PROJECT_NAME}.
+ament_nodl_register_node(basic_node FILE test/fixtures/basic_node.nodl.yaml)
+
+# Explicit PACKAGE override; the resource key and install destination both pick it up.
+ament_nodl_register_node(custom_exe
+  FILE test/fixtures/alt_pkg_node.nodl.yaml
+  PACKAGE custom_pkg)
+
+# Non-yaml frontend; the macro is extension-agnostic and just copies bytes.
+ament_nodl_register_node(json_node FILE test/fixtures/json_node.nodl.json)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(register_node_tests test/test_register_node.py)
+endif()
+
+ament_package()

--- a/test_ament_nodl/CMakeLists.txt
+++ b/test_ament_nodl/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(ament_nodl REQUIRED)
 # Default PACKAGE resolves to ${PROJECT_NAME}.
 ament_nodl_register_node(basic_node FILE test/fixtures/basic_node.nodl.yaml)
 
-# Explicit PACKAGE override; the resource key and install destination both pick it up.
+# Explicit PACKAGE override. The resource key and install destination both pick it up.
 ament_nodl_register_node(custom_exe
   FILE test/fixtures/alt_pkg_node.nodl.yaml
   PACKAGE custom_pkg)

--- a/test_ament_nodl/CMakeLists.txt
+++ b/test_ament_nodl/CMakeLists.txt
@@ -20,6 +20,7 @@ ament_nodl_register_node(json_node FILE test/fixtures/json_node.nodl.json)
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(register_node_tests test/test_register_node.py)
+  ament_add_pytest_test(macro_rejection_tests test/test_macro_rejection.py)
 endif()
 
 ament_package()

--- a/test_ament_nodl/package.xml
+++ b/test_ament_nodl/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<!--
+  SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+  SPDX-License-Identifier: Apache-2.0
+-->
+<package format="3">
+  <name>test_ament_nodl</name>
+  <version>0.0.0</version>
+  <description>Integration tests for the ament_nodl CMake macros.</description>
+  <maintainer email="me@emersonknapp.com">Emerson Knapp</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_nodl</buildtool_depend>
+
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_index_python</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/test_ament_nodl/package.xml
+++ b/test_ament_nodl/package.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<!--
-  SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
-  SPDX-License-Identifier: Apache-2.0
--->
 <package format="3">
   <name>test_ament_nodl</name>
   <version>0.0.0</version>
   <description>Integration tests for the ament_nodl CMake macros.</description>
-  <maintainer email="me@emersonknapp.com">Emerson Knapp</maintainer>
+  <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>
+  <author email="me@emersonknapp.com">Emerson Knapp</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_nodl</buildtool_depend>

--- a/test_ament_nodl/test/fixtures/alt_pkg_node.nodl.yaml
+++ b/test_ament_nodl/test/fixtures/alt_pkg_node.nodl.yaml
@@ -1,0 +1,3 @@
+---
+nodl_version: 2
+description: Test node registered under an explicit PACKAGE override.

--- a/test_ament_nodl/test/fixtures/basic_node.nodl.yaml
+++ b/test_ament_nodl/test/fixtures/basic_node.nodl.yaml
@@ -1,0 +1,10 @@
+---
+nodl_version: 2
+description: Basic test node used to exercise ament_nodl_register_node default args.
+publishers:
+  - name: /chatter
+    type: std_msgs/msg/String
+    qos:
+      history: KEEP_LAST
+      depth: 10
+      reliability: RELIABLE

--- a/test_ament_nodl/test/fixtures/json_node.nodl.json
+++ b/test_ament_nodl/test/fixtures/json_node.nodl.json
@@ -1,0 +1,4 @@
+{
+  "nodl_version": 2,
+  "description": "Test node using the JSON frontend; the macro should treat it the same as YAML."
+}

--- a/test_ament_nodl/test/test_macro_rejection.py
+++ b/test_ament_nodl/test/test_macro_rejection.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end test that the ament_nodl_register_node macro propagates validator failures as build failures.
+
+Writes a tiny inner ament_cmake project that registers an intentionally-invalid NoDL file via the macro,
+then spawns cmake to configure and build it; the build is expected to fail with the validator error.
+This catches regressions in the macro wiring itself, separate from the CLI tests in nodl_schema that
+already cover the validator's behavior in isolation.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_INNER_CMAKELISTS = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.22)
+    project(rejection_fixture)
+    find_package(ament_cmake REQUIRED)
+    find_package(ament_nodl REQUIRED)
+    ament_nodl_register_node(bad_exe FILE bad.nodl.yaml)
+    ament_package()
+""")
+
+_INNER_PACKAGE_XML = textwrap.dedent("""<?xml version="1.0"?>
+    <package format="3">
+      <name>rejection_fixture</name>
+      <version>0.0.0</version>
+      <description>Inner project used by test_ament_nodl to verify the macro rejects invalid files.</description>
+      <maintainer email="test@example.com">test</maintainer>
+      <license>Apache-2.0</license>
+      <buildtool_depend>ament_cmake</buildtool_depend>
+      <buildtool_depend>ament_nodl</buildtool_depend>
+      <export>
+        <build_type>ament_cmake</build_type>
+      </export>
+    </package>
+""").lstrip()
+
+_INVALID_NODL = textwrap.dedent("""
+    nodl_version: 2
+    parameters:
+      bad:
+        type: not_a_real_type
+""").lstrip()
+
+
+@pytest.fixture
+def inner_pkg(tmp_path: Path) -> Path:
+    pkg = tmp_path / 'rejection_fixture'
+    pkg.mkdir()
+    (pkg / 'CMakeLists.txt').write_text(_INNER_CMAKELISTS)
+    (pkg / 'package.xml').write_text(_INNER_PACKAGE_XML)
+    (pkg / 'bad.nodl.yaml').write_text(_INVALID_NODL)
+    return pkg
+
+
+@pytest.mark.skipif(shutil.which('cmake') is None, reason='cmake not on PATH')
+def test_macro_rejects_invalid_node(inner_pkg: Path):
+    # Inherit AMENT_PREFIX_PATH from the colcon-test env so the inner build
+    # can resolve find_package(ament_nodl) and find python with nodl_schema.
+    build = inner_pkg / 'build'
+    configure = subprocess.run(
+        ['cmake', '-S', str(inner_pkg), '-B', str(build)],
+        capture_output=True,
+        text=True,
+        env=os.environ,
+    )
+    assert configure.returncode == 0, f'Configure failed:\n{configure.stderr}'
+
+    result = subprocess.run(
+        ['cmake', '--build', str(build)],
+        capture_output=True,
+        text=True,
+        env=os.environ,
+    )
+    assert result.returncode != 0, 'Expected the inner build to fail on the invalid NoDL file'
+    combined = result.stdout + result.stderr
+    assert 'not_a_real_type' in combined, (
+        f'Expected the validator error to appear in the build output, got:\n{combined}'
+    )

--- a/test_ament_nodl/test/test_register_node.py
+++ b/test_ament_nodl/test/test_register_node.py
@@ -9,12 +9,18 @@ tree without re-invoking CMake.
 
 from pathlib import Path
 
-from ament_index_python.packages import get_package_share_directory
+from ament_index_python.packages import PackageNotFoundError, get_package_share_directory
 from ament_index_python.resources import get_resource
 
 
 def _share(pkg: str = 'test_ament_nodl') -> Path:
-    return Path(get_package_share_directory('test_ament_nodl'))
+    # Real packages resolve through the ament index.
+    # Virtual packages used only as a PACKAGE override aren't registered, so we
+    # resolve them as siblings under the registering package's install prefix.
+    try:
+        return Path(get_package_share_directory(pkg))
+    except PackageNotFoundError:
+        return Path(get_package_share_directory('test_ament_nodl')).parent / pkg
 
 
 # ---------------------------------------------------------------------------

--- a/test_ament_nodl/test/test_register_node.py
+++ b/test_ament_nodl/test/test_register_node.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for the ament_nodl_register_node CMake macro.
+
+The macro is exercised at configure / install time by this package's
+CMakeLists.txt; here we assert on the resulting ament index and install
+tree without re-invoking CMake.
+"""
+
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
+from ament_index_python.resources import get_resource
+
+
+def _share() -> Path:
+    return Path(get_package_share_directory('test_ament_nodl'))
+
+
+def _install_share_root() -> Path:
+    # share/<pkg> -> share/
+    return _share().parent
+
+
+# ---------------------------------------------------------------------------
+# Resource registration
+# ---------------------------------------------------------------------------
+
+
+def test_default_package_uses_project_name():
+    # No PACKAGE arg means the macro defaults to ${PROJECT_NAME}, so the key is test_ament_nodl__basic_node.
+    content, prefix = get_resource('nodl_nodes', 'test_ament_nodl__basic_node')
+    assert prefix
+    assert 'Basic test node' in content
+
+
+def test_explicit_package_override():
+    # PACKAGE custom_pkg makes the key custom_pkg__custom_exe even though the registering
+    # package is test_ament_nodl.
+    content, _ = get_resource('nodl_nodes', 'custom_pkg__custom_exe')
+    assert 'explicit PACKAGE override' in content
+
+
+def test_extension_agnostic_frontend():
+    # The macro reads bytes and writes bytes; a .nodl.json file round-trips just like yaml.
+    content, _ = get_resource('nodl_nodes', 'test_ament_nodl__json_node')
+    assert '"nodl_version": 2' in content
+
+
+def test_resource_content_matches_source():
+    # The registered resource should be byte-identical to the source file.
+    content, _ = get_resource('nodl_nodes', 'test_ament_nodl__basic_node')
+    on_disk = (_share() / 'nodl' / 'basic_node.nodl.yaml').read_text()
+    assert content == on_disk
+
+
+# ---------------------------------------------------------------------------
+# Source file installation
+# ---------------------------------------------------------------------------
+
+
+def test_source_file_installed_under_registering_package():
+    # Default PACKAGE installs the source under share/test_ament_nodl/nodl/.
+    assert (_share() / 'nodl' / 'basic_node.nodl.yaml').is_file()
+
+
+def test_json_source_file_installed():
+    # Original filename and extension are preserved.
+    assert (_share() / 'nodl' / 'json_node.nodl.json').is_file()
+
+
+def test_source_file_installed_under_override_package():
+    # PACKAGE override redirects the source-file install to share/<override>/nodl/.
+    target = _install_share_root() / 'custom_pkg' / 'nodl' / 'alt_pkg_node.nodl.yaml'
+    assert target.is_file()

--- a/test_ament_nodl/test/test_register_node.py
+++ b/test_ament_nodl/test/test_register_node.py
@@ -13,13 +13,8 @@ from ament_index_python.packages import get_package_share_directory
 from ament_index_python.resources import get_resource
 
 
-def _share() -> Path:
+def _share(pkg: str = 'test_ament_nodl') -> Path:
     return Path(get_package_share_directory('test_ament_nodl'))
-
-
-def _install_share_root() -> Path:
-    # share/<pkg> -> share/
-    return _share().parent
 
 
 # ---------------------------------------------------------------------------
@@ -35,8 +30,7 @@ def test_default_package_uses_project_name():
 
 
 def test_explicit_package_override():
-    # PACKAGE custom_pkg makes the key custom_pkg__custom_exe even though the registering
-    # package is test_ament_nodl.
+    # PACKAGE custom_pkg makes the key custom_pkg__custom_exe even though the registering package is test_ament_nodl.
     content, _ = get_resource('nodl_nodes', 'custom_pkg__custom_exe')
     assert 'explicit PACKAGE override' in content
 
@@ -71,5 +65,5 @@ def test_json_source_file_installed():
 
 def test_source_file_installed_under_override_package():
     # PACKAGE override redirects the source-file install to share/<override>/nodl/.
-    target = _install_share_root() / 'custom_pkg' / 'nodl' / 'alt_pkg_node.nodl.yaml'
+    target = _share('custom_pkg') / 'nodl' / 'alt_pkg_node.nodl.yaml'
     assert target.is_file()


### PR DESCRIPTION
Closes #73 

Add new `ament_nodl` package.

Provides function `ament_nodl_register_node(executable FILE <path> [PACKAGE <pkg>])` which publishes NoDL files into the ament index under the key `nodl_nodes` key.
Files are validated for schema validity, installed to the ament index, and installed to package's share directory.
Downstream tools (codegen, conformance testing, docgen) can then locate the description from the running node's executable name without any additional configuration.

Also adds `test_ament_nodl` package for testing the CMake wiring provided by `ament_nodl`