### PR TITLE
Add "NoDL fragments" to the schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: ros-tooling/action-ros-ci@v0.4
         with:
-          package-name: nodl nodl_schema ros2nodl
+          package-name: ament_nodl nodl nodl_schema ros2nodl test_ament_nodl
           target-ros2-distro: ${{ matrix.ros }}
       - uses: actions/upload-artifact@v4
         if: always()

--- a/ament_nodl/CMakeLists.txt
+++ b/ament_nodl/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+cmake_minimum_required(VERSION 3.22)
+project(ament_nodl)
+
+find_package(ament_cmake REQUIRED)
+
+install(FILES
+  cmake/ament_nodl_register_node.cmake
+  DESTINATION share/${PROJECT_NAME}/cmake)
+
+install(FILES package.xml
+  DESTINATION share/${PROJECT_NAME})
+
+ament_package(CONFIG_EXTRAS "ament_nodl-extras.cmake.in")

--- a/ament_nodl/CMakeLists.txt
+++ b/ament_nodl/CMakeLists.txt
@@ -6,6 +6,7 @@ project(ament_nodl)
 find_package(ament_cmake REQUIRED)
 
 install(FILES
+  cmake/ament_nodl_register_fragment.cmake
   cmake/ament_nodl_register_node.cmake
   DESTINATION share/${PROJECT_NAME}/cmake)
 

--- a/ament_nodl/ament_nodl-extras.cmake.in
+++ b/ament_nodl/ament_nodl-extras.cmake.in
@@ -1,0 +1,4 @@
+# Resolves ${Python3_EXECUTABLE} for the build-time validation step the macros invoke.
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+include("${CMAKE_CURRENT_LIST_DIR}/ament_nodl_register_node.cmake")

--- a/ament_nodl/ament_nodl-extras.cmake.in
+++ b/ament_nodl/ament_nodl-extras.cmake.in
@@ -1,4 +1,5 @@
 # Resolves ${Python3_EXECUTABLE} for the build-time validation step the macros invoke.
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
+include("${CMAKE_CURRENT_LIST_DIR}/ament_nodl_register_fragment.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/ament_nodl_register_node.cmake")

--- a/ament_nodl/cmake/ament_nodl_register_fragment.cmake
+++ b/ament_nodl/cmake/ament_nodl_register_fragment.cmake
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Register a NoDL fragment in the ament resource index.
+#
+# Publishes the contents of a NoDL file under the ``nodl_fragments`` resource type.
+# The resource key is ``<package>__<name>``.
+# NoDL documents reference the fragment by ``nodl://<package>/<name>``.
+#
+# Consumers retrieve the content via::
+#
+#   ament_index_python.packages.get_resource('nodl_fragments', '<pkg>__<name>')
+#
+# The source file is also installed under ``share/<package>/nodl/fragments/`` for direct filesystem access.
+#
+# Example::
+#
+#   ament_nodl_register_fragment(tf_listener
+#     FILE nodl/tf_listener.nodl.yaml
+#   )
+#
+# :param fragment_name: name of the fragment.
+#   Combined with PACKAGE to form the resource key and the ``nodl://<package>/<name>`` URI.
+# :type fragment_name: string
+# :param FILE: path to the NoDL file containing the fragment definition.
+#   May be absolute or relative to ``CMAKE_CURRENT_SOURCE_DIR``.
+# :type FILE: string
+# :param PACKAGE: package name to use in the resource key.
+#   Defaults to ``${PROJECT_NAME}``.
+# :type PACKAGE: string
+#
+# @public
+#
+function(ament_nodl_register_fragment fragment_name)
+  cmake_parse_arguments(_ARGS "" "FILE;PACKAGE" "" ${ARGN})
+
+  if(NOT _ARGS_FILE)
+    message(FATAL_ERROR "ament_nodl_register_fragment: FILE is required")
+  endif()
+  if(NOT _ARGS_PACKAGE)
+    set(_ARGS_PACKAGE "${PROJECT_NAME}")
+  endif()
+
+  get_filename_component(_abs_file "${_ARGS_FILE}" ABSOLUTE
+    BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  if(NOT EXISTS "${_abs_file}")
+    message(WARNING
+      "ament_nodl_register_fragment: file not found at configure time: ${_abs_file}")
+  endif()
+
+  # Validate the fragment at build time so authoring errors surface when registering, not downstream when consuming.
+  # --fragment additionally rejects nested base/fragments, which are disallowed in v2.
+  # This only runs when ${_abs_file} changes.
+  set(_stamp_dir "${CMAKE_CURRENT_BINARY_DIR}/ament_nodl/nodl_fragments")
+  set(_stamp "${_stamp_dir}/${_ARGS_PACKAGE}__${fragment_name}.valid.stamp")
+  file(MAKE_DIRECTORY "${_stamp_dir}")
+  add_custom_command(
+    OUTPUT "${_stamp}"
+    DEPENDS "${_abs_file}"
+    COMMAND "${Python3_EXECUTABLE}" -m nodl_schema --fragment "${_abs_file}"
+    COMMAND "${CMAKE_COMMAND}" -E touch "${_stamp}"
+    COMMENT "Validating NoDL fragment ${_ARGS_PACKAGE}/${fragment_name}"
+    VERBATIM
+  )
+  add_custom_target(_ament_nodl_validate_fragment_${_ARGS_PACKAGE}__${fragment_name} ALL
+    DEPENDS "${_stamp}"
+  )
+
+  # Install to ament index
+  install(
+    FILES "${_abs_file}"
+    DESTINATION "share/ament_index/resource_index/nodl_fragments"
+    RENAME "${_ARGS_PACKAGE}__${fragment_name}")
+
+  # Install to package's share directory
+  install(
+    FILES "${_abs_file}"
+    DESTINATION "share/${_ARGS_PACKAGE}/nodl/fragments")
+endfunction()

--- a/ament_nodl/cmake/ament_nodl_register_node.cmake
+++ b/ament_nodl/cmake/ament_nodl_register_node.cmake
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Register a NoDL document for an executable in the ament resource index.
+#
+# Publishes the contents of a NoDL file under the ``nodl_nodes`` resource type.
+# The resource key is ``<package>__<executable>``.
+# Tools like ``nodl_test`` and ``nodl_docgen`` use this to locate the spec by package and executable name.
+#
+# Consumers retrieve the content via::
+#
+#   ament_index_python.packages.get_resource('nodl_nodes', '<pkg>__<exe>')
+#
+# The source file is also installed under ``share/<package>/nodl/`` for direct filesystem access.
+#
+# Example::
+#
+#   ament_nodl_register_node(my_node
+#     FILE nodl/my_node.nodl.yaml
+#   )
+#
+# :param executable_name: name of the executable this NoDL document describes.
+#   Combined with PACKAGE to form the resource key.
+# :type executable_name: string
+# :param FILE: path to the NoDL file describing the executable's interface.
+#   May be absolute or relative to ``CMAKE_CURRENT_SOURCE_DIR``.
+# :type FILE: string
+# :param PACKAGE: package name to use in the resource key.
+#   Defaults to ``${PROJECT_NAME}``.
+# :type PACKAGE: string
+#
+# @public
+#
+function(ament_nodl_register_node executable_name)
+  cmake_parse_arguments(_ARGS "" "FILE;PACKAGE" "" ${ARGN})
+
+  if(NOT _ARGS_FILE)
+    message(FATAL_ERROR "ament_nodl_register_node: FILE is required")
+  endif()
+  if(NOT _ARGS_PACKAGE)
+    set(_ARGS_PACKAGE "${PROJECT_NAME}")
+  endif()
+
+  get_filename_component(_abs_file "${_ARGS_FILE}" ABSOLUTE
+    BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  if(NOT EXISTS "${_abs_file}")
+    message(WARNING
+      "ament_nodl_register_node: file not found at configure time: ${_abs_file}")
+  endif()
+
+  # Validate the file at build time so authoring errors surface when registering, not downstream when consuming.
+  # This only runs when ${_abs_file} changes.
+  set(_stamp_dir "${CMAKE_CURRENT_BINARY_DIR}/ament_nodl/nodl_nodes")
+  set(_stamp "${_stamp_dir}/${_ARGS_PACKAGE}__${executable_name}.valid.stamp")
+  file(MAKE_DIRECTORY "${_stamp_dir}")
+  add_custom_command(
+    OUTPUT "${_stamp}"
+    DEPENDS "${_abs_file}"
+    COMMAND "${Python3_EXECUTABLE}" -m nodl_schema "${_abs_file}"
+    COMMAND "${CMAKE_COMMAND}" -E touch "${_stamp}"
+    COMMENT "Validating NoDL node ${_ARGS_PACKAGE}/${executable_name}"
+    VERBATIM
+  )
+  add_custom_target(_ament_nodl_validate_node_${_ARGS_PACKAGE}__${executable_name} ALL
+    DEPENDS "${_stamp}"
+  )
+
+  # Install to ament index
+  install(
+    FILES "${_abs_file}"
+    DESTINATION "share/ament_index/resource_index/nodl_nodes"
+    RENAME "${_ARGS_PACKAGE}__${executable_name}")
+
+  # Install to package's share directory
+  install(
+    FILES "${_abs_file}"
+    DESTINATION "share/${_ARGS_PACKAGE}/nodl")
+endfunction()

--- a/ament_nodl/package.xml
+++ b/ament_nodl/package.xml
@@ -1,19 +1,16 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>nodl</name>
-  <version>0.0.0</version>
-  <description>ROS 2 Node Definition Language (NoDL) metapackage.</description>
+  <name>ament_nodl</name>
+  <version>0.1.0</version>
+  <description>CMake macros for registering NoDL documents with the ament index.</description>
   <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>
-  <author email="hello@alistairenglish.com">Alistair English</author>
   <author email="me@emersonknapp.com">Emerson Knapp</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <exec_depend>ament_nodl</exec_depend>
   <exec_depend>nodl_schema</exec_depend>
-  <exec_depend>ros2nodl</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nodl_schema/nodl_schema/__init__.py
+++ b/nodl_schema/nodl_schema/__init__.py
@@ -2,6 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 """NoDL schema, in-memory models, and validation helpers."""
 
-from nodl_schema.validator import dump_nodl, load_nodl, load_schema, validate
+from nodl_schema.resolve import LayeredDocument, resolve
+from nodl_schema.validator import (
+    dump_nodl,
+    load_fragment,
+    load_nodl,
+    load_schema,
+    validate,
+    validate_fragment,
+)
 
-__all__ = ['dump_nodl', 'load_nodl', 'load_schema', 'validate']
+__all__ = [
+    'LayeredDocument',
+    'dump_nodl',
+    'load_fragment',
+    'load_nodl',
+    'load_schema',
+    'resolve',
+    'validate',
+    'validate_fragment',
+]

--- a/nodl_schema/nodl_schema/__main__.py
+++ b/nodl_schema/nodl_schema/__main__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Entry point for ``python -m nodl_schema``.
+
+Delegates to nodl_schema.validator.main.
+"""
+
+import sys
+
+from nodl_schema.validator import main
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/nodl_schema/nodl_schema/models.py
+++ b/nodl_schema/nodl_schema/models.py
@@ -14,6 +14,15 @@ except ImportError:
     from pydantic import BaseModel, Extra, Field, conint, constr
 
 
+class Base(Enum):
+    """
+    Built-in ROS 2 base node type this node inherits from.
+    """
+
+    node = 'node'
+    lifecycle_node = 'lifecycle_node'
+
+
 class ScalarType(Enum):
     """
     Scalar types:
@@ -46,6 +55,24 @@ class ArrayType(Enum):
     int_array = 'int_array'
     double_array = 'double_array'
     string_array = 'string_array'
+
+
+class FragmentRef(BaseModel):
+    """
+    Reference to a NoDL fragment.
+    """
+
+    class Config:
+        extra = Extra.forbid
+
+    ref: str = Field(
+        ...,
+        description="'nodl://pkg/name' for ament-index fragments, or a relative file path.\n",
+    )
+    name: Optional[str] = Field(
+        None,
+        description='Optional label for this fragment in documentation and merge order.',
+    )
 
 
 class History(Enum):
@@ -425,6 +452,11 @@ class NodlDocument(BaseModel):
 
     nodl_version: int = Field(2, const=True, description='NoDL schema major version this document targets.')
     description: Optional[str] = Field(None, description='Human-readable description of what this node does.')
+    base: Optional[Base] = Field(None, description='Built-in ROS 2 base node type this node inherits from.')
+    fragments: Optional[list[FragmentRef]] = Field(
+        None,
+        description='NoDL fragments composed into this node (single-level, not recursive).',
+    )
     parameters: Optional[dict[str, ParameterDefinition]] = Field(
         None,
         description='ROS parameters declared by this node, keyed by parameter name.\nParameter shape is borrowed from generate_parameter_library\n(see parameter.schema.yaml).\n',

--- a/nodl_schema/nodl_schema/resolve.py
+++ b/nodl_schema/nodl_schema/resolve.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Resolution of NoDL composition (base + fragments) into a LayeredDocument."""
+
+from __future__ import annotations
+
+import importlib.resources as ir
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from nodl_schema.models import (
+    ActionEndpoint,
+    NodlDocument,
+    ParameterDefinition,
+    ServiceEndpoint,
+    TopicEndpoint,
+)
+
+_BUILTIN_BASES = frozenset(['node', 'lifecycle_node'])
+
+
+def _load_builtin(base: str) -> NodlDocument:
+    from nodl_schema.validator import load_fragment
+
+    path = ir.files('nodl_schema') / 'schemas' / 'fragments' / f'{base}.nodl.yaml'
+    return load_fragment(path.read_text(encoding='utf-8'))
+
+
+def _load_ament_fragment(pkg: str, name: str) -> NodlDocument:
+    try:
+        from ament_index_python.packages import get_resource
+    except ImportError as exc:
+        raise ImportError('ament_index_python is required to resolve nodl:// URIs') from exc
+    # Key format mirrors ament_nodl_register_fragment: pkg__name
+    resource_key = f'{pkg}__{name}'
+    try:
+        content, _ = get_resource('nodl_fragments', resource_key)
+    except KeyError:
+        raise FileNotFoundError(
+            f'NoDL fragment not found in ament index: {pkg}/{name} (looked up as nodl_fragments/{resource_key})'
+        )
+    from nodl_schema.validator import load_fragment
+
+    return load_fragment(content)
+
+
+def _resolve_ref(ref: str, source_path: Optional[Path] = None) -> NodlDocument:
+    if ref.startswith('nodl://'):
+        rest = ref[len('nodl://') :]
+        parts = rest.split('/', 1)
+        if len(parts) != 2:
+            raise ValueError(f'Invalid nodl:// URI: {ref!r} -- expected nodl://pkg/name')
+        return _load_ament_fragment(parts[0], parts[1])
+    if source_path is None:
+        raise ValueError(f'Cannot resolve relative fragment ref {ref!r} without a source path')
+    full_path = (source_path.parent / ref).resolve()
+    if not full_path.exists():
+        raise FileNotFoundError(f'Fragment file not found: {full_path}')
+    from nodl_schema.validator import load_fragment
+
+    return load_fragment(full_path.read_text(encoding='utf-8'))
+
+
+@dataclass
+class LayeredDocument:
+    """A NoDL document with its resolved composition layers, keyed by label."""
+
+    main: NodlDocument
+    base: Optional[NodlDocument] = None
+    base_name: Optional[str] = None
+    fragments: Dict[str, NodlDocument] = field(default_factory=dict)
+
+    def merged(self) -> NodlDocument:
+        """Merge all layers into a flat NodlDocument.
+
+        Layers applied in order: base -> named fragments (insertion order) -> main.
+        Later layers win on duplicate names.
+        """
+        layers: List[NodlDocument] = []
+        if self.base is not None:
+            layers.append(self.base)
+        layers.extend(self.fragments.values())
+        layers.append(self.main)
+
+        publishers: Dict[str, TopicEndpoint] = {}
+        subscriptions: Dict[str, TopicEndpoint] = {}
+        service_servers: Dict[str, ServiceEndpoint] = {}
+        service_clients: Dict[str, ServiceEndpoint] = {}
+        action_servers: Dict[str, ActionEndpoint] = {}
+        action_clients: Dict[str, ActionEndpoint] = {}
+        parameters: Dict[str, ParameterDefinition] = {}
+
+        for doc in layers:
+            for ep in doc.publishers or []:
+                publishers[ep.name] = ep
+            for ep in doc.subscriptions or []:
+                subscriptions[ep.name] = ep
+            for ep in doc.service_servers or []:
+                service_servers[ep.name] = ep
+            for ep in doc.service_clients or []:
+                service_clients[ep.name] = ep
+            for ep in doc.action_servers or []:
+                action_servers[ep.name] = ep
+            for ep in doc.action_clients or []:
+                action_clients[ep.name] = ep
+            for param_name, param in (doc.parameters or {}).items():
+                parameters[param_name] = param
+
+        return NodlDocument(
+            nodl_version=self.main.nodl_version,
+            parameters=parameters or None,
+            publishers=list(publishers.values()) or None,
+            subscriptions=list(subscriptions.values()) or None,
+            service_servers=list(service_servers.values()) or None,
+            service_clients=list(service_clients.values()) or None,
+            action_servers=list(action_servers.values()) or None,
+            action_clients=list(action_clients.values()) or None,
+        )
+
+
+def resolve(doc: NodlDocument, source_path: Optional[Path] = None) -> LayeredDocument:
+    """Resolve a NodlDocument's base and fragments into a LayeredDocument.
+
+    source_path: filesystem path to the NoDL file, used to resolve relative refs.
+    Fragments are single-level only -- fragment files are not themselves resolved.
+    """
+    # doc.base is an enum on pydantic v2 and may be either enum or string on v1
+    # depending on how the document was constructed. Normalize to the string value.
+    base_name: Optional[str] = None
+    if doc.base is not None:
+        base_name = doc.base.value if hasattr(doc.base, 'value') else doc.base
+
+    base_doc: Optional[NodlDocument] = None
+    if base_name is not None:
+        if base_name not in _BUILTIN_BASES:
+            raise ValueError(f'Unknown base {base_name!r}. Must be one of: {sorted(_BUILTIN_BASES)}')
+        base_doc = _load_builtin(base_name)
+
+    fragment_docs: Dict[str, NodlDocument] = {}
+    for frag_ref in doc.fragments or []:
+        label = frag_ref.name or frag_ref.ref
+        fragment_docs[label] = _resolve_ref(frag_ref.ref, source_path=source_path)
+
+    return LayeredDocument(
+        main=doc,
+        base=base_doc,
+        base_name=base_name,
+        fragments=fragment_docs,
+    )

--- a/nodl_schema/nodl_schema/schemas/fragments/lifecycle_node.nodl.yaml
+++ b/nodl_schema/nodl_schema/schemas/fragments/lifecycle_node.nodl.yaml
@@ -1,0 +1,26 @@
+nodl_version: 2
+parameters:
+  use_sim_time:
+    type: bool
+    default_value: false
+    description: Use simulation (clock) time instead of wall time
+
+service_servers:
+  - name: ~/change_state
+    type: lifecycle_msgs/srv/ChangeState
+  - name: ~/get_state
+    type: lifecycle_msgs/srv/GetState
+  - name: ~/get_available_states
+    type: lifecycle_msgs/srv/GetAvailableStates
+  - name: ~/get_available_transitions
+    type: lifecycle_msgs/srv/GetAvailableTransitions
+  - name: ~/get_transition_graph
+    type: lifecycle_msgs/srv/GetTransitionGraph
+
+publishers:
+  - name: ~/transition_event
+    type: lifecycle_msgs/msg/TransitionEvent
+    qos:
+      history: KEEP_LAST
+      depth: 10
+      reliability: RELIABLE

--- a/nodl_schema/nodl_schema/schemas/fragments/node.nodl.yaml
+++ b/nodl_schema/nodl_schema/schemas/fragments/node.nodl.yaml
@@ -1,0 +1,6 @@
+nodl_version: 2
+parameters:
+  use_sim_time:
+    type: bool
+    default_value: false
+    description: Use simulation (clock) time instead of wall time

--- a/nodl_schema/nodl_schema/schemas/nodl.schema.yaml
+++ b/nodl_schema/nodl_schema/schemas/nodl.schema.yaml
@@ -28,6 +28,17 @@ properties:
     type: string
     description: Human-readable description of what this node does.
 
+  base:
+    type: string
+    enum: [node, lifecycle_node]
+    description: Built-in ROS 2 base node type this node inherits from.
+
+  fragments:
+    type: array
+    description: NoDL fragments composed into this node (single-level, not recursive).
+    items:
+      $ref: '#/definitions/fragment_ref'
+
   parameters:
     type: object
     description: |
@@ -74,6 +85,20 @@ properties:
       $ref: '#/definitions/action_endpoint'
 
 definitions:
+  fragment_ref:
+    type: object
+    description: Reference to a NoDL fragment.
+    required: [ref]
+    additionalProperties: false
+    properties:
+      ref:
+        type: string
+        description: |
+          'nodl://pkg/name' for ament-index fragments, or a relative file path.
+      name:
+        type: string
+        description: Optional label for this fragment in documentation and merge order.
+
   rosName:
     type: string
     description: |

--- a/nodl_schema/nodl_schema/validator.py
+++ b/nodl_schema/nodl_schema/validator.py
@@ -55,6 +55,31 @@ def validate(data: dict) -> None:
     _make_validator().validate(data)
 
 
+# Top-level keys that a fragment document must not declare.
+# Fragments are flat ingredients; nested composition is intentionally disallowed in v2.
+_FRAGMENT_FORBIDDEN_KEYS = ('base', 'fragments')
+
+
+def validate_fragment(data: dict) -> None:
+    """Validate a NoDL fragment.
+
+    A fragment must pass the standard schema and additionally must not declare
+    a ``base`` or ``fragments`` key.
+    Nested fragment composition is intentionally disallowed in v2; if a real
+    use case emerges, the constraint can be lifted without a schema change.
+    Raises jsonschema.ValidationError on schema failure or ValueError on a
+    forbidden key.
+    """
+    validate(data)
+    forbidden = [k for k in _FRAGMENT_FORBIDDEN_KEYS if k in data]
+    if forbidden:
+        raise ValueError(
+            'NoDL fragment must not declare '
+            + ', '.join(repr(k) for k in forbidden)
+            + '; nested fragment composition is not supported in v2.'
+        )
+
+
 def load_nodl(source: Union[str, bytes, IO]) -> NodlDocument:
     """Load and validate a NoDL document from a string, bytes, or file-like object.
 
@@ -62,11 +87,22 @@ def load_nodl(source: Union[str, bytes, IO]) -> NodlDocument:
     Raises jsonschema.ValidationError on schema error or pydantic.ValidationError
     on type error.
     """
+    return _load(source, validate)
+
+
+def load_fragment(source: Union[str, bytes, IO]) -> NodlDocument:
+    """Load and validate a NoDL fragment document.
+
+    Same as load_nodl but enforces the no-base / no-fragments constraint.
+    """
+    return _load(source, validate_fragment)
+
+
+def _load(source, validator) -> NodlDocument:
     data = yaml.safe_load(source)
     if not isinstance(data, dict):
         raise ValueError('NoDL document must be a YAML/JSON mapping at the top level')
-
-    validate(data)
+    validator(data)
     # parse_obj is pydantic v1 API, retained as a deprecated alias in v2.
     # Used so this module works against both rosdep-shipped pydantic v1
     # (humble/jazzy/kilted) and v2 (lyrical+).
@@ -105,11 +141,19 @@ def main(argv: list[str] | None = None) -> int:
         description='Validate a NoDL file against the schema.',
     )
     parser.add_argument('file', type=Path, help='Path to the NoDL file to validate.')
+    parser.add_argument(
+        '--fragment',
+        action='store_true',
+        help='Validate the file as a fragment (rejects nested base/fragments).',
+    )
     args = parser.parse_args(argv)
 
     try:
         with args.file.open('r') as f:
-            load_nodl(f)
+            if args.fragment:
+                load_fragment(f)
+            else:
+                load_nodl(f)
     except Exception as exc:
         print(f'{args.file}: {exc}', file=sys.stderr)
         return 1

--- a/nodl_schema/nodl_schema/validator.py
+++ b/nodl_schema/nodl_schema/validator.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import importlib.resources as ir
 import json
+from pathlib import Path
 from typing import IO, Union
 
 import yaml
@@ -87,3 +88,31 @@ def dump_nodl(doc: Union[NodlDocument, dict], *, format: str = 'yaml') -> str:
     if format == 'json':
         return json.dumps(data, indent=2)
     return yaml.dump(data, default_flow_style=False, allow_unicode=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """``python -m nodl_schema <file>`` -- validate a NoDL file.
+
+    Exits 0 on success, 1 on validation failure or I/O error.
+    Designed for invocation from CMake macros (ament_nodl_register_node and
+    siblings) so files are checked at build time, not at runtime.
+    """
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        prog='python -m nodl_schema',
+        description='Validate a NoDL file against the schema.',
+    )
+    parser.add_argument('file', type=Path, help='Path to the NoDL file to validate.')
+    args = parser.parse_args(argv)
+
+    try:
+        with args.file.open('r') as f:
+            load_nodl(f)
+    except Exception as exc:
+        print(f'{args.file}: {exc}', file=sys.stderr)
+        return 1
+
+    print(f'{args.file}: ok')
+    return 0

--- a/nodl_schema/setup.py
+++ b/nodl_schema/setup.py
@@ -8,7 +8,7 @@ setup(
     name=package_name,
     version='0.0.0',
     packages=[package_name],
-    package_data={package_name: ['schemas/*.yaml']},
+    package_data={package_name: ['schemas/*.yaml', 'schemas/fragments/*.yaml']},
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
@@ -17,6 +17,13 @@ setup(
             [
                 'nodl_schema/schemas/nodl.schema.yaml',
                 'nodl_schema/schemas/parameter.schema.yaml',
+            ],
+        ),
+        (
+            'share/' + package_name + '/schemas/fragments',
+            [
+                'nodl_schema/schemas/fragments/node.nodl.yaml',
+                'nodl_schema/schemas/fragments/lifecycle_node.nodl.yaml',
             ],
         ),
     ],

--- a/nodl_schema/test/test_resolve.py
+++ b/nodl_schema/test/test_resolve.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for nodl_schema.resolve -- no ament_index or live ROS required."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from nodl_schema.models import FragmentRef, NodlDocument, ParameterDefinition, QosProfile, TopicEndpoint
+from nodl_schema.resolve import resolve
+
+_SYS_QOS = QosProfile(history='SYSTEM_DEFAULT', reliability='SYSTEM_DEFAULT')
+
+
+# ---------------------------------------------------------------------------
+# Built-in base resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_no_base_or_fragments():
+    doc = NodlDocument(nodl_version=2)
+    layered = resolve(doc)
+    assert layered.base is None
+    assert layered.fragments == {}
+    assert layered.merged() == NodlDocument(nodl_version=2)
+
+
+def test_resolve_base_node_loads_use_sim_time():
+    doc = NodlDocument(nodl_version=2, base='node')
+    layered = resolve(doc)
+    assert layered.base is not None
+    assert layered.base_name == 'node'
+    merged = layered.merged()
+    assert merged.parameters is not None
+    assert 'use_sim_time' in merged.parameters
+    p = merged.parameters['use_sim_time']
+    assert (p.type.value if hasattr(p.type, 'value') else p.type) == 'bool'
+
+
+def test_resolve_base_lifecycle_node_has_use_sim_time():
+    doc = NodlDocument(nodl_version=2, base='lifecycle_node')
+    merged = resolve(doc).merged()
+    assert 'use_sim_time' in (merged.parameters or {})
+
+
+def test_resolve_base_lifecycle_node_has_change_state_service():
+    merged = resolve(NodlDocument(nodl_version=2, base='lifecycle_node')).merged()
+    names = [s.name for s in (merged.service_servers or [])]
+    assert '~/change_state' in names
+
+
+def test_resolve_base_lifecycle_node_has_transition_event_publisher():
+    merged = resolve(NodlDocument(nodl_version=2, base='lifecycle_node')).merged()
+    topics = [p.name for p in (merged.publishers or [])]
+    assert '~/transition_event' in topics
+
+
+def test_resolve_unknown_base_raises():
+    # Pydantic rejects unknown bases at model construction time.
+    with pytest.raises(Exception):
+        NodlDocument(nodl_version=2, base='unknown_base')
+
+
+# ---------------------------------------------------------------------------
+# Fragment resolution -- relative path
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_relative_fragment(tmp_path: Path):
+    frag_file = tmp_path / 'my_frag.nodl.yaml'
+    frag_file.write_text(
+        textwrap.dedent("""\
+        nodl_version: 2
+        publishers:
+          - name: /extra
+            type: std_msgs/msg/String
+            qos:
+              history: SYSTEM_DEFAULT
+              reliability: SYSTEM_DEFAULT
+    """)
+    )
+
+    doc = NodlDocument(
+        nodl_version=2,
+        fragments=[FragmentRef(ref='my_frag.nodl.yaml', name='extra')],
+    )
+    layered = resolve(doc, source_path=tmp_path / 'root.nodl.yaml')
+    assert 'extra' in layered.fragments
+    topics = [p.name for p in (layered.merged().publishers or [])]
+    assert '/extra' in topics
+
+
+def test_resolve_relative_fragment_missing_raises(tmp_path: Path):
+    doc = NodlDocument(nodl_version=2, fragments=[FragmentRef(ref='nonexistent.nodl.yaml')])
+    with pytest.raises(FileNotFoundError):
+        resolve(doc, source_path=tmp_path / 'root.nodl.yaml')
+
+
+def test_resolve_relative_fragment_without_source_raises():
+    doc = NodlDocument(nodl_version=2, fragments=[FragmentRef(ref='./something.nodl.yaml')])
+    with pytest.raises(ValueError, match='source path'):
+        resolve(doc)
+
+
+def test_resolve_fragment_declaring_base_raises(tmp_path: Path):
+    # A fragment may not declare base; nested composition is disallowed in v2.
+    frag = tmp_path / 'frag.nodl.yaml'
+    frag.write_text('nodl_version: 2\nbase: node\n')
+    doc = NodlDocument(nodl_version=2, fragments=[FragmentRef(ref='frag.nodl.yaml')])
+    with pytest.raises(ValueError, match="'base'"):
+        resolve(doc, source_path=tmp_path / 'root.nodl.yaml')
+
+
+def test_resolve_fragment_declaring_fragments_raises(tmp_path: Path):
+    # A fragment may not declare its own fragments either.
+    frag = tmp_path / 'frag.nodl.yaml'
+    frag.write_text('nodl_version: 2\nfragments:\n  - ref: nodl://pkg/other\n')
+    doc = NodlDocument(nodl_version=2, fragments=[FragmentRef(ref='frag.nodl.yaml')])
+    with pytest.raises(ValueError, match="'fragments'"):
+        resolve(doc, source_path=tmp_path / 'root.nodl.yaml')
+
+
+# ---------------------------------------------------------------------------
+# LayeredDocument.merged() -- layer precedence
+# ---------------------------------------------------------------------------
+
+
+def test_merged_main_wins_over_base():
+    """Main document's parameter overrides the base's."""
+    doc = NodlDocument(
+        nodl_version=2,
+        base='node',
+        parameters={'use_sim_time': ParameterDefinition(type='bool', default_value=True)},
+    )
+    merged = resolve(doc).merged()
+    # Main sets default_value=True; base has default_value=False
+    assert merged.parameters['use_sim_time'].default_value is True
+
+
+def test_merged_fragment_wins_over_base(tmp_path: Path):
+    frag_file = tmp_path / 'frag.nodl.yaml'
+    frag_file.write_text(
+        textwrap.dedent("""\
+        nodl_version: 2
+        parameters:
+          use_sim_time:
+            type: bool
+            default_value: true
+    """)
+    )
+    doc = NodlDocument(
+        nodl_version=2,
+        base='node',
+        fragments=[FragmentRef(ref='frag.nodl.yaml', name='frag')],
+    )
+    merged = resolve(doc, source_path=tmp_path / 'root.nodl.yaml').merged()
+    assert merged.parameters['use_sim_time'].default_value is True
+
+
+def test_merged_combines_publishers_from_all_layers(tmp_path: Path):
+    frag_file = tmp_path / 'frag.nodl.yaml'
+    frag_file.write_text(
+        textwrap.dedent("""\
+        nodl_version: 2
+        publishers:
+          - name: /from_frag
+            type: std_msgs/msg/String
+            qos:
+              history: SYSTEM_DEFAULT
+              reliability: SYSTEM_DEFAULT
+    """)
+    )
+    doc = NodlDocument(
+        nodl_version=2,
+        publishers=[TopicEndpoint(name='/from_main', type='std_msgs/msg/String', qos=_SYS_QOS)],
+        fragments=[FragmentRef(ref='frag.nodl.yaml', name='f')],
+    )
+    merged = resolve(doc, source_path=tmp_path / 'root.nodl.yaml').merged()
+    topics = {p.name for p in (merged.publishers or [])}
+    assert '/from_main' in topics
+    assert '/from_frag' in topics
+
+
+def test_fragment_label_defaults_to_ref(tmp_path: Path):
+    frag_file = tmp_path / 'f.nodl.yaml'
+    frag_file.write_text(
+        textwrap.dedent("""\
+        nodl_version: 2
+        publishers:
+          - name: /t
+            type: std_msgs/msg/String
+            qos:
+              history: SYSTEM_DEFAULT
+              reliability: SYSTEM_DEFAULT
+    """)
+    )
+    doc = NodlDocument(nodl_version=2, fragments=[FragmentRef(ref='f.nodl.yaml')])
+    layered = resolve(doc, source_path=tmp_path / 'root.nodl.yaml')
+    assert 'f.nodl.yaml' in layered.fragments

--- a/nodl_schema/test/test_schema.py
+++ b/nodl_schema/test/test_schema.py
@@ -235,14 +235,26 @@ def test_string_nodl_version_rejected():
         validate({'nodl_version': '2'})
 
 
-def test_fragments_no_longer_allowed():
-    with pytest.raises(ValidationError):
-        validate({'nodl_version': 2, 'fragments': [{'ref': 'nodl://pkg/x'}]})
+def test_base_node_accepted():
+    validate({'nodl_version': 2, 'base': 'node'})
 
 
-def test_base_no_longer_allowed():
+def test_base_lifecycle_node_accepted():
+    validate({'nodl_version': 2, 'base': 'lifecycle_node'})
+
+
+def test_base_unknown_rejected():
     with pytest.raises(ValidationError):
-        validate({'nodl_version': 2, 'base': 'lifecycle_node'})
+        validate({'nodl_version': 2, 'base': 'unknown_base'})
+
+
+def test_fragments_accepted():
+    validate({'nodl_version': 2, 'fragments': [{'ref': 'nodl://pkg/x'}]})
+
+
+def test_fragment_missing_ref_rejected():
+    with pytest.raises(ValidationError):
+        validate({'nodl_version': 2, 'fragments': [{'name': 'no_ref'}]})
 
 
 def test_invalid_parameter_type():

--- a/nodl_schema/test/test_validator_cli.py
+++ b/nodl_schema/test/test_validator_cli.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ``python -m nodl_schema.validator`` CLI used by build-time hooks."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_VALID = """\
+nodl_version: 2
+publishers:
+  - name: /chatter
+    type: std_msgs/msg/String
+    qos:
+      history: KEEP_LAST
+      depth: 10
+      reliability: RELIABLE
+"""
+
+_INVALID_BAD_PARAM_TYPE = """\
+nodl_version: 2
+parameters:
+  speed:
+    type: not_a_real_type
+"""
+
+_INVALID_NOT_A_MAPPING = '- just a list\n'
+
+
+def _run(file: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, '-m', 'nodl_schema', str(file)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_valid_file_exits_zero(tmp_path: Path):
+    f = tmp_path / 'ok.nodl.yaml'
+    f.write_text(_VALID)
+    result = _run(f)
+    assert result.returncode == 0, result.stderr
+    assert str(f) in result.stdout
+
+
+def test_invalid_schema_exits_one(tmp_path: Path):
+    f = tmp_path / 'bad.nodl.yaml'
+    f.write_text(_INVALID_BAD_PARAM_TYPE)
+    result = _run(f)
+    assert result.returncode == 1
+    # The file path should be in the error so build logs are scannable.
+    assert str(f) in result.stderr
+
+
+def test_non_mapping_exits_one(tmp_path: Path):
+    f = tmp_path / 'list.nodl.yaml'
+    f.write_text(_INVALID_NOT_A_MAPPING)
+    result = _run(f)
+    assert result.returncode == 1
+    assert str(f) in result.stderr
+
+
+def test_missing_file_exits_one(tmp_path: Path):
+    result = _run(tmp_path / 'does_not_exist.nodl.yaml')
+    assert result.returncode == 1
+
+
+def test_json_frontend_supported(tmp_path: Path):
+    f = tmp_path / 'ok.nodl.json'
+    f.write_text('{"nodl_version": 2}\n')
+    result = _run(f)
+    assert result.returncode == 0, result.stderr

--- a/nodl_schema/test/test_validator_cli.py
+++ b/nodl_schema/test/test_validator_cli.py
@@ -29,12 +29,12 @@ parameters:
 _INVALID_NOT_A_MAPPING = '- just a list\n'
 
 
-def _run(file: Path) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [sys.executable, '-m', 'nodl_schema', str(file)],
-        capture_output=True,
-        text=True,
-    )
+def _run(file: Path, *, fragment: bool = False) -> subprocess.CompletedProcess:
+    cmd = [sys.executable, '-m', 'nodl_schema']
+    if fragment:
+        cmd.append('--fragment')
+    cmd.append(str(file))
+    return subprocess.run(cmd, capture_output=True, text=True)
 
 
 def test_valid_file_exits_zero(tmp_path: Path):
@@ -72,3 +72,41 @@ def test_json_frontend_supported(tmp_path: Path):
     f.write_text('{"nodl_version": 2}\n')
     result = _run(f)
     assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# --fragment mode
+# ---------------------------------------------------------------------------
+
+
+def test_valid_fragment_exits_zero(tmp_path: Path):
+    # A fragment with publishers / subscriptions but no base/fragments passes.
+    f = tmp_path / 'frag.nodl.yaml'
+    f.write_text(_VALID)
+    result = _run(f, fragment=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_fragment_with_base_rejected(tmp_path: Path):
+    f = tmp_path / 'bad_frag.nodl.yaml'
+    f.write_text('nodl_version: 2\nbase: node\n')
+    result = _run(f, fragment=True)
+    assert result.returncode == 1
+    assert str(f) in result.stderr
+    assert "'base'" in result.stderr
+
+
+def test_fragment_with_fragments_rejected(tmp_path: Path):
+    f = tmp_path / 'bad_frag.nodl.yaml'
+    f.write_text('nodl_version: 2\nfragments:\n  - ref: nodl://pkg/other\n')
+    result = _run(f, fragment=True)
+    assert result.returncode == 1
+    assert "'fragments'" in result.stderr
+
+
+def test_fragment_with_invalid_schema_still_rejected(tmp_path: Path):
+    # Schema validation happens before the fragment-only check.
+    f = tmp_path / 'doubly_bad.nodl.yaml'
+    f.write_text(_INVALID_BAD_PARAM_TYPE)
+    result = _run(f, fragment=True)
+    assert result.returncode == 1

--- a/test_ament_nodl/CMakeLists.txt
+++ b/test_ament_nodl/CMakeLists.txt
@@ -17,9 +17,18 @@ ament_nodl_register_node(custom_exe
 # Non-yaml frontend. Make sure the macro is extension-agnostic.
 ament_nodl_register_node(json_node FILE test/fixtures/json_node.nodl.json)
 
+# Default PACKAGE for the fragment register macro.
+ament_nodl_register_fragment(tf_listener FILE test/fixtures/tf_listener.nodl.yaml)
+
+# Explicit PACKAGE override for fragments.
+ament_nodl_register_fragment(extra_telemetry
+  FILE test/fixtures/extra_telemetry.nodl.yaml
+  PACKAGE custom_pkg)
+
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(register_node_tests test/test_register_node.py)
+  ament_add_pytest_test(register_fragment_tests test/test_register_fragment.py)
   ament_add_pytest_test(macro_rejection_tests test/test_macro_rejection.py)
 endif()
 

--- a/test_ament_nodl/CMakeLists.txt
+++ b/test_ament_nodl/CMakeLists.txt
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+cmake_minimum_required(VERSION 3.22)
+project(test_ament_nodl)
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_nodl REQUIRED)
+
+# Default PACKAGE resolves to ${PROJECT_NAME}.
+ament_nodl_register_node(basic_node FILE test/fixtures/basic_node.nodl.yaml)
+
+# Explicit PACKAGE override. The resource key and install destination both pick it up.
+ament_nodl_register_node(custom_exe
+  FILE test/fixtures/alt_pkg_node.nodl.yaml
+  PACKAGE custom_pkg)
+
+# Non-yaml frontend. Make sure the macro is extension-agnostic.
+ament_nodl_register_node(json_node FILE test/fixtures/json_node.nodl.json)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(register_node_tests test/test_register_node.py)
+  ament_add_pytest_test(macro_rejection_tests test/test_macro_rejection.py)
+endif()
+
+ament_package()

--- a/test_ament_nodl/package.xml
+++ b/test_ament_nodl/package.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>nodl</name>
+  <name>test_ament_nodl</name>
   <version>0.0.0</version>
-  <description>ROS 2 Node Definition Language (NoDL) metapackage.</description>
+  <description>Integration tests for the ament_nodl CMake macros.</description>
   <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>
-  <author email="hello@alistairenglish.com">Alistair English</author>
   <author email="me@emersonknapp.com">Emerson Knapp</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_nodl</buildtool_depend>
 
-  <exec_depend>ament_nodl</exec_depend>
-  <exec_depend>nodl_schema</exec_depend>
-  <exec_depend>ros2nodl</exec_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_index_python</test_depend>
+  <test_depend>python3-pytest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/test_ament_nodl/test/fixtures/alt_pkg_node.nodl.yaml
+++ b/test_ament_nodl/test/fixtures/alt_pkg_node.nodl.yaml
@@ -1,0 +1,3 @@
+---
+nodl_version: 2
+description: Test node registered under an explicit PACKAGE override.

--- a/test_ament_nodl/test/fixtures/basic_node.nodl.yaml
+++ b/test_ament_nodl/test/fixtures/basic_node.nodl.yaml
@@ -1,0 +1,10 @@
+---
+nodl_version: 2
+description: Basic test node used to exercise ament_nodl_register_node default args.
+publishers:
+  - name: /chatter
+    type: std_msgs/msg/String
+    qos:
+      history: KEEP_LAST
+      depth: 10
+      reliability: RELIABLE

--- a/test_ament_nodl/test/fixtures/extra_telemetry.nodl.yaml
+++ b/test_ament_nodl/test/fixtures/extra_telemetry.nodl.yaml
@@ -1,0 +1,10 @@
+---
+nodl_version: 2
+description: Test fragment registered under an explicit PACKAGE override.
+publishers:
+  - name: ~/diagnostics
+    type: diagnostic_msgs/msg/DiagnosticArray
+    qos:
+      history: KEEP_LAST
+      depth: 10
+      reliability: RELIABLE

--- a/test_ament_nodl/test/fixtures/json_node.nodl.json
+++ b/test_ament_nodl/test/fixtures/json_node.nodl.json
@@ -1,0 +1,4 @@
+{
+  "nodl_version": 2,
+  "description": "Test node using the JSON frontend; the macro should treat it the same as YAML."
+}

--- a/test_ament_nodl/test/fixtures/tf_listener.nodl.yaml
+++ b/test_ament_nodl/test/fixtures/tf_listener.nodl.yaml
@@ -1,0 +1,17 @@
+---
+nodl_version: 2
+description: Test fragment that adds the standard tf2 listener subscriptions.
+subscriptions:
+  - name: /tf
+    type: tf2_msgs/msg/TFMessage
+    qos:
+      history: KEEP_LAST
+      depth: 100
+      reliability: RELIABLE
+  - name: /tf_static
+    type: tf2_msgs/msg/TFMessage
+    qos:
+      history: KEEP_LAST
+      depth: 100
+      reliability: RELIABLE
+      durability: TRANSIENT_LOCAL

--- a/test_ament_nodl/test/test_macro_rejection.py
+++ b/test_ament_nodl/test/test_macro_rejection.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end test that the ament_nodl_register_node macro propagates validator failures as build failures.
+
+Writes a tiny inner ament_cmake project that registers an intentionally-invalid NoDL file via the macro,
+then spawns cmake to configure and build it; the build is expected to fail with the validator error.
+This catches regressions in the macro wiring itself, separate from the CLI tests in nodl_schema that
+already cover the validator's behavior in isolation.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_INNER_CMAKELISTS = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.22)
+    project(rejection_fixture)
+    find_package(ament_cmake REQUIRED)
+    find_package(ament_nodl REQUIRED)
+    ament_nodl_register_node(bad_exe FILE bad.nodl.yaml)
+    ament_package()
+""")
+
+_INNER_PACKAGE_XML = textwrap.dedent("""<?xml version="1.0"?>
+    <package format="3">
+      <name>rejection_fixture</name>
+      <version>0.0.0</version>
+      <description>Inner project used by test_ament_nodl to verify the macro rejects invalid files.</description>
+      <maintainer email="test@example.com">test</maintainer>
+      <license>Apache-2.0</license>
+      <buildtool_depend>ament_cmake</buildtool_depend>
+      <buildtool_depend>ament_nodl</buildtool_depend>
+      <export>
+        <build_type>ament_cmake</build_type>
+      </export>
+    </package>
+""").lstrip()
+
+_INVALID_NODL = textwrap.dedent("""
+    nodl_version: 2
+    parameters:
+      bad:
+        type: not_a_real_type
+""").lstrip()
+
+
+@pytest.fixture
+def inner_pkg(tmp_path: Path) -> Path:
+    pkg = tmp_path / 'rejection_fixture'
+    pkg.mkdir()
+    (pkg / 'CMakeLists.txt').write_text(_INNER_CMAKELISTS)
+    (pkg / 'package.xml').write_text(_INNER_PACKAGE_XML)
+    (pkg / 'bad.nodl.yaml').write_text(_INVALID_NODL)
+    return pkg
+
+
+@pytest.mark.skipif(shutil.which('cmake') is None, reason='cmake not on PATH')
+def test_macro_rejects_invalid_node(inner_pkg: Path):
+    # Inherit AMENT_PREFIX_PATH from the colcon-test env so the inner build
+    # can resolve find_package(ament_nodl) and find python with nodl_schema.
+    build = inner_pkg / 'build'
+    configure = subprocess.run(
+        ['cmake', '-S', str(inner_pkg), '-B', str(build)],
+        capture_output=True,
+        text=True,
+        env=os.environ,
+    )
+    assert configure.returncode == 0, f'Configure failed:\n{configure.stderr}'
+
+    result = subprocess.run(
+        ['cmake', '--build', str(build)],
+        capture_output=True,
+        text=True,
+        env=os.environ,
+    )
+    assert result.returncode != 0, 'Expected the inner build to fail on the invalid NoDL file'
+    combined = result.stdout + result.stderr
+    assert 'not_a_real_type' in combined, (
+        f'Expected the validator error to appear in the build output, got:\n{combined}'
+    )

--- a/test_ament_nodl/test/test_register_fragment.py
+++ b/test_ament_nodl/test/test_register_fragment.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for the ament_nodl_register_fragment CMake macro.
+
+The macro is exercised at configure / install time by this package's
+CMakeLists.txt; here we assert on the resulting ament index and install
+tree without re-invoking CMake.
+"""
+
+from pathlib import Path
+
+from ament_index_python.packages import PackageNotFoundError, get_package_share_directory
+from ament_index_python.resources import get_resource
+
+
+def _share(pkg: str = 'test_ament_nodl') -> Path:
+    # Real packages resolve through the ament index.
+    # Virtual packages used only as a PACKAGE override aren't registered, so we
+    # resolve them as siblings under the registering package's install prefix.
+    try:
+        return Path(get_package_share_directory(pkg))
+    except PackageNotFoundError:
+        return Path(get_package_share_directory('test_ament_nodl')).parent / pkg
+
+
+# ---------------------------------------------------------------------------
+# Resource registration
+# ---------------------------------------------------------------------------
+
+
+def test_default_package_uses_project_name():
+    # No PACKAGE arg means the macro defaults to ${PROJECT_NAME}, so the key is test_ament_nodl__tf_listener.
+    content, prefix = get_resource('nodl_fragments', 'test_ament_nodl__tf_listener')
+    assert prefix
+    assert 'tf2 listener' in content
+
+
+def test_explicit_package_override():
+    # PACKAGE custom_pkg makes the key custom_pkg__extra_telemetry, matching what nodl://custom_pkg/extra_telemetry
+    # would resolve to.
+    content, _ = get_resource('nodl_fragments', 'custom_pkg__extra_telemetry')
+    assert 'explicit PACKAGE override' in content
+
+
+def test_resource_content_matches_source():
+    # The registered resource should be byte-identical to the source file.
+    content, _ = get_resource('nodl_fragments', 'test_ament_nodl__tf_listener')
+    on_disk = (_share() / 'nodl' / 'fragments' / 'tf_listener.nodl.yaml').read_text()
+    assert content == on_disk
+
+
+# ---------------------------------------------------------------------------
+# Source file installation
+# ---------------------------------------------------------------------------
+
+
+def test_source_file_installed_under_registering_package():
+    # Default PACKAGE installs the source under share/test_ament_nodl/nodl/fragments/.
+    assert (_share() / 'nodl' / 'fragments' / 'tf_listener.nodl.yaml').is_file()
+
+
+def test_source_file_installed_under_override_package():
+    # PACKAGE override redirects the source-file install to share/<override>/nodl/fragments/.
+    assert (_share('custom_pkg') / 'nodl' / 'fragments' / 'extra_telemetry.nodl.yaml').is_file()

--- a/test_ament_nodl/test/test_register_node.py
+++ b/test_ament_nodl/test/test_register_node.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for the ament_nodl_register_node CMake macro.
+
+The macro is exercised at configure / install time by this package's
+CMakeLists.txt; here we assert on the resulting ament index and install
+tree without re-invoking CMake.
+"""
+
+from pathlib import Path
+
+from ament_index_python.packages import PackageNotFoundError, get_package_share_directory
+from ament_index_python.resources import get_resource
+
+
+def _share(pkg: str = 'test_ament_nodl') -> Path:
+    # Real packages resolve through the ament index.
+    # Virtual packages used only as a PACKAGE override aren't registered, so we
+    # resolve them as siblings under the registering package's install prefix.
+    try:
+        return Path(get_package_share_directory(pkg))
+    except PackageNotFoundError:
+        return Path(get_package_share_directory('test_ament_nodl')).parent / pkg
+
+
+# ---------------------------------------------------------------------------
+# Resource registration
+# ---------------------------------------------------------------------------
+
+
+def test_default_package_uses_project_name():
+    # No PACKAGE arg means the macro defaults to ${PROJECT_NAME}, so the key is test_ament_nodl__basic_node.
+    content, prefix = get_resource('nodl_nodes', 'test_ament_nodl__basic_node')
+    assert prefix
+    assert 'Basic test node' in content
+
+
+def test_explicit_package_override():
+    # PACKAGE custom_pkg makes the key custom_pkg__custom_exe even though the registering package is test_ament_nodl.
+    content, _ = get_resource('nodl_nodes', 'custom_pkg__custom_exe')
+    assert 'explicit PACKAGE override' in content
+
+
+def test_extension_agnostic_frontend():
+    # The macro reads bytes and writes bytes; a .nodl.json file round-trips just like yaml.
+    content, _ = get_resource('nodl_nodes', 'test_ament_nodl__json_node')
+    assert '"nodl_version": 2' in content
+
+
+def test_resource_content_matches_source():
+    # The registered resource should be byte-identical to the source file.
+    content, _ = get_resource('nodl_nodes', 'test_ament_nodl__basic_node')
+    on_disk = (_share() / 'nodl' / 'basic_node.nodl.yaml').read_text()
+    assert content == on_disk
+
+
+# ---------------------------------------------------------------------------
+# Source file installation
+# ---------------------------------------------------------------------------
+
+
+def test_source_file_installed_under_registering_package():
+    # Default PACKAGE installs the source under share/test_ament_nodl/nodl/.
+    assert (_share() / 'nodl' / 'basic_node.nodl.yaml').is_file()
+
+
+def test_json_source_file_installed():
+    # Original filename and extension are preserved.
+    assert (_share() / 'nodl' / 'json_node.nodl.json').is_file()
+
+
+def test_source_file_installed_under_override_package():
+    # PACKAGE override redirects the source-file install to share/<override>/nodl/.
+    target = _share('custom_pkg') / 'nodl' / 'alt_pkg_node.nodl.yaml'
+    assert target.is_file()


### PR DESCRIPTION
Closes #72 

Adds a new concept of a "NoDL Fragment" that is a partial specification for a node. There are effectively two use cases for framents:
1. The base node type (`Node` or `LifecycleNode`) which brings along with it a certain interface set
2. "add-ons"/"extensions"/"mixins" (really haven't landed on a single term for this yet) which a node instantiates, that adds to the node's interface. The prime example is the `TfBroadcaster` (which creates publishers) and `TfBuffer` (which creates subscriptions). This pattern is also used in Navigation2 to add parameters to nodes, etc.

The fragment concept allows resolving a full specification for a node via reference to other sub-documents, while keeping it clear for code generation and documentation what _specifically_ this node code actually provides. 