### PR TITLE
Add `ros2 nodl describe`: rosgraph_msgs/Node -> NoDL document (#53)

### DIFF
--- a/nodl/doc/describe.md
+++ b/nodl/doc/describe.md
@@ -101,10 +101,8 @@ same name but a different type remains. Use `--keep-hidden` to disable filtering
 
 When required data cannot be recovered, the command reports the affected field
 on stderr. It emits the draft by default; `--strict` makes any such gap fatal.
-
-Runtime observation cannot supply service QoS, descriptive prose, type hashes,
-parameter `dynamic_typing`, or byte-array parameter values in the current NoDL
-schema. Those values are omitted rather than guessed.
+Information absent from runtime observation, such as descriptive prose, is
+omitted rather than guessed.
 
 See [Concepts](concepts.md) for the backward workflow and [Schema](schema.md) for
 the document format.

--- a/nodl/doc/describe.md
+++ b/nodl/doc/describe.md
@@ -1,0 +1,85 @@
+# Describe
+
+`ros2 nodl describe` turns a running or captured ROS 2 node into a NoDL draft.
+It is the interpretation half of the backward workflow:
+
+> Observe records everything; describe interprets it.
+
+The `nodl_observe` backend captures `rosgraph_msgs/Node`. `describe` removes
+runtime infrastructure, maps observed values into the NoDL schema, and validates
+the result. The transform itself is deterministic and does not access the ROS
+graph; file input still requires a sourced ROS environment to deserialize the
+message.
+
+## Usage
+
+```console
+ros2 nodl describe NODE_NAME [--from FILE] [--no-params] [--keep-hidden]
+                             [--strict] [--raw] [--timeout SEC]
+                             [--topic NAME] [-o OUT.{yaml,json}]
+```
+
+| Option | Effect |
+|---|---|
+| `--from FILE` | Read a captured `Node` from YAML or MCAP instead of observing live. |
+| `--no-params` | Omit parameters and skip live parameter service calls. |
+| `--keep-hidden` | Keep framework-created endpoints and parameters. |
+| `--strict` | Return nonzero if a field cannot be recovered or validation fails. |
+| `--raw` | Emit the captured `Node` rather than the NoDL document. |
+| `--timeout SEC` | Set the live discovery timeout. |
+| `--topic NAME` | Override the live observation topic. |
+| `-o FILE` | Write YAML or JSON based on the filename extension. |
+
+```console
+ros2 nodl describe /ns/talker
+ros2 nodl describe /ns/talker --from talker.mcap -o talker.json
+```
+
+## Mapping
+
+Node identity is omitted because a NoDL document does not declare its own name.
+Empty interface collections are also omitted.
+
+Topics preserve their name and type. Their RMW QoS integers become NoDL enums:
+
+| Policy | When observation reports `UNKNOWN` |
+|---|---|
+| `history`, `reliability` | `SYSTEM_DEFAULT` (required by the schema) |
+| `durability`, `liveliness` | omitted |
+
+`depth` is emitted only for `KEEP_LAST`. Finite durations become nanoseconds;
+zero and the observation backend's infinite sentinel are omitted.
+
+Services use `request_type.name` as their type. Response types and service QoS
+are omitted because they add no representable runtime information.
+
+Actions become one endpoint. Their type is recovered from the generated
+`_SendGoal` or `_GetResult` service type; constituent services and topics are not
+re-emitted.
+
+Parameters are keyed by name. The descriptor supplies type, description,
+constraints, read-only state, and range bounds. The observed value becomes the
+default value when its type agrees with the descriptor.
+
+## Infrastructure filtering
+
+By default, `describe` removes framework-created interfaces:
+
+- `/rosout` and `/parameter_events`
+- parameter and type-description services
+- `use_sim_time`, `start_type_description_service`, and `qos_overrides.*`
+
+Endpoint filtering matches both name tail and type, so a user endpoint with the
+same name but a different type remains. Use `--keep-hidden` to disable filtering.
+
+## Drafts and limitations
+
+When required data cannot be recovered, the command reports the affected field
+on stderr. It emits the draft by default; `--strict` makes any such gap fatal.
+
+Runtime observation cannot supply service QoS, descriptive prose, type hashes,
+parameter `dynamic_typing`, or byte-array parameter values in the current NoDL
+schema. Those values are omitted rather than guessed.
+
+See [Concepts](concepts.md) for the backward workflow and [Schema](schema.md) for
+the document format.

--- a/nodl/doc/describe.md
+++ b/nodl/doc/describe.md
@@ -37,10 +37,35 @@ ros2 nodl describe /ns/talker --from talker.mcap -o talker.json
 
 ## Mapping
 
-Node identity is omitted because a NoDL document does not declare its own name.
-Empty interface collections are also omitted.
+The transform maps fields from `rosgraph_msgs/Node` into a NoDL document as
+follows. Empty interface collections are omitted from the output.
 
-Topics preserve their name and type. Their RMW QoS integers become NoDL enums:
+### Field mapping
+
+| `rosgraph_msgs/Node` input | NoDL YAML output | Rule |
+|---|---|---|
+| *(generated)* | `nodl_version` | Always `2`. |
+| `publishers[].name` | `publishers[].name` | Copied. |
+| `publishers[].type.name` | `publishers[].type` | Copied without the type hash. |
+| `publishers[].qos.*` | `publishers[].qos.*` | Policies become NoDL enum names; finite durations become nanoseconds. |
+| `subscriptions[]` | `subscriptions[]` | Uses the same topic mapping as publishers. |
+| `service_servers[].name` | `service_servers[].name` | Copied. |
+| `service_servers[].request_type.name` | `service_servers[].type` | Used as the complete service type. |
+| `service_clients[]` | `service_clients[]` | Uses the same service mapping as servers. |
+| `action_servers[].name` | `action_servers[].name` | Copied. |
+| `action_servers[].send_goal.request_type.name` | `action_servers[].type` | Removes the generated `_SendGoal` suffix; `_GetResult` is the fallback. |
+| `action_clients[]` | `action_clients[]` | Uses the same action mapping as servers. |
+| `parameters[i].name` | `parameters.<name>` | Becomes the key in the parameter mapping. |
+| `parameters[i].type` | `parameters.<name>.type` | Converted to the corresponding NoDL parameter type. |
+| `parameter_values[i]` | `parameters.<name>.default_value` | Included when its type agrees with the descriptor. |
+| `parameters[i].description` | `parameters.<name>.description` | Copied. |
+| `parameters[i].additional_constraints` | `parameters.<name>.additional_constraints` | Copied. |
+| `parameters[i].read_only` | `parameters.<name>.read_only` | Copied. |
+| `parameters[i].*_range[0]` | `parameters.<name>.validation.bounds` | Lower and upper bounds are copied. |
+
+### QoS mapping
+
+RMW QoS integers become NoDL enum names:
 
 | Policy | When observation reports `UNKNOWN` |
 |---|---|
@@ -50,16 +75,16 @@ Topics preserve their name and type. Their RMW QoS integers become NoDL enums:
 `depth` is emitted only for `KEEP_LAST`. Finite durations become nanoseconds;
 zero and the observation backend's infinite sentinel are omitted.
 
-Services use `request_type.name` as their type. Response types and service QoS
-are omitted because they add no representable runtime information.
+### Intentionally omitted fields
 
-Actions become one endpoint. Their type is recovered from the generated
-`_SendGoal` or `_GetResult` service type; constituent services and topics are not
-re-emitted.
-
-Parameters are keyed by name. The descriptor supplies type, description,
-constraints, read-only state, and range bounds. The observed value becomes the
-default value when its type agrees with the descriptor.
+| `rosgraph_msgs/Node` input | Reason omitted |
+|---|---|
+| `name` | A NoDL document does not declare its own node name. |
+| Endpoint `type.hash` | A NoDL endpoint type is represented by its name. |
+| Service response type and QoS | A NoDL service endpoint stores the service type, not its generated request/response details. |
+| Action constituent services and topics | They are collapsed into one NoDL action endpoint. |
+| Parameter `dynamic_typing` | It is not represented by the current NoDL parameter model. |
+| Byte-array parameter values | The current NoDL schema has no byte-array parameter type. |
 
 ## Infrastructure filtering
 

--- a/nodl/doc/index.md
+++ b/nodl/doc/index.md
@@ -14,6 +14,7 @@ NoDL (Node Definition Language) is a schema and toolkit to describe a ROS 2 node
 Home <self>
 concepts
 schema
+describe
 roadmap
 ```
 

--- a/ros2nodl/package.xml
+++ b/ros2nodl/package.xml
@@ -23,6 +23,10 @@
 
   <test_depend>python3-pytest</test_depend>
   <test_depend>std_msgs</test_depend>
+  <!-- Describe tests exercise generated messages and observe's MCAP fixtures. -->
+  <test_depend>rcl_interfaces</test_depend>
+  <test_depend>builtin_interfaces</test_depend>
+  <test_depend>mcap-ros2-support</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2nodl/ros2nodl/describe/__init__.py
+++ b/ros2nodl/ros2nodl/describe/__init__.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Public API for converting an observed Node message to a NoDL draft."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from nodl_schema.models import NodlDocument
+
+
+@dataclass(frozen=True)
+class Gap:
+    """A field that could not be recovered reliably from the observation."""
+
+    path: str
+    reason: str
+
+
+@dataclass
+class DescribeOptions:
+    include_parameters: bool = True
+    keep_hidden: bool = False
+
+
+@dataclass
+class DescribeResult:
+    doc: 'NodlDocument'
+    gaps: List[Gap] = field(default_factory=list)
+
+
+def node_to_nodl(node, opts: Optional[DescribeOptions] = None) -> DescribeResult:
+    """Convert a duck-typed ``rosgraph_msgs/Node`` into a NoDL document."""
+    from ros2nodl.describe._transform import convert
+
+    return convert(node, opts or DescribeOptions())

--- a/ros2nodl/ros2nodl/describe/_source.py
+++ b/ros2nodl/ros2nodl/describe/_source.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Acquire an observed Node from the live backend, YAML, or MCAP."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+
+_DEFAULT_TOPIC = '/nodl/observed_node'
+_KEEPALIVE_SEC = 3.0
+
+
+class SourceError(Exception):
+    """A user-facing acquisition failure."""
+
+
+def observe_binary():
+    try:
+        from ament_index_python.packages import get_package_prefix
+
+        path = os.path.join(get_package_prefix('nodl_observe'), 'lib', 'nodl_observe', 'observe')
+    except Exception:
+        return None
+    return path if os.path.isfile(path) else None
+
+
+def _latched_qos():
+    from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+
+    return QoSProfile(
+        depth=1,
+        history=HistoryPolicy.KEEP_LAST,
+        reliability=ReliabilityPolicy.RELIABLE,
+        durability=DurabilityPolicy.TRANSIENT_LOCAL,
+    )
+
+
+def _wait_for_exit(process) -> None:
+    try:
+        process.wait(timeout=_KEEPALIVE_SEC + 2.0)
+    except subprocess.TimeoutExpired:
+        process.terminate()
+        try:
+            process.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+
+
+def acquire_live(
+    node_name: str,
+    *,
+    timeout_sec: float,
+    include_parameters: bool = True,
+    topic: str = _DEFAULT_TOPIC,
+):
+    binary = observe_binary()
+    if binary is None:
+        raise SourceError('the nodl_observe `observe` executable was not found; build/install nodl_observe.')
+
+    import rclpy
+    from rosgraph_msgs.msg import Node as NodeMsg
+
+    command = [
+        binary,
+        node_name,
+        '--timeout',
+        repr(float(timeout_sec)),
+        '--topic',
+        topic,
+        '--spin-seconds',
+        repr(_KEEPALIVE_SEC),
+    ]
+    if not include_parameters:
+        command.append('--no-parameters')
+    process = subprocess.Popen(command, stderr=subprocess.PIPE, text=True)
+
+    try:
+        rclpy.init()
+        owns_context = True
+    except RuntimeError:
+        owns_context = False
+
+    received = []
+    try:
+        node = rclpy.create_node(f'_ros2nodl_describe_{os.getpid()}', start_parameter_services=False)
+        try:
+            node.create_subscription(NodeMsg, topic, received.append, _latched_qos())
+            deadline = time.monotonic() + timeout_sec + _KEEPALIVE_SEC + 2.0
+            while not received and time.monotonic() < deadline and process.poll() is None:
+                rclpy.spin_once(node, timeout_sec=0.1)
+            if received:
+                return received[0]
+
+            try:
+                _, error = process.communicate(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                process.terminate()
+                _, error = process.communicate(timeout=2.0)
+            raise SourceError(
+                (error or '').strip() or f'timed out waiting for an observation of {node_name!r} on {topic!r}.'
+            )
+        finally:
+            node.destroy_node()
+    finally:
+        if owns_context:
+            rclpy.shutdown()
+        _wait_for_exit(process)
+
+
+def acquire_from_file(path: str, *, channel: str | None = None):
+    if not os.path.isfile(path):
+        raise SourceError(f'--from: file not found: {path}')
+    extension = os.path.splitext(path)[1].lower()
+    if extension in ('.yaml', '.yml'):
+        return _load_yaml(path)
+    if extension == '.mcap':
+        return _load_mcap(path, channel)
+    raise SourceError(f'--from: unrecognised extension "{extension}"; use .yaml, .yml, or .mcap')
+
+
+def _load_yaml(path: str):
+    import yaml
+    from rosgraph_msgs.msg import Node
+    from rosidl_runtime_py.set_message import set_message_fields
+
+    try:
+        with open(path) as source:
+            data = yaml.safe_load(source)
+        if not isinstance(data, dict):
+            raise ValueError('expected a YAML mapping')
+        message = Node()
+        set_message_fields(message, data)
+        return message
+    except Exception as exc:
+        raise SourceError(f'--from: {path} does not match rosgraph_msgs/Node: {exc}') from exc
+
+
+def _load_mcap(path: str, channel: str | None):
+    try:
+        from mcap.reader import make_reader
+    except ImportError as exc:
+        raise SourceError("--from: reading .mcap requires the 'mcap' package") from exc
+    from rclpy.serialization import deserialize_message
+    from rosgraph_msgs.msg import Node
+
+    try:
+        with open(path, 'rb') as source:
+            available = []
+            for _, message_channel, message in make_reader(source).iter_messages():
+                available.append(message_channel.topic)
+                if channel is None or message_channel.topic == channel:
+                    return deserialize_message(message.data, Node)
+    except Exception as exc:
+        raise SourceError(f'--from: could not read {path}: {exc}') from exc
+    if channel is not None:
+        raise SourceError(f'--from: channel {channel!r} not found; available: {sorted(set(available))}')
+    raise SourceError(f'--from: no messages found in {path}')

--- a/ros2nodl/ros2nodl/describe/_transform.py
+++ b/ros2nodl/ros2nodl/describe/_transform.py
@@ -1,0 +1,366 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Pure, duck-typed ``rosgraph_msgs/Node`` to NoDL transform."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from nodl_schema.models import (
+    ActionEndpoint,
+    ArrayType,
+    Durability,
+    History,
+    Liveliness,
+    NodlDocument,
+    ParameterDefinition,
+    QosProfile,
+    Reliability,
+    ScalarType,
+    ServiceEndpoint,
+    TopicEndpoint,
+    Validation,
+)
+from ros2nodl.describe import DescribeOptions, DescribeResult
+
+
+def _record(gaps: Optional[list], path: str, reason: str) -> None:
+    if gaps is not None:
+        from ros2nodl.describe import Gap
+
+        gaps.append(Gap(path, reason))
+
+
+# rosgraph_msgs/msg/QoSProfile constants. UNKNOWN required policies fall back to
+# SYSTEM_DEFAULT; optional UNKNOWN policies are omitted.
+_HISTORY_SYSTEM_DEFAULT, _HISTORY_KEEP_LAST, _HISTORY_KEEP_ALL, _HISTORY_UNKNOWN = range(4)
+(
+    _RELIABILITY_SYSTEM_DEFAULT,
+    _RELIABILITY_RELIABLE,
+    _RELIABILITY_BEST_EFFORT,
+    _RELIABILITY_UNKNOWN,
+    _RELIABILITY_BEST_AVAILABLE,
+) = range(5)
+(
+    _DURABILITY_SYSTEM_DEFAULT,
+    _DURABILITY_TRANSIENT_LOCAL,
+    _DURABILITY_VOLATILE,
+    _DURABILITY_UNKNOWN,
+    _DURABILITY_BEST_AVAILABLE,
+) = range(5)
+_LIVELINESS_SYSTEM_DEFAULT = 0
+_LIVELINESS_AUTOMATIC = 1
+_LIVELINESS_MANUAL_BY_TOPIC = 3
+_LIVELINESS_UNKNOWN = 4
+_LIVELINESS_BEST_AVAILABLE = 5
+
+_HISTORY_MAP = {
+    _HISTORY_SYSTEM_DEFAULT: History.SYSTEM_DEFAULT,
+    _HISTORY_KEEP_LAST: History.KEEP_LAST,
+    _HISTORY_KEEP_ALL: History.KEEP_ALL,
+    _HISTORY_UNKNOWN: History.SYSTEM_DEFAULT,
+}
+_RELIABILITY_MAP = {
+    _RELIABILITY_SYSTEM_DEFAULT: Reliability.SYSTEM_DEFAULT,
+    _RELIABILITY_RELIABLE: Reliability.RELIABLE,
+    _RELIABILITY_BEST_EFFORT: Reliability.BEST_EFFORT,
+    _RELIABILITY_UNKNOWN: Reliability.SYSTEM_DEFAULT,
+    _RELIABILITY_BEST_AVAILABLE: Reliability.BEST_AVAILABLE,
+}
+_DURABILITY_MAP = {
+    _DURABILITY_SYSTEM_DEFAULT: Durability.SYSTEM_DEFAULT,
+    _DURABILITY_TRANSIENT_LOCAL: Durability.TRANSIENT_LOCAL,
+    _DURABILITY_VOLATILE: Durability.VOLATILE,
+    _DURABILITY_UNKNOWN: None,
+    _DURABILITY_BEST_AVAILABLE: Durability.BEST_AVAILABLE,
+}
+_LIVELINESS_MAP = {
+    _LIVELINESS_SYSTEM_DEFAULT: Liveliness.SYSTEM_DEFAULT,
+    _LIVELINESS_AUTOMATIC: Liveliness.AUTOMATIC,
+    _LIVELINESS_MANUAL_BY_TOPIC: Liveliness.MANUAL_BY_TOPIC,
+    _LIVELINESS_UNKNOWN: None,
+    _LIVELINESS_BEST_AVAILABLE: Liveliness.BEST_AVAILABLE,
+}
+_INT32_MAX = 2_147_483_647
+_NS_PER_SEC = 1_000_000_000
+
+
+def _duration_to_ns(duration) -> Optional[int]:
+    if duration is None:
+        return None
+    sec = int(getattr(duration, 'sec', 0))
+    nanosec = int(getattr(duration, 'nanosec', 0))
+    if sec < 0 or sec == _INT32_MAX or (sec == 0 and nanosec == 0):
+        return None
+    return sec * _NS_PER_SEC + nanosec
+
+
+def _required_policy(mapping, raw: int, fallback, gaps: Optional[list], path: str):
+    value = mapping.get(raw)
+    if value is not None:
+        return value
+    _record(gaps, path, f'unrecognised policy {raw}; using SYSTEM_DEFAULT')
+    return fallback
+
+
+def to_qos_profile(qos, gaps: Optional[list] = None, path: str = '') -> QosProfile:
+    history_raw = int(getattr(qos, 'history', _HISTORY_SYSTEM_DEFAULT))
+    reliability_raw = int(getattr(qos, 'reliability', _RELIABILITY_SYSTEM_DEFAULT))
+    history = _required_policy(_HISTORY_MAP, history_raw, History.SYSTEM_DEFAULT, gaps, f'{path}.history')
+    reliability = _required_policy(
+        _RELIABILITY_MAP,
+        reliability_raw,
+        Reliability.SYSTEM_DEFAULT,
+        gaps,
+        f'{path}.reliability',
+    )
+
+    depth = None
+    if history is History.KEEP_LAST:
+        depth = int(getattr(qos, 'depth', 0))
+        if depth < 1:
+            _record(gaps, f'{path}.depth', f'KEEP_LAST requires depth >= 1, got {depth}')
+            depth = None
+
+    return QosProfile(
+        history=history,
+        depth=depth,
+        reliability=reliability,
+        durability=_DURABILITY_MAP.get(int(getattr(qos, 'durability', 0))),
+        deadline_ns=_duration_to_ns(getattr(qos, 'deadline', None)),
+        lifespan_ns=_duration_to_ns(getattr(qos, 'lifespan', None)),
+        liveliness=_LIVELINESS_MAP.get(int(getattr(qos, 'liveliness', 0))),
+        liveliness_lease_duration_ns=_duration_to_ns(getattr(qos, 'liveliness_lease_duration', None)),
+    )
+
+
+# Framework-created endpoints are matched by both name tail and type so user
+# endpoints with a colliding name survive.
+_HIDDEN_PUBLISHERS = {
+    ('rosout', 'rcl_interfaces/msg/Log'),
+    ('parameter_events', 'rcl_interfaces/msg/ParameterEvent'),
+}
+_HIDDEN_SUBSCRIPTIONS = {
+    ('parameter_events', 'rcl_interfaces/msg/ParameterEvent'),
+}
+_HIDDEN_SERVICES = {
+    ('describe_parameters', 'rcl_interfaces/srv/DescribeParameters'),
+    ('get_parameter_types', 'rcl_interfaces/srv/GetParameterTypes'),
+    ('get_parameters', 'rcl_interfaces/srv/GetParameters'),
+    ('list_parameters', 'rcl_interfaces/srv/ListParameters'),
+    ('set_parameters', 'rcl_interfaces/srv/SetParameters'),
+    ('set_parameters_atomically', 'rcl_interfaces/srv/SetParametersAtomically'),
+    ('get_type_description', 'type_description_interfaces/srv/GetTypeDescription'),
+}
+_HIDDEN_PARAMETERS = {'use_sim_time', 'start_type_description_service'}
+
+
+def name_tail(name: str) -> str:
+    return name.rsplit('/', 1)[-1]
+
+
+def is_hidden_publisher(name: str, type: str) -> bool:
+    return (name_tail(name), type) in _HIDDEN_PUBLISHERS
+
+
+def is_hidden_subscription(name: str, type: str) -> bool:
+    return (name_tail(name), type) in _HIDDEN_SUBSCRIPTIONS
+
+
+def is_hidden_service(name: str, type: str) -> bool:
+    return (name_tail(name), type) in _HIDDEN_SERVICES
+
+
+def is_hidden_parameter(name: str) -> bool:
+    return name in _HIDDEN_PARAMETERS or name.startswith('qos_overrides.')
+
+
+def _build_endpoint(model, gaps: Optional[list], path: str, **fields):
+    try:
+        return model(**fields)
+    except Exception as exc:
+        reported = False
+        for error in getattr(exc, 'errors', lambda: [])():
+            field = error.get('loc', ('endpoint',))[0]
+            if field in ('name', 'type'):
+                _record(gaps, f'{path}.{field}', error.get('msg', 'invalid value'))
+                reported = True
+        if not reported:
+            _record(gaps, path, str(exc))
+        return model.construct(**fields)
+
+
+def topic_endpoint(topic, gaps: Optional[list] = None, path: str = '') -> TopicEndpoint:
+    return _build_endpoint(
+        TopicEndpoint,
+        gaps,
+        path,
+        name=getattr(topic, 'name', ''),
+        type=getattr(getattr(topic, 'type', None), 'name', ''),
+        qos=to_qos_profile(getattr(topic, 'qos', None), gaps, f'{path}.qos'),
+    )
+
+
+def service_endpoint(service, gaps: Optional[list] = None, path: str = '') -> ServiceEndpoint:
+    return _build_endpoint(
+        ServiceEndpoint,
+        gaps,
+        path,
+        name=getattr(service, 'name', ''),
+        type=getattr(getattr(service, 'request_type', None), 'name', ''),
+        qos=None,
+    )
+
+
+def action_endpoint(action, gaps: Optional[list] = None, path: str = '') -> ActionEndpoint:
+    send_goal = getattr(getattr(getattr(action, 'send_goal', None), 'request_type', None), 'name', '')
+    get_result = getattr(getattr(getattr(action, 'get_result', None), 'request_type', None), 'name', '')
+    action_type = send_goal or get_result
+    for candidate, suffix in ((send_goal, '_SendGoal'), (get_result, '_GetResult')):
+        if candidate and candidate.endswith(suffix) and len(candidate) > len(suffix):
+            action_type = candidate[: -len(suffix)]
+            break
+    return _build_endpoint(
+        ActionEndpoint,
+        gaps,
+        path,
+        name=getattr(action, 'name', ''),
+        type=action_type,
+    )
+
+
+# rcl_interfaces/msg/ParameterType constants.
+(
+    PARAMETER_NOT_SET,
+    PARAMETER_BOOL,
+    PARAMETER_INTEGER,
+    PARAMETER_DOUBLE,
+    PARAMETER_STRING,
+    PARAMETER_BYTE_ARRAY,
+    PARAMETER_BOOL_ARRAY,
+    PARAMETER_INTEGER_ARRAY,
+    PARAMETER_DOUBLE_ARRAY,
+    PARAMETER_STRING_ARRAY,
+) = range(10)
+
+_TYPE_MAP: dict[int, Any] = {
+    PARAMETER_BOOL: ScalarType.bool,
+    PARAMETER_INTEGER: ScalarType.int,
+    PARAMETER_DOUBLE: ScalarType.double,
+    PARAMETER_STRING: ScalarType.string,
+    PARAMETER_BYTE_ARRAY: ScalarType.none,
+    PARAMETER_BOOL_ARRAY: ArrayType.bool_array,
+    PARAMETER_INTEGER_ARRAY: ArrayType.int_array,
+    PARAMETER_DOUBLE_ARRAY: ArrayType.double_array,
+    PARAMETER_STRING_ARRAY: ArrayType.string_array,
+}
+_VALUE_FIELDS = {
+    PARAMETER_BOOL: 'bool_value',
+    PARAMETER_INTEGER: 'integer_value',
+    PARAMETER_DOUBLE: 'double_value',
+    PARAMETER_STRING: 'string_value',
+    PARAMETER_BOOL_ARRAY: 'bool_array_value',
+    PARAMETER_INTEGER_ARRAY: 'integer_array_value',
+    PARAMETER_DOUBLE_ARRAY: 'double_array_value',
+    PARAMETER_STRING_ARRAY: 'string_array_value',
+}
+_ARRAY_TYPES = {
+    PARAMETER_BOOL_ARRAY,
+    PARAMETER_INTEGER_ARRAY,
+    PARAMETER_DOUBLE_ARRAY,
+    PARAMETER_STRING_ARRAY,
+}
+
+
+def _resolved_parameter_type(descriptor, value) -> int:
+    declared = int(descriptor.type)
+    if declared == PARAMETER_NOT_SET and value is not None:
+        return int(value.type)
+    return declared
+
+
+def _parameter_value(value, resolved_type: int):
+    if value is None or int(value.type) != resolved_type:
+        return None
+    field = _VALUE_FIELDS.get(resolved_type)
+    if field is None:
+        return None
+    result = getattr(value, field)
+    return list(result) if resolved_type in _ARRAY_TYPES else result
+
+
+def _parameter_validation(descriptor) -> Optional[Validation]:
+    ranges = getattr(descriptor, 'floating_point_range', None) or getattr(descriptor, 'integer_range', None)
+    if not ranges:
+        return None
+    return Validation(bounds=[ranges[0].from_value, ranges[0].to_value])
+
+
+def parameter_definition(descriptor, value=None) -> ParameterDefinition:
+    resolved_type = _resolved_parameter_type(descriptor, value)
+    return ParameterDefinition(
+        type=_TYPE_MAP.get(resolved_type, ScalarType.none),
+        default_value=_parameter_value(value, resolved_type),
+        description=descriptor.description,
+        read_only=descriptor.read_only,
+        additional_constraints=descriptor.additional_constraints,
+        validation=_parameter_validation(descriptor),
+    )
+
+
+def _dedupe(endpoints: list) -> list:
+    seen = set()
+    result = []
+    for endpoint in endpoints:
+        key = endpoint.json(exclude_none=True)
+        if key not in seen:
+            seen.add(key)
+            result.append(endpoint)
+    return result
+
+
+def _map_endpoints(
+    items,
+    mapper,
+    gaps: list,
+    array_name: str,
+    hidden: Optional[Callable[[str, str], bool]] = None,
+    keep_hidden: bool = False,
+) -> list:
+    result = []
+    for index, item in enumerate(items or []):
+        endpoint = mapper(item, gaps, f'{array_name}[{index}]')
+        if hidden and not keep_hidden and hidden(endpoint.name, endpoint.type):
+            continue
+        result.append(endpoint)
+    return _dedupe(result)
+
+
+def _map_parameters(node, keep_hidden: bool) -> dict:
+    values = list(getattr(node, 'parameter_values', None) or [])
+    result = {}
+    for index, descriptor in enumerate(getattr(node, 'parameters', None) or []):
+        if keep_hidden or not is_hidden_parameter(descriptor.name):
+            value = values[index] if index < len(values) else None
+            result[descriptor.name] = parameter_definition(descriptor, value)
+    return result
+
+
+def convert(node, opts: Optional[DescribeOptions] = None) -> DescribeResult:
+    opts = opts or DescribeOptions()
+    gaps = []
+    mapping = {
+        'publishers': (topic_endpoint, is_hidden_publisher),
+        'subscriptions': (topic_endpoint, is_hidden_subscription),
+        'service_servers': (service_endpoint, is_hidden_service),
+        'service_clients': (service_endpoint, is_hidden_service),
+        'action_servers': (action_endpoint, None),
+        'action_clients': (action_endpoint, None),
+    }
+    fields = {
+        name: _map_endpoints(getattr(node, name, None), mapper, gaps, name, hidden, opts.keep_hidden) or None
+        for name, (mapper, hidden) in mapping.items()
+    }
+    parameters = _map_parameters(node, opts.keep_hidden) if opts.include_parameters else {}
+    doc = NodlDocument(nodl_version=2, parameters=parameters or None, **fields)
+    return DescribeResult(doc=doc, gaps=gaps)

--- a/ros2nodl/ros2nodl/verb/describe.py
+++ b/ros2nodl/ros2nodl/verb/describe.py
@@ -1,250 +1,185 @@
 # SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
 # SPDX-License-Identifier: Apache-2.0
-"""``ros2 nodl describe NODE_NAME [knobs...]`` -- observe a running node and publish its description.
-
-The observation itself is performed by the C++ ``observe`` executable (from the
-``nodl_observe`` package): the verb is a thin wrapper that shells out to it,
-receives the latched ``rosgraph_msgs/Node`` the binary publishes, and renders it.
-The serialized message is the only language boundary -- there is no in-process
-C++<->Python message conversion and no pybind build surface.
-"""
+"""``ros2 nodl describe`` command."""
 
 import argparse
 import json
 import os
-import subprocess
 import sys
-import time
 
 from ros2nodl.verb import VerbExtension
 
 _DEFAULT_TOPIC = '/nodl/observed_node'
 _DEFAULT_TIMEOUT = 5.0
 
-# How long the binary is asked to stay alive after publishing, so its latched
-# (transient_local) sample is still being served when we subscribe to render it.
-_KEEPALIVE_SEC = 3.0
-
 
 def _infer_format(path: str) -> str:
-    """Return 'yaml' or 'json' inferred from *path*'s extension.
-
-    Raises :class:`argparse.ArgumentTypeError` for any other extension so the
-    caller can surface it as an argparse-level error before ROS is initialised.
-    """
-    _, ext = os.path.splitext(path)
-    ext = ext.lower()
-    if ext in ('.yaml', '.yml'):
+    extension = os.path.splitext(path)[1].lower()
+    if extension in ('.yaml', '.yml'):
         return 'yaml'
-    if ext == '.json':
+    if extension == '.json':
         return 'json'
-    raise argparse.ArgumentTypeError(f'-o/--output: unrecognised extension "{ext}"; use .yaml, .yml, or .json')
+    raise argparse.ArgumentTypeError(f'-o/--output: unrecognised extension "{extension}"; use .yaml, .yml, or .json')
 
 
 class DescribeVerb(VerbExtension):
-    """Observe a running node and publish its description as rosgraph_msgs/Node."""
+    """Create a NoDL draft from a running or captured node."""
 
     def add_arguments(self, parser, cli_name):
+        parser.add_argument('node_name', metavar='NODE_NAME', help='Fully-qualified target node name.')
         parser.add_argument(
-            'node_name',
-            metavar='NODE_NAME',
-            help='Fully-qualified name of the target node (e.g. /my_namespace/my_node).',
+            '--from',
+            metavar='FILE',
+            dest='from_file',
+            help='Read a captured Node from YAML or MCAP instead of observing live.',
         )
         parser.add_argument(
             '--timeout',
             metavar='SEC',
             type=float,
             default=_DEFAULT_TIMEOUT,
-            help=(
-                'Maximum time in seconds to wait for discovery, parameter services, '
-                'and publish acknowledgement (default: %(default)s).'
-            ),
+            help='Live discovery timeout in seconds (default: %(default)s).',
         )
         parser.add_argument(
             '--no-params',
             action='store_true',
-            default=False,
             dest='no_params',
-            help=('Skip remote parameter service calls. Faster and zero-contact with the target node.'),
+            help='Omit parameters and skip live parameter service calls.',
         )
+        parser.add_argument(
+            '--keep-hidden',
+            action='store_true',
+            help='Keep framework-created endpoints and parameters.',
+        )
+        parser.add_argument('--strict', action='store_true', help='Fail when any field cannot be recovered.')
+        parser.add_argument('--raw', action='store_true', help='Emit the captured Node instead of NoDL.')
         parser.add_argument(
             '--topic',
             metavar='NAME',
             default=_DEFAULT_TOPIC,
-            help='Latched topic the description is published on (default: %(default)s).',
+            help='Live observation topic (default: %(default)s).',
         )
         parser.add_argument(
             '-o',
             '--output',
             metavar='FILE',
-            default=None,
-            dest='output',
-            help=(
-                'Write the description to FILE instead of stdout. '
-                'Format is inferred from the extension: .yaml/.yml or .json.'
-            ),
+            help='Write YAML or JSON, inferred from the extension.',
         )
 
     def main(self, *, args):
-        # Validate the output extension before touching ROS so the error is clean.
-        output_format = None
-        if args.output is not None:
-            try:
-                output_format = _infer_format(args.output)
-            except argparse.ArgumentTypeError as e:
-                print(str(e), file=sys.stderr)
-                return 1
-
+        try:
+            output_format = _infer_format(args.output) if args.output else 'yaml'
+        except argparse.ArgumentTypeError as exc:
+            print(exc, file=sys.stderr)
+            return 1
         return _run(
             node_name=args.node_name,
+            from_file=args.from_file,
             timeout_sec=args.timeout,
             include_parameters=not args.no_params,
+            keep_hidden=args.keep_hidden,
+            strict=args.strict,
+            raw=args.raw,
             topic=args.topic,
             output_path=args.output,
             output_format=output_format,
         )
 
 
-def _observe_binary():
-    """Return the path to the C++ ``observe`` executable, or ``None`` if absent."""
-    try:
-        from ament_index_python.packages import get_package_prefix
+def _acquire_node(*, node_name, from_file, timeout_sec, include_parameters, topic):
+    from ros2nodl.describe import _source
 
-        prefix = get_package_prefix('nodl_observe')
-    except Exception:
-        return None
-    candidate = os.path.join(prefix, 'lib', 'nodl_observe', 'observe')
-    return candidate if os.path.isfile(candidate) else None
-
-
-def _latched_qos():
-    """The QoS the ``observe`` binary latch-publishes with (reliable, transient_local, depth 1)."""
-    from rclpy.qos import (
-        DurabilityPolicy,
-        HistoryPolicy,
-        QoSProfile,
-        ReliabilityPolicy,
-    )
-
-    return QoSProfile(
-        depth=1,
-        history=HistoryPolicy.KEEP_LAST,
-        reliability=ReliabilityPolicy.RELIABLE,
-        durability=DurabilityPolicy.TRANSIENT_LOCAL,
+    if from_file:
+        return _source.acquire_from_file(from_file)
+    return _source.acquire_live(
+        node_name,
+        timeout_sec=timeout_sec,
+        include_parameters=include_parameters,
+        topic=topic,
     )
 
 
-def _to_yaml(msg) -> str:
+def _render_raw(message, output_format: str) -> str:
+    if output_format == 'json':
+        from rosidl_runtime_py.convert import message_to_ordereddict
+
+        return json.dumps(message_to_ordereddict(message), indent=2)
     from rosidl_runtime_py import message_to_yaml
 
-    return message_to_yaml(msg)
+    return message_to_yaml(message)
 
 
-def _to_json(msg) -> str:
-    from rosidl_runtime_py.convert import message_to_ordereddict
-
-    return json.dumps(message_to_ordereddict(msg), indent=2) + '\n'
+def _write(text: str, output_path) -> int:
+    text = text if text.endswith('\n') else text + '\n'
+    if output_path is None:
+        print(text, end='')
+        return 0
+    try:
+        with open(output_path, 'w') as output:
+            output.write(text)
+    except OSError as exc:
+        print(f'ros2 nodl describe: {exc}', file=sys.stderr)
+        return 1
+    return 0
 
 
 def _run(
     *,
-    node_name: str,
-    timeout_sec: float,
-    include_parameters: bool,
-    topic: str,
+    node_name,
+    from_file,
+    timeout_sec,
+    include_parameters,
+    keep_hidden,
+    strict,
+    raw,
+    topic,
     output_path,
     output_format,
 ) -> int:
-    binary = _observe_binary()
-    if binary is None:
-        print(
-            'ros2 nodl describe: the nodl_observe `observe` executable was not '
-            'found; build/install the nodl_observe package (it provides the '
-            'observation backend).',
-            file=sys.stderr,
+    from ros2nodl.describe._source import SourceError
+
+    try:
+        message = _acquire_node(
+            node_name=node_name,
+            from_file=from_file,
+            timeout_sec=timeout_sec,
+            include_parameters=include_parameters,
+            topic=topic,
         )
+    except SourceError as exc:
+        print(f'ros2 nodl describe: {exc}', file=sys.stderr)
         return 1
 
-    import rclpy
-    from rosgraph_msgs.msg import Node as NodeMsg
+    if raw:
+        return _write(_render_raw(message, output_format), output_path)
 
-    # Spawn the observer: it observes the target, latch-publishes on `topic`, and
-    # stays alive for `_KEEPALIVE_SEC` so this process can subscribe and render.
-    cmd = [
-        binary,
-        node_name,
-        '--timeout',
-        repr(float(timeout_sec)),
-        '--topic',
-        topic,
-        '--spin-seconds',
-        repr(_KEEPALIVE_SEC),
-    ]
-    if not include_parameters:
-        cmd.append('--no-parameters')
-    proc = subprocess.Popen(cmd, stderr=subprocess.PIPE, text=True)
+    from nodl_schema import validator
+    from ros2nodl.describe import DescribeOptions, node_to_nodl
 
-    # Own the rclpy lifecycle only if nobody initialised it yet (an embedding
-    # caller -- e.g. an in-process test harness -- that already called
-    # rclpy.init() keeps ownership).
     try:
-        rclpy.init()
-        owns_context = True
-    except RuntimeError:
-        owns_context = False
+        result = node_to_nodl(
+            message,
+            DescribeOptions(
+                include_parameters=include_parameters,
+                keep_hidden=keep_hidden,
+            ),
+        )
+    except Exception as exc:
+        print(f'ros2 nodl describe: failed to interpret node: {exc}', file=sys.stderr)
+        return 1
 
-    received = []
     try:
-        node = rclpy.create_node(f'_ros2nodl_describe_{os.getpid()}', start_parameter_services=False)
-        try:
-            node.create_subscription(NodeMsg, topic, lambda m: received.append(m), _latched_qos())
+        validator.validate(json.loads(result.doc.json(exclude_none=True)))
+        invalid_reason = None
+    except Exception as exc:
+        invalid_reason = str(exc)
 
-            # The binary may spend up to `timeout_sec` discovering before it
-            # publishes; wait for that plus the keepalive window plus margin.
-            deadline = time.monotonic() + timeout_sec + _KEEPALIVE_SEC + 2.0
-            while not received and time.monotonic() < deadline:
-                rclpy.spin_once(node, timeout_sec=0.1)
-                if not received and proc.poll() is not None:
-                    # The binary exited before publishing -- usually node-not-found.
-                    break
+    for gap in result.gaps:
+        print(f'ros2 nodl describe: {gap.path}: {gap.reason}', file=sys.stderr)
+    if invalid_reason:
+        print(f'ros2 nodl describe: document failed validation: {invalid_reason}', file=sys.stderr)
 
-            if not received:
-                _, err = proc.communicate(timeout=2.0)
-                if err:
-                    sys.stderr.write(err if err.endswith('\n') else err + '\n')
-                rc = proc.returncode if proc.returncode not in (None, 0) else 1
-                if rc == 1 and not err:
-                    print(
-                        f'ros2 nodl describe: timed out waiting for an observation of {node_name!r} on {topic!r}.',
-                        file=sys.stderr,
-                    )
-                return rc
-
-            msg = received[0]
-            if output_path is None:
-                print(_to_yaml(msg), end='')
-            else:
-                text = _to_json(msg) if output_format == 'json' else _to_yaml(msg)
-                try:
-                    with open(output_path, 'w') as fh:
-                        fh.write(text)
-                except OSError as e:
-                    print(f'ros2 nodl describe: {e}', file=sys.stderr)
-                    return 1
-        finally:
-            node.destroy_node()
-    finally:
-        if owns_context:
-            rclpy.shutdown()
-        # Reap the observer; it should exit on its own after the keepalive window.
-        try:
-            proc.wait(timeout=_KEEPALIVE_SEC + 2.0)
-        except subprocess.TimeoutExpired:
-            proc.terminate()
-            try:
-                proc.wait(timeout=2.0)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait()
-
-    return 0
+    write_result = _write(validator.dump_nodl(result.doc, format=output_format), output_path)
+    if write_result:
+        return write_result
+    return int(bool(strict and (result.gaps or invalid_reason)))

--- a/ros2nodl/test/describe/fixtures/base__s1_node.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/base__s1_node.nodl.yaml
@@ -1,0 +1,19 @@
+nodl_version: 2
+publishers:
+- name: /s1/chatter
+  qos:
+    depth: 10
+    durability: VOLATILE
+    history: KEEP_LAST
+    liveliness: AUTOMATIC
+    reliability: RELIABLE
+  type: std_msgs/msg/String
+subscriptions:
+- name: /s1/commands
+  qos:
+    depth: 10
+    durability: VOLATILE
+    history: KEEP_LAST
+    liveliness: AUTOMATIC
+    reliability: RELIABLE
+  type: std_msgs/msg/String

--- a/ros2nodl/test/describe/fixtures/base__s1_node.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/base__s1_node.nodl.yaml
@@ -1,19 +1,20 @@
+---
 nodl_version: 2
 publishers:
-- name: /s1/chatter
-  qos:
-    depth: 10
-    durability: VOLATILE
-    history: KEEP_LAST
-    liveliness: AUTOMATIC
-    reliability: RELIABLE
-  type: std_msgs/msg/String
+  - name: /s1/chatter
+    qos:
+      depth: 10
+      durability: VOLATILE
+      history: KEEP_LAST
+      liveliness: AUTOMATIC
+      reliability: RELIABLE
+    type: std_msgs/msg/String
 subscriptions:
-- name: /s1/commands
-  qos:
-    depth: 10
-    durability: VOLATILE
-    history: KEEP_LAST
-    liveliness: AUTOMATIC
-    reliability: RELIABLE
-  type: std_msgs/msg/String
+  - name: /s1/commands
+    qos:
+      depth: 10
+      durability: VOLATILE
+      history: KEEP_LAST
+      liveliness: AUTOMATIC
+      reliability: RELIABLE
+    type: std_msgs/msg/String

--- a/ros2nodl/test/describe/fixtures/base__s2_node.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/base__s2_node.nodl.yaml
@@ -1,9 +1,10 @@
+---
 action_clients:
-- name: /s2/compute
-  type: example_interfaces/action/Fibonacci
+  - name: /s2/compute
+    type: example_interfaces/action/Fibonacci
 action_servers:
-- name: /s2/fib
-  type: example_interfaces/action/Fibonacci
+  - name: /s2/fib
+    type: example_interfaces/action/Fibonacci
 nodl_version: 2
 parameters:
   max_count:
@@ -25,34 +26,34 @@ parameters:
     read_only: false
     type: double
 publishers:
-- name: /s2/be_pub
-  qos:
-    depth: 10
-    durability: VOLATILE
-    history: KEEP_LAST
-    liveliness: AUTOMATIC
-    reliability: BEST_EFFORT
-  type: std_msgs/msg/String
-- name: /s2/tl_pub
-  qos:
-    durability: TRANSIENT_LOCAL
-    history: KEEP_ALL
-    liveliness: AUTOMATIC
-    reliability: RELIABLE
-  type: std_msgs/msg/String
+  - name: /s2/be_pub
+    qos:
+      depth: 10
+      durability: VOLATILE
+      history: KEEP_LAST
+      liveliness: AUTOMATIC
+      reliability: BEST_EFFORT
+    type: std_msgs/msg/String
+  - name: /s2/tl_pub
+    qos:
+      durability: TRANSIENT_LOCAL
+      history: KEEP_ALL
+      liveliness: AUTOMATIC
+      reliability: RELIABLE
+    type: std_msgs/msg/String
 service_clients:
-- name: /s2/multiply
-  type: example_interfaces/srv/AddTwoInts
+  - name: /s2/multiply
+    type: example_interfaces/srv/AddTwoInts
 service_servers:
-- name: /s2/add
-  type: example_interfaces/srv/AddTwoInts
+  - name: /s2/add
+    type: example_interfaces/srv/AddTwoInts
 subscriptions:
-- name: /s2/dl_sub
-  qos:
-    deadline_ns: 2000000000
-    depth: 5
-    durability: VOLATILE
-    history: KEEP_LAST
-    liveliness: AUTOMATIC
-    reliability: RELIABLE
-  type: std_msgs/msg/String
+  - name: /s2/dl_sub
+    qos:
+      deadline_ns: 2000000000
+      depth: 5
+      durability: VOLATILE
+      history: KEEP_LAST
+      liveliness: AUTOMATIC
+      reliability: RELIABLE
+    type: std_msgs/msg/String

--- a/ros2nodl/test/describe/fixtures/base__s2_node.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/base__s2_node.nodl.yaml
@@ -1,0 +1,58 @@
+action_clients:
+- name: /s2/compute
+  type: example_interfaces/action/Fibonacci
+action_servers:
+- name: /s2/fib
+  type: example_interfaces/action/Fibonacci
+nodl_version: 2
+parameters:
+  max_count:
+    additional_constraints: ''
+    default_value: 10
+    description: ''
+    read_only: false
+    type: int
+  mode:
+    additional_constraints: ''
+    default_value: auto
+    description: operating mode
+    read_only: true
+    type: string
+  speed:
+    additional_constraints: ''
+    default_value: 1.5
+    description: ''
+    read_only: false
+    type: double
+publishers:
+- name: /s2/be_pub
+  qos:
+    depth: 10
+    durability: VOLATILE
+    history: KEEP_LAST
+    liveliness: AUTOMATIC
+    reliability: BEST_EFFORT
+  type: std_msgs/msg/String
+- name: /s2/tl_pub
+  qos:
+    durability: TRANSIENT_LOCAL
+    history: KEEP_ALL
+    liveliness: AUTOMATIC
+    reliability: RELIABLE
+  type: std_msgs/msg/String
+service_clients:
+- name: /s2/multiply
+  type: example_interfaces/srv/AddTwoInts
+service_servers:
+- name: /s2/add
+  type: example_interfaces/srv/AddTwoInts
+subscriptions:
+- name: /s2/dl_sub
+  qos:
+    deadline_ns: 2000000000
+    depth: 5
+    durability: VOLATILE
+    history: KEEP_LAST
+    liveliness: AUTOMATIC
+    reliability: RELIABLE
+  type: std_msgs/msg/String

--- a/ros2nodl/test/describe/fixtures/base__s3_node_a.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/base__s3_node_a.nodl.yaml
@@ -1,19 +1,20 @@
+---
 nodl_version: 2
 publishers:
-- name: /s3/shared
-  qos:
-    depth: 10
-    durability: VOLATILE
-    history: KEEP_LAST
-    liveliness: AUTOMATIC
-    reliability: RELIABLE
-  type: std_msgs/msg/String
+  - name: /s3/shared
+    qos:
+      depth: 10
+      durability: VOLATILE
+      history: KEEP_LAST
+      liveliness: AUTOMATIC
+      reliability: RELIABLE
+    type: std_msgs/msg/String
 subscriptions:
-- name: /s3/a_only
-  qos:
-    depth: 10
-    durability: VOLATILE
-    history: KEEP_LAST
-    liveliness: AUTOMATIC
-    reliability: RELIABLE
-  type: std_msgs/msg/String
+  - name: /s3/a_only
+    qos:
+      depth: 10
+      durability: VOLATILE
+      history: KEEP_LAST
+      liveliness: AUTOMATIC
+      reliability: RELIABLE
+    type: std_msgs/msg/String

--- a/ros2nodl/test/describe/fixtures/base__s3_node_a.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/base__s3_node_a.nodl.yaml
@@ -1,0 +1,19 @@
+nodl_version: 2
+publishers:
+- name: /s3/shared
+  qos:
+    depth: 10
+    durability: VOLATILE
+    history: KEEP_LAST
+    liveliness: AUTOMATIC
+    reliability: RELIABLE
+  type: std_msgs/msg/String
+subscriptions:
+- name: /s3/a_only
+  qos:
+    depth: 10
+    durability: VOLATILE
+    history: KEEP_LAST
+    liveliness: AUTOMATIC
+    reliability: RELIABLE
+  type: std_msgs/msg/String

--- a/ros2nodl/test/describe/fixtures/base__s3_node_b.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/base__s3_node_b.nodl.yaml
@@ -1,0 +1,16 @@
+action_servers:
+- name: /s3/b_fib
+  type: example_interfaces/action/Fibonacci
+nodl_version: 2
+service_servers:
+- name: /s3/b_add
+  type: example_interfaces/srv/AddTwoInts
+subscriptions:
+- name: /s3/shared
+  qos:
+    depth: 1
+    durability: VOLATILE
+    history: KEEP_LAST
+    liveliness: AUTOMATIC
+    reliability: BEST_EFFORT
+  type: std_msgs/msg/String

--- a/ros2nodl/test/describe/fixtures/base__s3_node_b.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/base__s3_node_b.nodl.yaml
@@ -1,16 +1,17 @@
+---
 action_servers:
-- name: /s3/b_fib
-  type: example_interfaces/action/Fibonacci
+  - name: /s3/b_fib
+    type: example_interfaces/action/Fibonacci
 nodl_version: 2
 service_servers:
-- name: /s3/b_add
-  type: example_interfaces/srv/AddTwoInts
+  - name: /s3/b_add
+    type: example_interfaces/srv/AddTwoInts
 subscriptions:
-- name: /s3/shared
-  qos:
-    depth: 1
-    durability: VOLATILE
-    history: KEEP_LAST
-    liveliness: AUTOMATIC
-    reliability: BEST_EFFORT
-  type: std_msgs/msg/String
+  - name: /s3/shared
+    qos:
+      depth: 1
+      durability: VOLATILE
+      history: KEEP_LAST
+      liveliness: AUTOMATIC
+      reliability: BEST_EFFORT
+    type: std_msgs/msg/String

--- a/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s1_node.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s1_node.nodl.yaml
@@ -1,17 +1,18 @@
+---
 nodl_version: 2
 publishers:
-- name: /s1/chatter
-  qos:
-    durability: VOLATILE
-    history: SYSTEM_DEFAULT
-    liveliness: AUTOMATIC
-    reliability: RELIABLE
-  type: std_msgs/msg/String
+  - name: /s1/chatter
+    qos:
+      durability: VOLATILE
+      history: SYSTEM_DEFAULT
+      liveliness: AUTOMATIC
+      reliability: RELIABLE
+    type: std_msgs/msg/String
 subscriptions:
-- name: /s1/commands
-  qos:
-    durability: VOLATILE
-    history: SYSTEM_DEFAULT
-    liveliness: AUTOMATIC
-    reliability: RELIABLE
-  type: std_msgs/msg/String
+  - name: /s1/commands
+    qos:
+      durability: VOLATILE
+      history: SYSTEM_DEFAULT
+      liveliness: AUTOMATIC
+      reliability: RELIABLE
+    type: std_msgs/msg/String

--- a/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s1_node.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s1_node.nodl.yaml
@@ -1,0 +1,17 @@
+nodl_version: 2
+publishers:
+- name: /s1/chatter
+  qos:
+    durability: VOLATILE
+    history: SYSTEM_DEFAULT
+    liveliness: AUTOMATIC
+    reliability: RELIABLE
+  type: std_msgs/msg/String
+subscriptions:
+- name: /s1/commands
+  qos:
+    durability: VOLATILE
+    history: SYSTEM_DEFAULT
+    liveliness: AUTOMATIC
+    reliability: RELIABLE
+  type: std_msgs/msg/String

--- a/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s2_node.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s2_node.nodl.yaml
@@ -1,9 +1,10 @@
+---
 action_clients:
-- name: /s2/compute
-  type: example_interfaces/action/Fibonacci
+  - name: /s2/compute
+    type: example_interfaces/action/Fibonacci
 action_servers:
-- name: /s2/fib
-  type: example_interfaces/action/Fibonacci
+  - name: /s2/fib
+    type: example_interfaces/action/Fibonacci
 nodl_version: 2
 parameters:
   max_count:
@@ -25,32 +26,32 @@ parameters:
     read_only: false
     type: double
 publishers:
-- name: /s2/be_pub
-  qos:
-    durability: VOLATILE
-    history: SYSTEM_DEFAULT
-    liveliness: AUTOMATIC
-    reliability: BEST_EFFORT
-  type: std_msgs/msg/String
-- name: /s2/tl_pub
-  qos:
-    durability: TRANSIENT_LOCAL
-    history: SYSTEM_DEFAULT
-    liveliness: AUTOMATIC
-    reliability: RELIABLE
-  type: std_msgs/msg/String
+  - name: /s2/be_pub
+    qos:
+      durability: VOLATILE
+      history: SYSTEM_DEFAULT
+      liveliness: AUTOMATIC
+      reliability: BEST_EFFORT
+    type: std_msgs/msg/String
+  - name: /s2/tl_pub
+    qos:
+      durability: TRANSIENT_LOCAL
+      history: SYSTEM_DEFAULT
+      liveliness: AUTOMATIC
+      reliability: RELIABLE
+    type: std_msgs/msg/String
 service_clients:
-- name: /s2/multiply
-  type: example_interfaces/srv/AddTwoInts
+  - name: /s2/multiply
+    type: example_interfaces/srv/AddTwoInts
 service_servers:
-- name: /s2/add
-  type: example_interfaces/srv/AddTwoInts
+  - name: /s2/add
+    type: example_interfaces/srv/AddTwoInts
 subscriptions:
-- name: /s2/dl_sub
-  qos:
-    deadline_ns: 2000000000
-    durability: VOLATILE
-    history: SYSTEM_DEFAULT
-    liveliness: AUTOMATIC
-    reliability: RELIABLE
-  type: std_msgs/msg/String
+  - name: /s2/dl_sub
+    qos:
+      deadline_ns: 2000000000
+      durability: VOLATILE
+      history: SYSTEM_DEFAULT
+      liveliness: AUTOMATIC
+      reliability: RELIABLE
+    type: std_msgs/msg/String

--- a/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s2_node.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s2_node.nodl.yaml
@@ -1,0 +1,56 @@
+action_clients:
+- name: /s2/compute
+  type: example_interfaces/action/Fibonacci
+action_servers:
+- name: /s2/fib
+  type: example_interfaces/action/Fibonacci
+nodl_version: 2
+parameters:
+  max_count:
+    additional_constraints: ''
+    default_value: 10
+    description: ''
+    read_only: false
+    type: int
+  mode:
+    additional_constraints: ''
+    default_value: auto
+    description: operating mode
+    read_only: true
+    type: string
+  speed:
+    additional_constraints: ''
+    default_value: 1.5
+    description: ''
+    read_only: false
+    type: double
+publishers:
+- name: /s2/be_pub
+  qos:
+    durability: VOLATILE
+    history: SYSTEM_DEFAULT
+    liveliness: AUTOMATIC
+    reliability: BEST_EFFORT
+  type: std_msgs/msg/String
+- name: /s2/tl_pub
+  qos:
+    durability: TRANSIENT_LOCAL
+    history: SYSTEM_DEFAULT
+    liveliness: AUTOMATIC
+    reliability: RELIABLE
+  type: std_msgs/msg/String
+service_clients:
+- name: /s2/multiply
+  type: example_interfaces/srv/AddTwoInts
+service_servers:
+- name: /s2/add
+  type: example_interfaces/srv/AddTwoInts
+subscriptions:
+- name: /s2/dl_sub
+  qos:
+    deadline_ns: 2000000000
+    durability: VOLATILE
+    history: SYSTEM_DEFAULT
+    liveliness: AUTOMATIC
+    reliability: RELIABLE
+  type: std_msgs/msg/String

--- a/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s3_node_a.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s3_node_a.nodl.yaml
@@ -1,0 +1,17 @@
+nodl_version: 2
+publishers:
+- name: /s3/shared
+  qos:
+    durability: VOLATILE
+    history: SYSTEM_DEFAULT
+    liveliness: AUTOMATIC
+    reliability: RELIABLE
+  type: std_msgs/msg/String
+subscriptions:
+- name: /s3/a_only
+  qos:
+    durability: VOLATILE
+    history: SYSTEM_DEFAULT
+    liveliness: AUTOMATIC
+    reliability: RELIABLE
+  type: std_msgs/msg/String

--- a/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s3_node_a.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s3_node_a.nodl.yaml
@@ -1,17 +1,18 @@
+---
 nodl_version: 2
 publishers:
-- name: /s3/shared
-  qos:
-    durability: VOLATILE
-    history: SYSTEM_DEFAULT
-    liveliness: AUTOMATIC
-    reliability: RELIABLE
-  type: std_msgs/msg/String
+  - name: /s3/shared
+    qos:
+      durability: VOLATILE
+      history: SYSTEM_DEFAULT
+      liveliness: AUTOMATIC
+      reliability: RELIABLE
+    type: std_msgs/msg/String
 subscriptions:
-- name: /s3/a_only
-  qos:
-    durability: VOLATILE
-    history: SYSTEM_DEFAULT
-    liveliness: AUTOMATIC
-    reliability: RELIABLE
-  type: std_msgs/msg/String
+  - name: /s3/a_only
+    qos:
+      durability: VOLATILE
+      history: SYSTEM_DEFAULT
+      liveliness: AUTOMATIC
+      reliability: RELIABLE
+    type: std_msgs/msg/String

--- a/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s3_node_b.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s3_node_b.nodl.yaml
@@ -1,15 +1,16 @@
+---
 action_servers:
-- name: /s3/b_fib
-  type: example_interfaces/action/Fibonacci
+  - name: /s3/b_fib
+    type: example_interfaces/action/Fibonacci
 nodl_version: 2
 service_servers:
-- name: /s3/b_add
-  type: example_interfaces/srv/AddTwoInts
+  - name: /s3/b_add
+    type: example_interfaces/srv/AddTwoInts
 subscriptions:
-- name: /s3/shared
-  qos:
-    durability: VOLATILE
-    history: SYSTEM_DEFAULT
-    liveliness: AUTOMATIC
-    reliability: BEST_EFFORT
-  type: std_msgs/msg/String
+  - name: /s3/shared
+    qos:
+      durability: VOLATILE
+      history: SYSTEM_DEFAULT
+      liveliness: AUTOMATIC
+      reliability: BEST_EFFORT
+    type: std_msgs/msg/String

--- a/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s3_node_b.nodl.yaml
+++ b/ros2nodl/test/describe/fixtures/rmw_fastrtps_cpp__s3_node_b.nodl.yaml
@@ -1,0 +1,15 @@
+action_servers:
+- name: /s3/b_fib
+  type: example_interfaces/action/Fibonacci
+nodl_version: 2
+service_servers:
+- name: /s3/b_add
+  type: example_interfaces/srv/AddTwoInts
+subscriptions:
+- name: /s3/shared
+  qos:
+    durability: VOLATILE
+    history: SYSTEM_DEFAULT
+    liveliness: AUTOMATIC
+    reliability: BEST_EFFORT
+  type: std_msgs/msg/String

--- a/ros2nodl/test/describe/stub_msgs.py
+++ b/ros2nodl/test/describe/stub_msgs.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Small duck-typed message builders for ROS-free transform tests."""
+
+from types import SimpleNamespace as NS
+
+HISTORY_SYSTEM_DEFAULT, HISTORY_KEEP_LAST, HISTORY_KEEP_ALL, HISTORY_UNKNOWN = range(4)
+(
+    RELIABILITY_SYSTEM_DEFAULT,
+    RELIABILITY_RELIABLE,
+    RELIABILITY_BEST_EFFORT,
+    RELIABILITY_UNKNOWN,
+    RELIABILITY_BEST_AVAILABLE,
+) = range(5)
+(
+    DURABILITY_SYSTEM_DEFAULT,
+    DURABILITY_TRANSIENT_LOCAL,
+    DURABILITY_VOLATILE,
+    DURABILITY_UNKNOWN,
+    DURABILITY_BEST_AVAILABLE,
+) = range(5)
+LIVELINESS_SYSTEM_DEFAULT = 0
+LIVELINESS_AUTOMATIC = 1
+LIVELINESS_MANUAL_BY_TOPIC = 3
+LIVELINESS_UNKNOWN = 4
+LIVELINESS_BEST_AVAILABLE = 5
+INT32_MAX = 2_147_483_647
+(
+    PARAMETER_NOT_SET,
+    PARAMETER_BOOL,
+    PARAMETER_INTEGER,
+    PARAMETER_DOUBLE,
+    PARAMETER_STRING,
+    PARAMETER_BYTE_ARRAY,
+    PARAMETER_BOOL_ARRAY,
+    PARAMETER_INTEGER_ARRAY,
+    PARAMETER_DOUBLE_ARRAY,
+    PARAMETER_STRING_ARRAY,
+) = range(10)
+
+
+def duration(sec=INT32_MAX, nanosec=0):
+    return NS(sec=sec, nanosec=nanosec)
+
+
+def _duration(value):
+    if value is None:
+        return duration()
+    return duration(*value) if isinstance(value, tuple) else value
+
+
+def qos(
+    history=HISTORY_SYSTEM_DEFAULT,
+    reliability=RELIABILITY_SYSTEM_DEFAULT,
+    durability=DURABILITY_SYSTEM_DEFAULT,
+    liveliness=LIVELINESS_SYSTEM_DEFAULT,
+    depth=0,
+    deadline=None,
+    lifespan=None,
+    liveliness_lease=None,
+):
+    return NS(
+        history=history,
+        reliability=reliability,
+        durability=durability,
+        liveliness=liveliness,
+        depth=depth,
+        deadline=_duration(deadline),
+        lifespan=_duration(lifespan),
+        liveliness_lease_duration=_duration(liveliness_lease),
+    )
+
+
+def interface_type(name):
+    return NS(name=name, hash=NS(version=1, value=list(range(32))))
+
+
+def topic(name, type, qos=None):
+    return NS(name=name, type=interface_type(type), qos=qos or globals()['qos']())
+
+
+def service(name, request_type, response_type=None, request_qos=None, response_qos=None):
+    unknown_qos = qos(reliability=RELIABILITY_UNKNOWN, durability=DURABILITY_UNKNOWN)
+    return NS(
+        name=name,
+        request_type=interface_type(request_type),
+        response_type=interface_type(response_type or request_type),
+        request_qos=request_qos or unknown_qos,
+        response_qos=response_qos or unknown_qos,
+    )
+
+
+def action(
+    name,
+    send_goal_type=None,
+    get_result_type=None,
+    cancel_goal_type='action_msgs/srv/CancelGoal',
+    feedback_type=None,
+    status_type='action_msgs/msg/GoalStatusArray',
+):
+    return NS(
+        name=name,
+        send_goal=service(f'{name}/_action/send_goal', send_goal_type) if send_goal_type else None,
+        get_result=service(f'{name}/_action/get_result', get_result_type) if get_result_type else None,
+        cancel_goal=service(f'{name}/_action/cancel_goal', cancel_goal_type),
+        feedback=topic(f'{name}/_action/feedback', feedback_type) if feedback_type else None,
+        status=topic(f'{name}/_action/status', status_type),
+    )
+
+
+def fp_range(from_value, to_value, step=0.0):
+    return NS(from_value=from_value, to_value=to_value, step=step)
+
+
+def int_range(from_value, to_value, step=0):
+    return NS(from_value=from_value, to_value=to_value, step=step)
+
+
+def descriptor(
+    name,
+    type,
+    description='',
+    additional_constraints='',
+    read_only=False,
+    dynamic_typing=False,
+    floating_point_range=None,
+    integer_range=None,
+):
+    return NS(
+        name=name,
+        type=type,
+        description=description,
+        additional_constraints=additional_constraints,
+        read_only=read_only,
+        dynamic_typing=dynamic_typing,
+        floating_point_range=[] if floating_point_range is None else [floating_point_range],
+        integer_range=[] if integer_range is None else [integer_range],
+    )
+
+
+def value(type, **fields):
+    defaults = {
+        'bool_value': False,
+        'integer_value': 0,
+        'double_value': 0.0,
+        'string_value': '',
+        'byte_array_value': [],
+        'bool_array_value': [],
+        'integer_array_value': [],
+        'double_array_value': [],
+        'string_array_value': [],
+    }
+    return NS(type=type, **(defaults | fields))
+
+
+def node(name='/n', **arrays):
+    fields = {
+        key: list(arrays.get(key, ()))
+        for key in (
+            'publishers',
+            'subscriptions',
+            'service_servers',
+            'service_clients',
+            'action_servers',
+            'action_clients',
+            'parameters',
+            'parameter_values',
+        )
+    }
+    return NS(name=name, **fields)

--- a/ros2nodl/test/describe/test_describe_convert.py
+++ b/ros2nodl/test/describe/test_describe_convert.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import stub_msgs
+
+from nodl_schema.validator import validate
+from ros2nodl.describe import DescribeOptions, node_to_nodl
+
+
+def _qos():
+    return stub_msgs.qos(
+        history=stub_msgs.HISTORY_KEEP_LAST,
+        reliability=stub_msgs.RELIABILITY_RELIABLE,
+        durability=stub_msgs.DURABILITY_VOLATILE,
+        depth=10,
+    )
+
+
+def _node():
+    return stub_msgs.node(
+        name='/robot/controller',
+        publishers=[
+            stub_msgs.topic('/state', 'std_msgs/msg/String', _qos()),
+            stub_msgs.topic('/rosout', 'rcl_interfaces/msg/Log', _qos()),
+        ],
+        subscriptions=[stub_msgs.topic('/command', 'std_msgs/msg/String', _qos())],
+        service_servers=[stub_msgs.service('/reset', 'std_srvs/srv/Empty')],
+        service_clients=[stub_msgs.service('/calibrate', 'std_srvs/srv/Trigger')],
+        action_servers=[
+            stub_msgs.action(
+                '/move',
+                send_goal_type='example_interfaces/action/Fibonacci_SendGoal',
+            )
+        ],
+        parameters=[
+            stub_msgs.descriptor('speed', stub_msgs.PARAMETER_DOUBLE),
+            stub_msgs.descriptor('use_sim_time', stub_msgs.PARAMETER_BOOL),
+        ],
+        parameter_values=[
+            stub_msgs.value(stub_msgs.PARAMETER_DOUBLE, double_value=1.5),
+            stub_msgs.value(stub_msgs.PARAMETER_BOOL, bool_value=False),
+        ],
+    )
+
+
+def _data(result):
+    return json.loads(result.doc.json(exclude_none=True))
+
+
+def test_minimal_node_only_has_schema_version():
+    assert _data(node_to_nodl(stub_msgs.node())) == {'nodl_version': 2}
+
+
+def test_complete_node_maps_filters_and_validates():
+    result = node_to_nodl(_node())
+    data = _data(result)
+    validate(data)
+
+    assert result.gaps == []
+    assert 'name' not in data
+    assert [endpoint['name'] for endpoint in data['publishers']] == ['/state']
+    assert data['subscriptions'][0]['name'] == '/command'
+    assert data['service_servers'][0]['type'] == 'std_srvs/srv/Empty'
+    assert data['service_clients'][0]['type'] == 'std_srvs/srv/Trigger'
+    assert data['action_servers'][0]['type'] == 'example_interfaces/action/Fibonacci'
+    assert data['parameters']['speed']['default_value'] == 1.5
+    assert 'use_sim_time' not in data['parameters']
+
+
+def test_options_control_parameters_and_filtering():
+    without_parameters = _data(node_to_nodl(_node(), DescribeOptions(include_parameters=False)))
+    with_hidden = _data(node_to_nodl(_node(), DescribeOptions(keep_hidden=True)))
+    assert 'parameters' not in without_parameters
+    assert '/rosout' in [endpoint['name'] for endpoint in with_hidden['publishers']]
+    assert 'use_sim_time' in with_hidden['parameters']
+
+
+def test_identical_endpoints_are_deduplicated():
+    topic = stub_msgs.topic('/state', 'std_msgs/msg/String', _qos())
+    data = _data(node_to_nodl(stub_msgs.node(publishers=[topic, topic])))
+    assert len(data['publishers']) == 1

--- a/ros2nodl/test/describe/test_describe_endpoints.py
+++ b/ros2nodl/test/describe/test_describe_endpoints.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import stub_msgs
+
+from ros2nodl.describe._transform import action_endpoint, service_endpoint, topic_endpoint
+
+
+def test_topic_maps_name_type_and_qos():
+    endpoint = topic_endpoint(
+        stub_msgs.topic(
+            '/scan',
+            'sensor_msgs/msg/LaserScan',
+            stub_msgs.qos(history=stub_msgs.HISTORY_KEEP_LAST, depth=10),
+        )
+    )
+    assert endpoint.name == '/scan'
+    assert endpoint.type == 'sensor_msgs/msg/LaserScan'
+    assert endpoint.qos.depth == 10
+    assert 'hash' not in endpoint.dict()
+
+
+def test_service_uses_request_type_and_omits_qos():
+    endpoint = service_endpoint(stub_msgs.service('/reset', 'std_srvs/srv/Empty'))
+    assert endpoint.type == 'std_srvs/srv/Empty'
+    assert endpoint.qos is None
+
+
+@pytest.mark.parametrize(
+    'kwargs',
+    [
+        {'send_goal_type': 'example_interfaces/action/Fibonacci_SendGoal'},
+        {'get_result_type': 'example_interfaces/action/Fibonacci_GetResult'},
+        {'send_goal_type': 'example_interfaces/action/Fibonacci'},
+    ],
+)
+def test_action_type_recovery(kwargs):
+    endpoint = action_endpoint(stub_msgs.action('/fibonacci', **kwargs))
+    assert endpoint.type == 'example_interfaces/action/Fibonacci'
+
+
+def test_missing_action_type_becomes_a_gap():
+    gaps = []
+    endpoint = action_endpoint(stub_msgs.action('/fibonacci'), gaps, 'action_servers[0]')
+    assert endpoint.type == ''
+    assert gaps[0].path == 'action_servers[0].type'
+
+
+@pytest.mark.parametrize(
+    'mapper,message',
+    [
+        (topic_endpoint, stub_msgs.topic('/scan', '')),
+        (service_endpoint, stub_msgs.service('/reset', '')),
+    ],
+)
+def test_invalid_endpoint_type_becomes_a_gap(mapper, message):
+    gaps = []
+    mapper(message, gaps, 'endpoints[0]')
+    assert gaps[0].path == 'endpoints[0].type'

--- a/ros2nodl/test/describe/test_describe_filter.py
+++ b/ros2nodl/test/describe/test_describe_filter.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from ros2nodl.describe._transform import (
+    is_hidden_parameter,
+    is_hidden_publisher,
+    is_hidden_service,
+    is_hidden_subscription,
+)
+
+
+@pytest.mark.parametrize(
+    'predicate,name,type',
+    [
+        (is_hidden_publisher, '/rosout', 'rcl_interfaces/msg/Log'),
+        (is_hidden_publisher, '/parameter_events', 'rcl_interfaces/msg/ParameterEvent'),
+        (is_hidden_subscription, '/parameter_events', 'rcl_interfaces/msg/ParameterEvent'),
+        (is_hidden_service, '/n/get_parameters', 'rcl_interfaces/srv/GetParameters'),
+        (is_hidden_service, '/n/set_parameters', 'rcl_interfaces/srv/SetParameters'),
+        (
+            is_hidden_service,
+            '/n/get_type_description',
+            'type_description_interfaces/srv/GetTypeDescription',
+        ),
+    ],
+)
+def test_framework_endpoints_are_hidden(predicate, name, type):
+    assert predicate(name, type)
+    assert not predicate(name, 'example_interfaces/msg/Other')
+
+
+@pytest.mark.parametrize(
+    'name,hidden',
+    [
+        ('use_sim_time', True),
+        ('start_type_description_service', True),
+        ('qos_overrides./scan.publisher.depth', True),
+        ('user_parameter', False),
+    ],
+)
+def test_framework_parameters(name, hidden):
+    assert is_hidden_parameter(name) is hidden

--- a/ros2nodl/test/describe/test_describe_fixtures.py
+++ b/ros2nodl/test/describe/test_describe_fixtures.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Run the transform over every real observe MCAP fixture."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip('rclpy')
+pytest.importorskip('mcap')
+pytest.importorskip('rosgraph_msgs')
+
+from nodl_schema.validator import validate  # noqa: E402
+from ros2nodl.describe import node_to_nodl  # noqa: E402
+
+_FIXTURES = Path(__file__).parents[3] / 'nodl_observe' / 'test' / 'fixtures'
+sys.path.insert(0, str(_FIXTURES.parent))
+
+import mcap_fixtures  # noqa: E402
+
+
+@pytest.mark.parametrize('fixture', sorted(_FIXTURES.glob('*.mcap')), ids=lambda path: path.stem)
+def test_observe_fixture_converts_to_valid_nodl(fixture):
+    for channel, node in mcap_fixtures.read_fixture(str(fixture)).items():
+        result = node_to_nodl(node)
+        data = json.loads(result.doc.json(exclude_none=True))
+        validate(data)
+        assert not [gap for gap in result.gaps if gap.path.endswith(('.name', '.type'))], (
+            fixture.name,
+            channel,
+            result.gaps,
+        )
+
+        endpoints = [
+            endpoint
+            for key in (
+                'publishers',
+                'subscriptions',
+                'service_servers',
+                'service_clients',
+                'action_servers',
+                'action_clients',
+            )
+            for endpoint in data.get(key, [])
+        ]
+        assert all(endpoint.get('name') and endpoint.get('type') for endpoint in endpoints)
+        names = {endpoint['name'] for endpoint in endpoints}
+        assert '/rosout' not in names
+        assert '/parameter_events' not in names
+        assert not any('/_action/' in name for name in names)
+        assert 'use_sim_time' not in data.get('parameters', {})

--- a/ros2nodl/test/describe/test_describe_fixtures.py
+++ b/ros2nodl/test/describe/test_describe_fixtures.py
@@ -1,53 +1,41 @@
 # SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
 # SPDX-License-Identifier: Apache-2.0
-"""Run the transform over every real observe MCAP fixture."""
+"""Compare every real observe MCAP fixture with its expected NoDL document."""
 
 import json
 import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
-pytest.importorskip('rclpy')
-pytest.importorskip('mcap')
-pytest.importorskip('rosgraph_msgs')
-
-from nodl_schema.validator import validate  # noqa: E402
-from ros2nodl.describe import node_to_nodl  # noqa: E402
+from nodl_schema.validator import validate
+from ros2nodl.describe import node_to_nodl
 
 _FIXTURES = Path(__file__).parents[3] / 'nodl_observe' / 'test' / 'fixtures'
-sys.path.insert(0, str(_FIXTURES.parent))
+_GOLDENS = Path(__file__).parent / 'fixtures'
 
-import mcap_fixtures  # noqa: E402
+
+def test_golden_documents_are_valid_nodl():
+    for golden in _GOLDENS.glob('*.nodl.yaml'):
+        validate(yaml.safe_load(golden.read_text()))
 
 
 @pytest.mark.parametrize('fixture', sorted(_FIXTURES.glob('*.mcap')), ids=lambda path: path.stem)
 def test_observe_fixture_converts_to_valid_nodl(fixture):
+    pytest.importorskip('rclpy')
+    pytest.importorskip('mcap')
+    pytest.importorskip('rosgraph_msgs')
+    sys.path.insert(0, str(_FIXTURES.parent))
+    import mcap_fixtures
+
     for channel, node in mcap_fixtures.read_fixture(str(fixture)).items():
         result = node_to_nodl(node)
-        data = json.loads(result.doc.json(exclude_none=True))
-        validate(data)
-        assert not [gap for gap in result.gaps if gap.path.endswith(('.name', '.type'))], (
-            fixture.name,
-            channel,
-            result.gaps,
-        )
+        actual = json.loads(result.doc.json(exclude_none=True))
+        profile = 'rmw_fastrtps_cpp' if 'rmw_fastrtps_cpp' in fixture.stem else 'base'
+        golden = _GOLDENS / f'{profile}__{channel}.nodl.yaml'
+        expected = yaml.safe_load(golden.read_text())
 
-        endpoints = [
-            endpoint
-            for key in (
-                'publishers',
-                'subscriptions',
-                'service_servers',
-                'service_clients',
-                'action_servers',
-                'action_clients',
-            )
-            for endpoint in data.get(key, [])
-        ]
-        assert all(endpoint.get('name') and endpoint.get('type') for endpoint in endpoints)
-        names = {endpoint['name'] for endpoint in endpoints}
-        assert '/rosout' not in names
-        assert '/parameter_events' not in names
-        assert not any('/_action/' in name for name in names)
-        assert 'use_sim_time' not in data.get('parameters', {})
+        validate(actual)
+        assert result.gaps == []
+        assert actual == expected

--- a/ros2nodl/test/describe/test_describe_parameters.py
+++ b/ros2nodl/test/describe/test_describe_parameters.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import stub_msgs
+
+from nodl_schema.models import ArrayType, ScalarType
+from ros2nodl.describe._transform import parameter_definition
+
+
+@pytest.mark.parametrize(
+    'source,expected',
+    [
+        (stub_msgs.PARAMETER_NOT_SET, ScalarType.none),
+        (stub_msgs.PARAMETER_BOOL, ScalarType.bool),
+        (stub_msgs.PARAMETER_INTEGER, ScalarType.int),
+        (stub_msgs.PARAMETER_DOUBLE, ScalarType.double),
+        (stub_msgs.PARAMETER_STRING, ScalarType.string),
+        (stub_msgs.PARAMETER_BYTE_ARRAY, ScalarType.none),
+        (stub_msgs.PARAMETER_BOOL_ARRAY, ArrayType.bool_array),
+        (stub_msgs.PARAMETER_INTEGER_ARRAY, ArrayType.int_array),
+        (stub_msgs.PARAMETER_DOUBLE_ARRAY, ArrayType.double_array),
+        (stub_msgs.PARAMETER_STRING_ARRAY, ArrayType.string_array),
+    ],
+)
+def test_parameter_type_mapping(source, expected):
+    assert parameter_definition(stub_msgs.descriptor('p', source)).type is expected
+
+
+@pytest.mark.parametrize(
+    'type,field,value',
+    [
+        (stub_msgs.PARAMETER_BOOL, 'bool_value', True),
+        (stub_msgs.PARAMETER_INTEGER, 'integer_value', 42),
+        (stub_msgs.PARAMETER_DOUBLE, 'double_value', 1.5),
+        (stub_msgs.PARAMETER_STRING, 'string_value', 'hello'),
+        (stub_msgs.PARAMETER_INTEGER_ARRAY, 'integer_array_value', [1, 2]),
+        (stub_msgs.PARAMETER_STRING_ARRAY, 'string_array_value', ['a', 'b']),
+    ],
+)
+def test_default_value_mapping(type, field, value):
+    definition = parameter_definition(
+        stub_msgs.descriptor('p', type),
+        stub_msgs.value(type, **{field: value}),
+    )
+    assert definition.default_value == value
+
+
+def test_not_set_descriptor_uses_value_type():
+    definition = parameter_definition(
+        stub_msgs.descriptor('p', stub_msgs.PARAMETER_NOT_SET),
+        stub_msgs.value(stub_msgs.PARAMETER_INTEGER, integer_value=7),
+    )
+    assert definition.type is ScalarType.int
+    assert definition.default_value == 7
+
+
+def test_mismatched_value_is_omitted():
+    definition = parameter_definition(
+        stub_msgs.descriptor('p', stub_msgs.PARAMETER_STRING),
+        stub_msgs.value(stub_msgs.PARAMETER_INTEGER, integer_value=7),
+    )
+    assert definition.default_value is None
+
+
+@pytest.mark.parametrize(
+    'range_field,range_value',
+    [
+        ('floating_point_range', stub_msgs.fp_range(0.5, 2.5)),
+        ('integer_range', stub_msgs.int_range(1, 5)),
+    ],
+)
+def test_range_and_metadata(range_field, range_value):
+    definition = parameter_definition(
+        stub_msgs.descriptor(
+            'p',
+            stub_msgs.PARAMETER_DOUBLE,
+            description='speed',
+            additional_constraints='positive',
+            read_only=True,
+            **{range_field: range_value},
+        )
+    )
+    assert definition.validation.bounds == [range_value.from_value, range_value.to_value]
+    assert definition.description == 'speed'
+    assert definition.additional_constraints == 'positive'
+    assert definition.read_only is True

--- a/ros2nodl/test/describe/test_describe_qos.py
+++ b/ros2nodl/test/describe/test_describe_qos.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import stub_msgs
+
+from nodl_schema.models import Durability, History, Liveliness, Reliability
+from ros2nodl.describe._transform import to_qos_profile
+
+
+@pytest.mark.parametrize(
+    'field,value,expected',
+    [
+        ('history', stub_msgs.HISTORY_KEEP_LAST, History.KEEP_LAST),
+        ('history', stub_msgs.HISTORY_KEEP_ALL, History.KEEP_ALL),
+        ('reliability', stub_msgs.RELIABILITY_RELIABLE, Reliability.RELIABLE),
+        ('reliability', stub_msgs.RELIABILITY_BEST_EFFORT, Reliability.BEST_EFFORT),
+        ('reliability', stub_msgs.RELIABILITY_BEST_AVAILABLE, Reliability.BEST_AVAILABLE),
+        ('durability', stub_msgs.DURABILITY_TRANSIENT_LOCAL, Durability.TRANSIENT_LOCAL),
+        ('durability', stub_msgs.DURABILITY_VOLATILE, Durability.VOLATILE),
+        ('durability', stub_msgs.DURABILITY_BEST_AVAILABLE, Durability.BEST_AVAILABLE),
+        ('liveliness', stub_msgs.LIVELINESS_AUTOMATIC, Liveliness.AUTOMATIC),
+        ('liveliness', stub_msgs.LIVELINESS_MANUAL_BY_TOPIC, Liveliness.MANUAL_BY_TOPIC),
+        ('liveliness', stub_msgs.LIVELINESS_BEST_AVAILABLE, Liveliness.BEST_AVAILABLE),
+    ],
+)
+def test_policy_mapping(field, value, expected):
+    output = to_qos_profile(stub_msgs.qos(**{field: value}, depth=1))
+    assert getattr(output, field) is expected
+
+
+def test_unknown_policy_handling():
+    output = to_qos_profile(
+        stub_msgs.qos(
+            history=stub_msgs.HISTORY_UNKNOWN,
+            reliability=stub_msgs.RELIABILITY_UNKNOWN,
+            durability=stub_msgs.DURABILITY_UNKNOWN,
+            liveliness=stub_msgs.LIVELINESS_UNKNOWN,
+        )
+    )
+    assert output.history is History.SYSTEM_DEFAULT
+    assert output.reliability is Reliability.SYSTEM_DEFAULT
+    assert output.durability is None
+    assert output.liveliness is None
+
+
+def test_invalid_required_policy_records_gap():
+    gaps = []
+    output = to_qos_profile(stub_msgs.qos(history=99, reliability=99), gaps, 'publishers[0].qos')
+    assert output.history is History.SYSTEM_DEFAULT
+    assert output.reliability is Reliability.SYSTEM_DEFAULT
+    assert [gap.path for gap in gaps] == [
+        'publishers[0].qos.history',
+        'publishers[0].qos.reliability',
+    ]
+
+
+def test_depth_only_applies_to_keep_last():
+    assert to_qos_profile(stub_msgs.qos(history=stub_msgs.HISTORY_KEEP_LAST, depth=7)).depth == 7
+    assert to_qos_profile(stub_msgs.qos(history=stub_msgs.HISTORY_KEEP_ALL, depth=7)).depth is None
+
+
+def test_invalid_keep_last_depth_records_gap():
+    gaps = []
+    output = to_qos_profile(stub_msgs.qos(history=stub_msgs.HISTORY_KEEP_LAST), gaps, 'qos')
+    assert output.depth is None
+    assert gaps[0].path == 'qos.depth'
+
+
+def test_duration_conversion_and_omission():
+    output = to_qos_profile(
+        stub_msgs.qos(
+            deadline=(1, 500_000_000),
+            lifespan=(0, 0),
+            liveliness_lease=(stub_msgs.INT32_MAX, 0),
+        )
+    )
+    assert output.deadline_ns == 1_500_000_000
+    assert output.lifespan_ns is None
+    assert output.liveliness_lease_duration_ns is None

--- a/ros2nodl/test/test_describe_verb.py
+++ b/ros2nodl/test/test_describe_verb.py
@@ -1,86 +1,103 @@
 # SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
 # SPDX-License-Identifier: Apache-2.0
-"""CLI smoke tests for the ``ros2 nodl describe`` verb.
-
-The verb shells out to the C++ ``observe`` executable (from ``nodl_observe``),
-subscribes to the latched ``rosgraph_msgs/Node`` it publishes, and renders it.
-The smoke tests below therefore require a live ROS environment *and* the built
-``observe`` binary; they skip automatically where either is absent (e.g. the
-macOS dev machine).  The third-party "latched publish reaches a late subscriber"
-semantics belong to the binary and are covered by ``nodl_observe``'s own
-integration test -- here we test the verb's own responsibilities: it drives the
-binary, renders YAML/JSON, relays exit codes, and honours its flags.
-
-Design notes:
-
-- Tests drive the verb through its Python API (:meth:`DescribeVerb.main`) to
-  stay consistent with ``test_verbs.py``'s style.
-- A lightweight target node is spun up *in-process* in an isolated ROS domain
-  to avoid interference with stray nodes on the machine.
-- Each test shares one :mod:`rclpy` init/shutdown via the ``ros_context``
-  fixture; the verb detects the already-initialised context and does not own it.
-"""
 
 import argparse
 import json
 import os
+import threading
 
 import pytest
+import yaml
 
-# Guard: skip the whole module if the ROS stack is absent.  (nodl_observe is now
-# a C++ package -- it is NOT importable as Python, so we must not importorskip it;
-# the smoke tests instead gate on the built `observe` binary below.)
+pytest.importorskip('ros2cli')
 rclpy = pytest.importorskip('rclpy')
-pytest.importorskip('rosgraph_msgs')
 
-import yaml  # noqa: E402
-from rclpy.qos import ReliabilityPolicy  # noqa: E402
+from nodl_schema.validator import validate  # noqa: E402
+from ros2nodl.describe._source import observe_binary  # noqa: E402
+from ros2nodl.verb.describe import DescribeVerb, _infer_format  # noqa: E402
 
-from ros2nodl.verb.describe import DescribeVerb, _infer_format, _observe_binary  # noqa: E402
-
-# Live observation requires Iron+ (REP-2011 type hashes / int32-safe QoS
-# durations); pre-Iron distros (Humble) are a tracked follow-up.  The
-# pure-argument tests below still run everywhere; only the smoke tests that
-# actually observe a node are gated.  BEST_AVAILABLE presence is the Iron+ proxy.
-_IRON_PLUS = hasattr(ReliabilityPolicy, 'BEST_AVAILABLE')
-
-# The smoke tests need the built `observe` executable on the install space.
-_BINARY = _observe_binary()
-_SMOKE_OK = _IRON_PLUS and _BINARY is not None
-_SMOKE_REASON = (
-    'live observation requires Iron+' if not _IRON_PLUS else 'the nodl_observe `observe` binary is not built/installed'
-)
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-_DOMAIN_ID = int(os.environ.get('ROS_DOMAIN_ID', '42'))
 _TARGET_NODE = '/ros2nodl_test_target'
 
 
-def _make_args(**kwargs):
-    """Build a minimal :class:`argparse.Namespace` for :meth:`DescribeVerb.main`."""
-    defaults = dict(
-        node_name=_TARGET_NODE,
-        timeout=5.0,
-        no_params=False,
-        topic='/nodl/observed_node_test',
-        output=None,
-    )
-    defaults.update(kwargs)
-    return argparse.Namespace(**defaults)
+def _args(**overrides):
+    values = {
+        'node_name': _TARGET_NODE,
+        'from_file': None,
+        'timeout': 5.0,
+        'no_params': False,
+        'keep_hidden': False,
+        'strict': False,
+        'raw': False,
+        'topic': '/nodl/observed_node_test',
+        'output': None,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    'path,format',
+    [('out.yaml', 'yaml'), ('out.yml', 'yaml'), ('out.json', 'json'), ('OUT.YAML', 'yaml')],
+)
+def test_infer_format(path, format):
+    assert _infer_format(path) == format
+
+
+def test_invalid_output_extension_fails(capsys):
+    assert DescribeVerb().main(args=_args(output='out.txt')) == 1
+    assert 'unrecognised extension' in capsys.readouterr().err
+
+
+def test_missing_capture_fails_cleanly(capsys):
+    assert DescribeVerb().main(args=_args(from_file='/no/such/capture.yaml')) == 1
+    assert 'file not found' in capsys.readouterr().err
+
+
+@pytest.fixture()
+def captured_node(tmp_path):
+    from rosgraph_msgs.msg import Node, Topic
+    from rosidl_runtime_py import message_to_yaml
+
+    message = Node()
+    message.name = _TARGET_NODE
+    endpoint = Topic()
+    endpoint.name = '/chatter'
+    endpoint.type.name = 'std_msgs/msg/String'
+    endpoint.qos.history = 1
+    endpoint.qos.reliability = 1
+    endpoint.qos.durability = 2
+    endpoint.qos.depth = 10
+    message.publishers.append(endpoint)
+    path = tmp_path / 'capture.yaml'
+    path.write_text(message_to_yaml(message))
+    return path
+
+
+def test_from_yaml_emits_valid_nodl(captured_node, capsys):
+    assert DescribeVerb().main(args=_args(from_file=str(captured_node))) == 0
+    data = yaml.safe_load(capsys.readouterr().out)
+    validate(data)
+    assert data['nodl_version'] == 2
+    assert data['publishers'][0]['name'] == '/chatter'
+    assert 'name' not in data
+
+
+def test_from_yaml_can_emit_raw_message(captured_node, capsys):
+    assert DescribeVerb().main(args=_args(from_file=str(captured_node), raw=True)) == 0
+    data = yaml.safe_load(capsys.readouterr().out)
+    assert data['name'] == _TARGET_NODE
+    assert 'nodl_version' not in data
+
+
+def test_from_yaml_writes_json(captured_node, tmp_path):
+    output = tmp_path / 'description.json'
+    assert DescribeVerb().main(args=_args(from_file=str(captured_node), output=str(output))) == 0
+    assert json.loads(output.read_text())['nodl_version'] == 2
 
 
 @pytest.fixture(scope='module')
 def ros_context():
-    """Module-scoped rclpy init/shutdown in an isolated, test-only ROS domain."""
-    os.environ.setdefault('ROS_DOMAIN_ID', str(_DOMAIN_ID))
+    os.environ.setdefault('ROS_DOMAIN_ID', '42')
     os.environ.setdefault('ROS_AUTOMATIC_DISCOVERY_RANGE', 'LOCALHOST')
     rclpy.init()
     yield
@@ -89,152 +106,25 @@ def ros_context():
 
 @pytest.fixture()
 def target_node(ros_context):
-    """A live rclpy node that acts as the observation target.
-
-    Spun on a background executor so the binary (a separate process) discovers
-    it and its endpoints over DDS.
-    """
-    import threading
-
-    import std_msgs.msg  # present in any standard ROS 2 install
     from rclpy.executors import SingleThreadedExecutor
+    from std_msgs.msg import String
 
     node = rclpy.create_node(_TARGET_NODE.lstrip('/'))
-    node.create_publisher(std_msgs.msg.String, '/test_topic', 10)
-    node.create_subscription(std_msgs.msg.String, '/test_topic', lambda _: None, 10)
-
+    node.create_publisher(String, '/test_topic', 10)
+    node.create_subscription(String, '/test_topic', lambda _: None, 10)
     executor = SingleThreadedExecutor()
     executor.add_node(node)
     thread = threading.Thread(target=executor.spin, daemon=True)
     thread.start()
-    try:
-        yield node
-    finally:
-        executor.shutdown()
-        thread.join(timeout=3.0)
-        node.destroy_node()
+    yield
+    executor.shutdown()
+    thread.join(timeout=3.0)
+    node.destroy_node()
 
 
-# ---------------------------------------------------------------------------
-# Pure-Python (no ROS) tests — run anywhere
-# ---------------------------------------------------------------------------
-
-
-class TestInferFormat:
-    def test_yaml_extension(self):
-        assert _infer_format('out.yaml') == 'yaml'
-
-    def test_yml_extension(self):
-        assert _infer_format('out.yml') == 'yaml'
-
-    def test_json_extension(self):
-        assert _infer_format('out.json') == 'json'
-
-    def test_uppercase_extension(self):
-        assert _infer_format('OUT.YAML') == 'yaml'
-
-    def test_unknown_extension_raises(self):
-        import argparse as _ap
-
-        with pytest.raises(_ap.ArgumentTypeError, match='unrecognised extension'):
-            _infer_format('out.txt')
-
-    def test_no_extension_raises(self):
-        import argparse as _ap
-
-        with pytest.raises(_ap.ArgumentTypeError):
-            _infer_format('noextension')
-
-
-class TestDescribeVerbBadArgs:
-    """Tests that do not require a live ROS environment."""
-
-    def test_unknown_output_extension_returns_1(self, capsys):
-        verb = DescribeVerb()
-        args = _make_args(output='out.txt')
-        rc = verb.main(args=args)
-        assert rc == 1
-        assert 'unrecognised extension' in capsys.readouterr().err
-
-    def test_unknown_output_extension_no_ros_started(self, capsys):
-        """Verify the extension check happens *before* any ROS work."""
-        verb = DescribeVerb()
-        args = _make_args(output='out.png')
-        rc = verb.main(args=args)
-        assert rc == 1
-
-
-# ---------------------------------------------------------------------------
-# ROS smoke tests — require rclpy + the observe binary + a running target node
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.skipif(not _SMOKE_OK, reason=_SMOKE_REASON)
-class TestDescribeVerbSmoke:
-    def test_exit_code_zero(self, target_node):
-        """Verb exits 0 when the target node is present."""
-        verb = DescribeVerb()
-        rc = verb.main(args=_make_args())
-        assert rc == 0
-
-    def test_stdout_is_valid_yaml_with_node_name(self, target_node, capsys):
-        """Default output (no -o) is YAML that contains the target node's FQN."""
-        verb = DescribeVerb()
-        verb.main(args=_make_args())
-        out = capsys.readouterr().out
-        doc = yaml.safe_load(out)
-        assert doc is not None, 'stdout did not parse as YAML'
-        # rosgraph_msgs/Node has a 'name' field at the top level.
-        assert 'name' in doc, f'YAML output missing "name" field: {doc!r}'
-        assert _TARGET_NODE in doc['name'], f'Expected {_TARGET_NODE!r} in name field, got {doc["name"]!r}'
-
-    def test_output_json_is_valid(self, target_node, tmp_path):
-        """``-o foo.json`` writes parseable JSON."""
-        out_file = tmp_path / 'obs.json'
-        verb = DescribeVerb()
-        rc = verb.main(args=_make_args(output=str(out_file)))
-        assert rc == 0
-        assert out_file.exists(), '-o did not create the output file'
-        data = json.loads(out_file.read_text())
-        assert isinstance(data, dict), 'JSON output is not an object'
-        assert 'name' in data
-
-    def test_output_yaml_matches_stdout(self, target_node, tmp_path, capsys):
-        """``-o foo.yaml`` and stdout (no -o) produce the same bytes."""
-        verb = DescribeVerb()
-        verb.main(args=_make_args())
-        stdout_text = capsys.readouterr().out
-
-        out_file = tmp_path / 'obs.yaml'
-        verb.main(args=_make_args(output=str(out_file)))
-
-        assert out_file.read_text() == stdout_text, '-o .yaml output differs from stdout'
-
-    def test_custom_topic_used(self, target_node):
-        """``--topic`` overrides the publish destination.
-
-        The verb both publishes (via the binary) and subscribes on the same
-        topic to render; a clean exit proves the message flowed over the custom
-        topic end to end.
-        """
-        verb = DescribeVerb()
-        rc = verb.main(args=_make_args(topic='/nodl/custom_topic_smoke_test'))
-        assert rc == 0
-
-    def test_node_not_found_returns_nonzero(self, ros_context, capsys):
-        """Verb returns nonzero with a clear message when the target is absent."""
-        verb = DescribeVerb()
-        rc = verb.main(args=_make_args(node_name='/nonexistent_node_xyzzy', timeout=2.0))
-        assert rc != 0
-        err = capsys.readouterr().err
-        assert 'not found' in err.lower() or 'nonexistent' in err.lower(), (
-            f'Expected a not-found message in stderr, got: {err!r}'
-        )
-
-    def test_no_params_flag_succeeds(self, target_node, capsys):
-        """``--no-params`` completes successfully and does not contact the target."""
-        verb = DescribeVerb()
-        rc = verb.main(args=_make_args(no_params=True))
-        assert rc == 0
-        out = capsys.readouterr().out
-        assert yaml.safe_load(out) is not None
+@pytest.mark.skipif(observe_binary() is None, reason='observe binary is not installed')
+def test_live_describe_emits_valid_nodl(target_node, capsys):
+    assert DescribeVerb().main(args=_args()) == 0
+    data = yaml.safe_load(capsys.readouterr().out)
+    validate(data)
+    assert data['nodl_version'] == 2


### PR DESCRIPTION
Implements #53: turn a captured `rosgraph_msgs/Node` into a schema-valid NoDL document behind `ros2 nodl describe`.

## What changed

- Added a pure, duck-typed `Node` → NoDL transform for topics, services, actions, parameters, and QoS.
- Added live acquisition through the `nodl_observe` binary plus offline YAML/MCAP input.
- Replaced the temporary raw-Node output with NoDL by default; `--raw` preserves the old behavior.
- Added `--from`, `--no-params`, `--keep-hidden`, `--strict`, `--topic`, and `-o`.
- Added user documentation and focused unit, real-fixture, file-input, and live CLI tests.

Observe #83 is merged, and this branch is based directly on current `main`; the PR now contains only the describe work.

## Behavior

- Drops observation-only type hashes and framework-created interfaces such as `/rosout`, parameter services, and `qos_overrides.*`.
- Maps RMW QoS integer policies and durations into NoDL values.
- Recovers action types from generated `_SendGoal` / `_GetResult` service types.
- Uses observed parameter descriptors and values to produce parameter definitions.
- Reports fields that cannot be recovered as gaps. The default emits a best-effort draft; `--strict` returns nonzero for gaps or schema validation failures.
- Supports live observation and captured `.yaml`, `.yml`, or `.mcap` input.

## Review scope

The implementation was reduced from 28 changed files / 4,292 additions to **15 changed files / 1,426 additions**.

The core review surface is:

- `ros2nodl/ros2nodl/describe/_transform.py` — pure interpretation logic
- `ros2nodl/ros2nodl/describe/_source.py` — live and file acquisition
- `ros2nodl/ros2nodl/verb/describe.py` — CLI orchestration
- `nodl/doc/describe.md` — documented behavior and limitations

The remaining changes are focused tests and package wiring.

## Validation

- `pre-commit run --all-files` — passes
- ROS-free describe suite — **58 passed, 2 ROS-only modules skipped**
- Previous full GitHub matrix on Humble, Jazzy, Kilted, Lyrical, and Rolling — passed
- Sphinx and Read the Docs builds — passed

The new signed commit will rerun the full GitHub matrix.
