### PR TITLE
Include other nodls by reference

### DIFF
--- a/ament_nodl/cmake/ament_nodl_register_node.cmake
+++ b/ament_nodl/cmake/ament_nodl_register_node.cmake
@@ -13,11 +13,17 @@
 #
 # The source file is also installed under ``share/<package>/nodl/`` for direct filesystem access.
 #
+# If the document uses relative ``include`` references, what is installed is a rewritten copy in
+# which each relative reference has become ``nodl://<package>/<name>``.
+# A relative reference is an intra-package convenience that means nothing to a consumer reading the
+# document back out of the index, so it is resolved to a name that does.
+# The referenced document must already be registered, by an earlier call to this macro, which is
+# what gives it the name to rewrite to.
+#
 # Example::
 #
-#   ament_nodl_register_node(my_node
-#     FILE nodl/my_node.nodl.yaml
-#   )
+#   ament_nodl_register_node(telemetry FILE nodl/common/telemetry.nodl.yaml)
+#   ament_nodl_register_node(my_node   FILE nodl/my_node.nodl.yaml)  # may include common/telemetry.nodl.yaml
 #
 # :param executable_name: name of the executable this NoDL document describes.
 #   Combined with PACKAGE to form the resource key.
@@ -49,31 +55,144 @@ function(ament_nodl_register_node executable_name)
       "ament_nodl_register_node: file not found at configure time: ${_abs_file}")
   endif()
 
-  # Validate the file at build time so authoring errors surface when registering, not downstream when consuming.
-  # This only runs when ${_abs_file} changes.
-  set(_stamp_dir "${CMAKE_CURRENT_BINARY_DIR}/ament_nodl/nodl_nodes")
-  set(_stamp "${_stamp_dir}/${_ARGS_PACKAGE}__${executable_name}.valid.stamp")
-  file(MAKE_DIRECTORY "${_stamp_dir}")
+  _ament_nodl_record_registration("${_abs_file}" "${_ARGS_PACKAGE}" "${executable_name}")
+  _ament_nodl_local_references("${_abs_file}" _local_refs)
+  _ament_nodl_reference_map(_map_args)
+
+  # Every relative reference must already be registered, so the rewrite below cannot fail on a
+  # name that does not exist. Checking here rather than at build time puts the error where the
+  # fix is: the ordering of calls in this CMakeLists.
+  get_property(_registered GLOBAL PROPERTY _AMENT_NODL_REGISTERED_PATHS)
+  foreach(_ref IN LISTS _local_refs)
+    if(NOT "${_ref}" IN_LIST _registered)
+      message(FATAL_ERROR
+        "ament_nodl_register_node(${executable_name}): ${_abs_file} references ${_ref}, "
+        "which is not registered.\n"
+        "Add an ament_nodl_register_node() call for it above this one.")
+    endif()
+  endforeach()
+
+  # Rewriting reads only ${_abs_file}, but validation follows relative references into the source
+  # tree, so the stamp has to depend on everything reachable through them.
+  get_filename_component(_basename "${_abs_file}" NAME)
+  set(_gen_dir "${CMAKE_CURRENT_BINARY_DIR}/ament_nodl/${_ARGS_PACKAGE}__${executable_name}")
+  set(_gen_file "${_gen_dir}/${_basename}")
   add_custom_command(
-    OUTPUT "${_stamp}"
-    DEPENDS "${_abs_file}"
+    OUTPUT "${_gen_file}"
+    DEPENDS "${_abs_file}" ${_local_refs}
     COMMAND "${Python3_EXECUTABLE}" -m nodl_schema "${_abs_file}"
-    COMMAND "${CMAKE_COMMAND}" -E touch "${_stamp}"
+    COMMAND "${Python3_EXECUTABLE}" -m nodl_schema "${_abs_file}"
+      --rewrite-to "${_gen_file}" ${_map_args}
     COMMENT "Validating NoDL node ${_ARGS_PACKAGE}/${executable_name}"
     VERBATIM
   )
   add_custom_target(_ament_nodl_validate_node_${_ARGS_PACKAGE}__${executable_name} ALL
-    DEPENDS "${_stamp}"
+    DEPENDS "${_gen_file}"
   )
 
   # Install to ament index
   install(
-    FILES "${_abs_file}"
+    FILES "${_gen_file}"
     DESTINATION "share/ament_index/resource_index/nodl_nodes"
     RENAME "${_ARGS_PACKAGE}__${executable_name}")
 
   # Install to package's share directory
   install(
-    FILES "${_abs_file}"
+    FILES "${_gen_file}"
     DESTINATION "share/${_ARGS_PACKAGE}/nodl")
+endfunction()
+
+#
+# Record a registration so later calls can rewrite relative references to it.
+#
+# Two parallel global lists hold the record: an absolute path and the ``<package>/<name>`` it was
+# registered as. A name may map to exactly one file, because a second registration would otherwise
+# quietly take over a name that an already-rewritten reference points at.
+#
+# :param abs_file: absolute path of the document being registered.
+# :param package: package the resource key uses.
+# :param name: executable name the resource key uses.
+#
+function(_ament_nodl_record_registration abs_file package name)
+  get_property(_paths GLOBAL PROPERTY _AMENT_NODL_REGISTERED_PATHS)
+  get_property(_targets GLOBAL PROPERTY _AMENT_NODL_REGISTERED_TARGETS)
+  set(_target "${package}/${name}")
+
+  list(FIND _targets "${_target}" _index)
+  if(NOT _index EQUAL -1)
+    list(GET _paths ${_index} _existing)
+    if(NOT "${_existing}" STREQUAL "${abs_file}")
+      message(FATAL_ERROR
+        "ament_nodl_register_node: ${_target} is already registered from a different file.\n"
+        "  first:  ${_existing}\n"
+        "  second: ${abs_file}\n"
+        "A name may refer to only one document, since references are rewritten to it by name.")
+    endif()
+    message(FATAL_ERROR
+      "ament_nodl_register_node: ${_target} is already registered from ${abs_file}.\n"
+      "Remove the duplicate call.")
+  endif()
+
+  set_property(GLOBAL APPEND PROPERTY _AMENT_NODL_REGISTERED_PATHS "${abs_file}")
+  set_property(GLOBAL APPEND PROPERTY _AMENT_NODL_REGISTERED_TARGETS "${_target}")
+endfunction()
+
+#
+# Return the documents reachable from a file through relative references, transitively.
+#
+# Also marks them as configure dependencies, so adding or removing a reference in any of them
+# reruns configure and refreshes the dependency list computed here.
+#
+# :param abs_file: absolute path of the document to walk.
+# :param out_var: name of the variable to set in the caller's scope.
+#
+function(_ament_nodl_local_references abs_file out_var)
+  # A document generated by another custom command does not exist yet, and registering one is
+  # supported (the missing-file case is a warning above, not an error). There is nothing to read,
+  # so it contributes no references and no dependencies.
+  if(NOT EXISTS "${abs_file}")
+    set(${out_var} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  execute_process(
+    COMMAND "${Python3_EXECUTABLE}" -m nodl_schema "${abs_file}" --list-references
+    OUTPUT_VARIABLE _output
+    ERROR_VARIABLE _error
+    RESULT_VARIABLE _result
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(NOT _result EQUAL 0)
+    message(FATAL_ERROR
+      "ament_nodl_register_node: could not read includes of ${abs_file}:\n${_error}")
+  endif()
+
+  string(REPLACE "\n" ";" _refs "${_output}")
+  list(REMOVE_ITEM _refs "")
+  if(_refs)
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${_refs})
+  endif()
+  set(${out_var} "${_refs}" PARENT_SCOPE)
+endfunction()
+
+#
+# Build the ``--map <path>=<package>/<name>`` arguments describing every registration so far.
+#
+# :param out_var: name of the variable to set in the caller's scope.
+#
+function(_ament_nodl_reference_map out_var)
+  get_property(_paths GLOBAL PROPERTY _AMENT_NODL_REGISTERED_PATHS)
+  get_property(_targets GLOBAL PROPERTY _AMENT_NODL_REGISTERED_TARGETS)
+
+  set(_args "")
+  list(LENGTH _paths _count)
+  if(_count GREATER 0)
+    math(EXPR _last "${_count} - 1")
+    foreach(_i RANGE ${_last})
+      list(GET _paths ${_i} _path)
+      list(GET _targets ${_i} _target)
+      list(APPEND _args "--map" "${_path}=${_target}")
+    endforeach()
+  endif()
+  set(${out_var} "${_args}" PARENT_SCOPE)
 endfunction()

--- a/ament_nodl/doc/overview.md
+++ b/ament_nodl/doc/overview.md
@@ -10,7 +10,10 @@ For what a NoDL document declares, see {external+nodl:doc}`concepts`.
 Register a NoDL document for an executable. This does three things:
 
 1. Validates the file at build time (via `python -m nodl_schema`), so authoring errors surface when registering
-   rather than downstream when a consumer reads the spec.
+   rather than downstream when a consumer reads the spec. If the document uses `include`, this step also checks that
+   every reference resolves, so a broken `nodl://` or `http(s)://` reference fails the build. Because validation runs
+   before install, an included `nodl://<package>/<name>` must belong to a package that is already built and a
+   dependency of this one; a document cannot resolve an include pointing back into its own not-yet-installed package.
 2. Installs the file into the ament index under the `nodl_nodes` resource type, keyed `<package>__<executable>`.
 3. Installs the file under `share/<package>/nodl/` for direct filesystem access.
 

--- a/ament_nodl/doc/overview.md
+++ b/ament_nodl/doc/overview.md
@@ -9,13 +9,12 @@ For what a NoDL document declares, see {external+nodl:doc}`concepts`.
 
 Register a NoDL document for an executable. This does three things:
 
-1. Validates the file at build time (via `python -m nodl_schema`), so authoring errors surface when registering
-   rather than downstream when a consumer reads the spec. If the document uses `include`, this step also checks that
-   every reference resolves, so a broken `nodl://` or `http(s)://` reference fails the build. Because validation runs
-   before install, an included `nodl://<package>/<name>` must belong to a package that is already built and a
-   dependency of this one; a document cannot resolve an include pointing back into its own not-yet-installed package.
-2. Installs the file into the ament index under the `nodl_nodes` resource type, keyed `<package>__<executable>`.
-3. Installs the file under `share/<package>/nodl/` for direct filesystem access.
+1. Validates the file at build time, so authoring errors surface when registering rather than downstream when a consumer reads it.
+   If the document uses `include`, this step also checks that references resolve correctly.
+   Because validation runs before install, an included `nodl://<package>/<name>` must belong to a package that is already built and a dependency of this one.
+2. Rewrites relative `include` references to `nodl://<package>/<name>`, if the document has any.
+   A document without them is installed exactly as authored.
+3. Installs the result into the ament index under the `nodl_nodes` resource type, keyed `<package>__<executable>`, and under `share/<package>/nodl/` for direct filesystem access.
 
 ```cmake
 find_package(ament_nodl REQUIRED)
@@ -24,6 +23,37 @@ ament_nodl_register_node(my_node
   FILE nodl/my_node.nodl.yaml
 )
 ```
+
+### Relative includes
+
+A document may reference another document in the same package by relative path, which is the only form that can reach a
+document in the package being built. Such a reference means nothing to a consumer reading the document back out of the
+index, which gets text and no path to resolve against, so registration rewrites it to the name the referenced document
+was registered under.
+
+That name has to exist, so **the referenced document must be registered first**:
+
+```cmake
+# telemetry.nodl.yaml first: composed_node references it by path, and the rewrite needs its name.
+ament_nodl_register_node(telemetry FILE nodl/common/telemetry.nodl.yaml)
+ament_nodl_register_node(composed_node FILE nodl/composed_node.nodl.yaml)
+```
+
+With `composed_node.nodl.yaml` authored as:
+
+```yaml
+nodl_version: 2
+include:
+  - ref: common/telemetry.nodl.yaml
+```
+
+what installs is that same document with the reference reading `nodl://<package>/telemetry`.
+
+Two mistakes are caught when CMake configures rather than later:
+
+- Referencing a document that no earlier `ament_nodl_register_node` call registered. There is no name to rewrite to.
+- Registering one name from two different files. The second would take over a name that an already-rewritten reference
+  points at.
 
 ### Arguments
 

--- a/design/composition.md
+++ b/design/composition.md
@@ -1,0 +1,86 @@
+# NoDL composition: design overview
+
+This describes how one NoDL document reuses the interface of others, at a high level.
+
+## Goal
+
+A node's interface is often assembled from shared, reusable pieces: a common telemetry surface, a standard lifecycle
+interface, a fleet-wide diagnostics contract.
+Composition lets a document declare those pieces by reference instead of copying them, and have them merged in when the
+document is loaded.
+
+This pass is deliberately simple.
+Earlier passes modelled composition as a layered `base` + `mixins` + `main` structure with a separate interface-vs-node
+schema split; that is abandoned.
+There is one document type, and one new key.
+
+## The `include` key
+
+A document may carry a top-level `include` list.
+Each entry is an object with a required `ref`:
+
+```yaml
+nodl_version: 2
+include:
+  - ref: nodl://sensor_common/imu_driver
+  - ref: https://example.com/shared/telemetry.nodl.yaml
+```
+
+`ref` is one of two forms:
+
+- `nodl://<package>/<name>` resolves through the ament index to the document that `ament_nodl_register_node`
+  publishes as the resource `nodl_nodes/<package>__<name>`.
+  The macro installs the file itself into the index, so resolution is a direct `get_resource` lookup that returns the
+  document text.
+- `http://` / `https://` fetches the document over the network.
+
+The schema constrains `ref` to those two schemes; anything else is a schema error, before resolution is even attempted.
+
+## What loading does
+
+`load_nodl` validates the document against the schema, then, if it has includes, resolves them and returns a
+`NodlDocument` whose interface is the merged result and whose `include` key is gone.
+`load_nodl(..., resolve=False)` skips resolution and returns the document as authored.
+
+Resolution:
+
+1. Fetch each `ref` through a `Resolver` (the default handles ament and http; tests inject their own).
+2. Validate the fetched document against the schema.
+3. Resolve its includes recursively.
+4. Merge its entities into the accumulator.
+
+Merging is **strict, error on collision.**
+Within any single category (each of `parameters`, `publishers`, `subscriptions`, the service and action lists) a
+duplicate name across the document and its includes is an error.
+Different categories are independent, so a publisher and a subscription may share a topic name.
+There is no override or last-wins rule yet; we start strict and will loosen only when a concrete use case argues for it.
+
+Include **cycles are detected** by tracking the resolution stack and rejected with a clear error.
+A note on the current limitation: because dedup is not performed across resolution paths, a diamond (two includes that
+each pull in the same third document) surfaces as a collision rather than being merged once.
+That is acceptable under the strict policy for now.
+
+## Build-time validation
+
+`ament_nodl_register_node` already validates a document at build time by running `python -m nodl_schema` on it, and
+that path now resolves includes by default.
+So registering a document also checks that its references resolve: a broken `nodl://` or unreachable `http(s)://`
+reference fails the build, next to the schema check.
+
+This has an ordering consequence.
+Validation runs before the package is installed, so an included `nodl://<package>/<name>` must point at a package that
+is already built and is a dependency of the registering one.
+A document cannot resolve an include that points back into its own, not-yet-installed package at build time (it
+resolves fine at runtime, after install).
+`http(s)://` references make the build perform network I/O; `--no-resolve` on the validator is the escape hatch for a
+schema-only check.
+
+## Code layout
+
+- `nodl_schema/schemas/nodl.schema.yaml`: the `include` array and the `reference` definition (`ref` pattern).
+  `models.py` is regenerated from it.
+- `nodl_schema/composition.py`: the `Resolver` protocol, `DefaultResolver` (ament + http), and `resolve_document`
+  (recursive fetch, validate, cycle detection, strict merge). `CompositionError` is the failure type.
+- `nodl_schema/validator.py`: `load_nodl` gains `resolve` / `resolver`; the CLI gains `--no-resolve`.
+- Resolution is pluggable so the merge and cycle logic are unit-tested with an in-memory fake resolver, with a
+  separate end-to-end test resolving a real `nodl://` reference through the installed ament index.

--- a/design/composition.md
+++ b/design/composition.md
@@ -23,18 +23,28 @@ Each entry is an object with a required `ref`:
 nodl_version: 2
 include:
   - ref: nodl://sensor_common/imu_driver
-  - ref: https://example.com/shared/telemetry.nodl.yaml
+  - ref: common/telemetry.nodl.yaml
 ```
 
 `ref` is one of two forms:
 
-- `nodl://<package>/<name>` resolves through the ament index to the document that `ament_nodl_register_node`
-  publishes as the resource `nodl_nodes/<package>__<name>`.
-  The macro installs the file itself into the index, so resolution is a direct `get_resource` lookup that returns the
-  document text.
-- `http://` / `https://` fetches the document over the network.
+- `nodl://<package>/<name>` names a registered document in an already-installed package, resolved through the ament
+  index as the resource `nodl_nodes/<package>__<name>`.
+- A relative path resolves against the directory of the document that contains the reference.
+  It names a document in the same package, and it is the only form that can reference a document in the package
+  currently being built.
 
-The schema constrains `ref` to those two schemes; anything else is a schema error, before resolution is even attempted.
+The schema constrains `ref` to those two forms; anything else is a schema error, before resolution is even attempted.
+An absolute filesystem path is not a valid `ref`, because it cannot mean the same thing on two machines.
+
+Two forms are what this pass needs, but **it must remain possible to support other reference resolutions in the
+future.**
+Adding one should be a matter of teaching the resolver a new form, not reworking composition.
+Two things keep that true: the `Resolver` protocol is a plain `ref -> text` function, so a form is a fetch strategy and
+nothing more, and everything downstream of the fetch works on document text and never inspects the reference that
+produced it.
+Deciding what a reference form costs, whether that is network access during a build, caching, or trust in a remote
+source, is then a question about that form alone rather than a question about composition.
 
 ## What loading does
 
@@ -44,10 +54,23 @@ The schema constrains `ref` to those two schemes; anything else is a schema erro
 
 Resolution:
 
-1. Fetch each `ref` through a `Resolver` (the default handles ament and http; tests inject their own).
-2. Validate the fetched document against the schema.
-3. Resolve its includes recursively.
-4. Merge its entities into the accumulator.
+1. Normalize each `ref` against the **origin** of the document that contains it (see below).
+   A relative path becomes an absolute `file://` ref at this step; a `nodl://` ref passes through unchanged.
+2. Fetch the normalized `ref` through a `Resolver` (the default handles ament and file; tests inject their own).
+3. Validate the fetched document against the schema.
+4. Resolve its includes recursively, with the fetched document's own location as the new origin.
+5. Merge its entities into the accumulator.
+
+An **origin** is where a document was loaded from, and it is what a relative `ref` inside that document is relative to.
+Normalizing before fetching keeps the `Resolver` protocol a plain `ref -> text` function, so a relative path never
+reaches a resolver that would have no way to interpret it.
+Normalizing also makes cycle detection correct: the resolution stack now holds absolute refs, so two different
+spellings of the same file are recognized as the same document rather than recursing until something else breaks.
+
+Only a document whose origin is a local file can carry a relative `ref`.
+A relative reference inside a document fetched from the ament index is an error, because an index resource is text with
+no location to be relative to.
+That case should not arise in practice, because registration rewrites relative references before installing (see below).
 
 Merging is **strict, error on collision.**
 Within any single category (each of `parameters`, `publishers`, `subscriptions`, the service and action lists) a
@@ -60,27 +83,147 @@ A note on the current limitation: because dedup is not performed across resoluti
 each pull in the same third document) surfaces as a collision rather than being merged once.
 That is acceptable under the strict policy for now.
 
+## Requirement: relative references must survive registration
+
+A relative `ref` is resolvable in the source tree and meaningless outside it.
+Registration has to close that gap, because `ament_nodl_register_node` publishes the document into the ament index and
+a consumer in another package then reads it back with `get_resource('nodl_nodes', '<pkg>__<exe>')`.
+That call returns the document *text* and nothing else.
+There is no package name, no path, no origin of any kind attached to it, so a consumer that receives
+`ref: common/telemetry.nodl.yaml` has nothing to resolve it against.
+
+**The chosen resolution is that a relative reference is a private, intra-package spelling of a reference that is public
+after install.**
+A referenced document must already be registered in its own right, so it already has an index name and is already
+installed.
+Registration rewrites the reference in the installed copy from the relative path to the `nodl://<package>/<name>` that
+names the same document, and nothing else changes.
+A consumer never encounters a relative ref, so it never needs a base to resolve one.
+
+Requiring prior registration is what keeps this small.
+The alternative was for registration to publish referenced documents on their own initiative, which meant inventing an
+index name for a document nobody had named, deciding where such a document installs, and making the install layout a
+contract so the name could be resolved back to a file.
+Requiring registration first means the name already exists, chosen by whoever registered it, so none of that is needed.
+
+The other alternative was to inline the referenced entities and drop the reference, which also removes relative refs
+from the installed artifact.
+Rewriting is preferred because inlining answers "what is this node's interface" but destroys "what contracts does this
+node implement," and the second question is most of the value of having composition at all.
+Rewriting also keeps the installed document diffable against the authored one, since they differ only in the spelling of
+each reference, and it stores a shared document once instead of copying it into every document that includes it.
+
+Rewriting costs a runtime consideration in exchange: installed documents still carry references, so a consumer resolves
+them at read time and the cycle detection and collision rules now matter after install, not only during the build.
+That is already implemented and tested, so it is a shift in when the logic runs rather than new logic.
+
+### Naming and ordering
+
+Two rules make the rewrite unambiguous:
+
+- **Registration order.**
+  A document must be registered before any document that relatively includes it.
+  `ament_nodl_register_node` records each registration for the current package, so a relative reference that resolves to
+  an unregistered file is a configure-time error naming the file and asking for its registration to be moved above.
+- **One name, one file.**
+  Registering the same name twice for the same package from two different absolute files is a configure-time error.
+  Without this a later registration would silently take over a name that an already-rewritten reference points at.
+
+The rewrite looks the referenced document's absolute path up in that record and uses the name it was registered under.
+In the normal case that name is the document's base name, so a reference to `common/telemetry.nodl.yaml` becomes
+`nodl://<package>/telemetry` and reads the way the author wrote it.
+Taking the name from the record rather than recomputing it from the base name costs nothing and removes a failure mode,
+since a document registered under some other name still rewrites correctly instead of producing a reference to an index
+entry that does not exist.
+
+Two constraints that earlier drafts spelled out separately now come for free.
+A reference cannot escape the package, because the record holds only this package's registrations and a file outside it
+is simply not in the record.
+Rewriting does not recurse, because each registered document is rewritten by its own registration call, so a document
+that includes a document that includes a third one needs no special handling.
+
 ## Build-time validation
 
 `ament_nodl_register_node` already validates a document at build time by running `python -m nodl_schema` on it, and
 that path now resolves includes by default.
-So registering a document also checks that its references resolve: a broken `nodl://` or unreachable `http(s)://`
-reference fails the build, next to the schema check.
+So registering a document also checks that its references resolve: a broken reference fails the build, next to the
+schema check.
 
 This has an ordering consequence.
 Validation runs before the package is installed, so an included `nodl://<package>/<name>` must point at a package that
 is already built and is a dependency of the registering one.
 A document cannot resolve an include that points back into its own, not-yet-installed package at build time (it
 resolves fine at runtime, after install).
-`http(s)://` references make the build perform network I/O; `--no-resolve` on the validator is the escape hatch for a
-schema-only check.
+`--no-resolve` on the validator is the escape hatch for a schema-only check.
+
+Both current reference forms read only the local filesystem and the installed workspace, so validation is offline and
+deterministic.
+A future form that is neither is worth weighing against that, since build-time validation is where the cost of resolving
+a reference is paid.
+
+Relative references are the answer to that ordering constraint rather than another instance of it.
+They resolve against the source tree, which is present at build time, so a package can finally compose its own
+documents.
+Splitting a shared telemetry surface out of two of a package's own nodes previously required either duplicating it or
+publishing it through a separate package; a relative ref makes it a local file.
+
+## What registration does
+
+`ament_nodl_register_node` gains a rewrite step between validation and install, and records the registration:
+
+1. **Record** this document's absolute path, name, and package, erroring if the name is already recorded against a
+   different file.
+   The record is a global CMake property, so it is visible to later calls wherever they appear in the project.
+2. **Check** that every relative reference reachable from the document is already recorded, and fail configure naming
+   the offending file if one is not.
+   Doing this at configure time puts the error where the fix is, which is the ordering of calls in the `CMakeLists.txt`.
+3. **Validate** the authored document with full resolution, as today.
+   A broken reference fails the build.
+4. **Rewrite** the document into the build directory, replacing each relative `ref` with the `nodl://<package>/<name>`
+   its record entry gives and leaving `nodl://` entries untouched.
+5. **Install** the rewritten document, as the `nodl_nodes` resource and into `share/<package>/nodl/`, exactly where the
+   authored file went before.
+
+A document with no relative references is passed through byte for byte, so registering one is unchanged by any of this.
+Only a document that actually has a reference to rewrite is re-serialized, and then in the format its extension implies,
+so a `.nodl.json` document stays JSON.
+Such a document is no longer installed exactly as authored, which is the visible cost of the approach.
+It is a small one: it differs from the authored file only in the spelling of its references, so the two remain readable
+against each other, and the authored file stays in the source tree and in version control.
+
+Dependency tracking uses the transitive set of relatively referenced files, not just the direct ones.
+Validation resolves a relative reference from the source tree, and a referenced document's own relative references
+resolve from the source tree too, so editing a document two levels down still changes what validation sees.
+The macro asks `nodl_schema` for that set at configure time and adds it to the validation command's `DEPENDS` and to
+`CMAKE_CONFIGURE_DEPENDS`.
+Rewriting stays non-recursive regardless, since each document is rewritten by its own registration.
+
+The `PACKAGE` override is carried through the record, so a document registered under a different package name rewrites
+to a reference naming that package rather than the one being built.
 
 ## Code layout
 
 - `nodl_schema/schemas/nodl.schema.yaml`: the `include` array and the `reference` definition (`ref` pattern).
+  The pattern admits a `nodl://` URI or a relative path, and rejects a leading `/`.
   `models.py` is regenerated from it.
-- `nodl_schema/composition.py`: the `Resolver` protocol, `DefaultResolver` (ament + http), and `resolve_document`
-  (recursive fetch, validate, cycle detection, strict merge). `CompositionError` is the failure type.
-- `nodl_schema/validator.py`: `load_nodl` gains `resolve` / `resolver`; the CLI gains `--no-resolve`.
+- `nodl_schema/composition.py`: the `Resolver` protocol, `DefaultResolver` (ament index and local file), and
+  `resolve_document` (normalize against origin, recursive fetch, validate, cycle detection, strict merge).
+  `resolve_document` takes an `origin` and threads each fetched document's location through the recursion.
+  Two entry points serve registration: one reports the transitive set of relative references reachable from a document,
+  and one rewrites a document's relative references given a path-to-name mapping, without merging anything.
+  `CompositionError` is the failure type.
+- `nodl_schema/validator.py`: `load_nodl` takes a `base` for the origin of a document loaded from text.
+  The CLI gains `--list-references`, reporting a document's transitive relative references for CMake dependency
+  tracking, and `--rewrite-to`, emitting a rewritten document. Both are flags on the existing interface rather than
+  subcommands, so `python -m nodl_schema <file>` keeps working unchanged.
+- `ament_nodl/cmake/ament_nodl_register_node.cmake`: keeps the per-package registration record and its duplicate-name
+  check, queries the transitive reference set at configure time and adds it to the custom command's `DEPENDS` and to
+  `CMAKE_CONFIGURE_DEPENDS`, rewrites the document, and installs the rewritten copy in place of the source file.
 - Resolution is pluggable so the merge and cycle logic are unit-tested with an in-memory fake resolver, with a
   separate end-to-end test resolving a real `nodl://` reference through the installed ament index.
+  Relative references need coverage the fake resolver cannot give: a temp-directory test for origin threading, and a
+  `test_ament_nodl` case that registers a shared document, registers a second document that relatively includes it, and
+  asserts that the installed resource carries the rewritten `nodl://` ref and that a downstream package resolves the
+  chain with no knowledge of the source layout.
+  The two configure-time errors need coverage in `test_macro_rejection.py`: referencing an unregistered file, and
+  registering one name twice from different files.

--- a/nodl_schema/doc/overview.md
+++ b/nodl_schema/doc/overview.md
@@ -63,8 +63,8 @@ Each entry is a reference that is resolved, validated, and merged into the inclu
 ```yaml
 nodl_version: 2
 include:
-  - ref: nodl://sensor_common/imu_driver          # resolved through the ament index
-  - ref: https://example.com/shared/telemetry.nodl.yaml  # fetched over the network
+  - ref: nodl://sensor_common/imu_driver   # resolved through the ament index
+  - ref: common/telemetry.nodl.yaml        # a document in this package, relative to this file
 publishers:
   - name: /status
     type: std_msgs/msg/String
@@ -75,16 +75,24 @@ Two reference forms are accepted:
 
 - `nodl://<package>/<name>` resolves through the ament index to the document registered by
   `ament_nodl_register_node` as the resource `nodl_nodes/<package>__<name>`.
-- `http://` / `https://` fetches the document over the network.
+- A relative path resolves against the directory of the document holding the reference. It names a document in the same
+  package, and is the only form that can reach a document in the package currently being built, since it reads the
+  source tree rather than an installed workspace. Pass `load_nodl(..., base=<path the text came from>)` so relative
+  references have something to resolve against; an open file supplies it automatically.
 
 Includes are followed recursively. The merge is strict: a name collision within any single category (two publishers
 named `/status`, two parameters named `gain`, and so on) across the document and its includes is an error. A publisher
 and a subscription may share a name, since they are different categories. Include cycles are detected and rejected.
 
+Relative references do not survive installation: `ament_nodl_register_node` rewrites them to their `nodl://` form, so a
+document read back out of the index never contains one. `local_references` and `rewrite_references` are the two entry
+points it uses, and are exposed for tooling that needs the same information.
+
 Resolution is pluggable. `load_nodl(..., resolver=...)` accepts anything satisfying the `Resolver` protocol
-(`fetch(ref) -> str`); the default `DefaultResolver` handles `nodl://` and `http(s)://`. `resolve_document(data,
-resolver)` exposes the merge directly for callers working with plain dicts. Resolution failures and collisions raise
-`CompositionError`.
+(`fetch(ref) -> str`); the default `DefaultResolver` handles `nodl://` and the `file://` references that relative paths
+normalize to. A reference is normalized against its document's origin before it is fetched, so adding a reference form
+later means teaching a resolver a new scheme and nothing else. `resolve_document(data, resolver)` exposes the merge
+directly for callers working with plain dicts. Resolution failures and collisions raise `CompositionError`.
 
 ```python
 from nodl_schema import load_nodl, resolve_document, DefaultResolver, CompositionError

--- a/nodl_schema/doc/overview.md
+++ b/nodl_schema/doc/overview.md
@@ -22,10 +22,14 @@ The public API is re-exported from the package root:
 from nodl_schema import load_nodl, dump_nodl, load_schema, validate
 ```
 
-### `load_nodl(source) -> NodlDocument`
+### `load_nodl(source, *, resolve=True, resolver=None) -> NodlDocument`
 
 Load and validate a NoDL document from a string, bytes, or file-like object, returning a typed `NodlDocument`.
 Raises a validation error if the document does not conform to the schema.
+
+If the document has an `include` list, each reference is resolved and merged in (see the Composition section below);
+the returned document carries the combined interface and no `include`. Pass `resolve=False` to parse the document
+exactly as authored, following nothing.
 
 ```python
 from nodl_schema import load_nodl
@@ -33,8 +37,8 @@ from nodl_schema import load_nodl
 with open('my_node.nodl.yaml') as f:
     doc = load_nodl(f)
 
-for parameter in doc.parameters:
-    print(parameter.name, parameter.type)
+for name, parameter in (doc.parameters or {}).items():
+    print(name, parameter.type)
 ```
 
 ### `validate(data) -> None`
@@ -50,6 +54,41 @@ Serialize a `NodlDocument` (or a plain `dict`) back to a YAML or JSON string.
 ### `load_schema() -> dict`
 
 Load and cache the raw NoDL JSON schema as a `dict`, for tools that want to inspect the schema directly.
+
+## Composition: the `include` key
+
+A document can pull in the interface of other NoDL documents through a top-level `include` list.
+Each entry is a reference that is resolved, validated, and merged into the including document when it is loaded:
+
+```yaml
+nodl_version: 2
+include:
+  - ref: nodl://sensor_common/imu_driver          # resolved through the ament index
+  - ref: https://example.com/shared/telemetry.nodl.yaml  # fetched over the network
+publishers:
+  - name: /status
+    type: std_msgs/msg/String
+    qos: {history: SYSTEM_DEFAULT, reliability: SYSTEM_DEFAULT}
+```
+
+Two reference forms are accepted:
+
+- `nodl://<package>/<name>` resolves through the ament index to the document registered by
+  `ament_nodl_register_node` as the resource `nodl_nodes/<package>__<name>`.
+- `http://` / `https://` fetches the document over the network.
+
+Includes are followed recursively. The merge is strict: a name collision within any single category (two publishers
+named `/status`, two parameters named `gain`, and so on) across the document and its includes is an error. A publisher
+and a subscription may share a name, since they are different categories. Include cycles are detected and rejected.
+
+Resolution is pluggable. `load_nodl(..., resolver=...)` accepts anything satisfying the `Resolver` protocol
+(`fetch(ref) -> str`); the default `DefaultResolver` handles `nodl://` and `http(s)://`. `resolve_document(data,
+resolver)` exposes the merge directly for callers working with plain dicts. Resolution failures and collisions raise
+`CompositionError`.
+
+```python
+from nodl_schema import load_nodl, resolve_document, DefaultResolver, CompositionError
+```
 
 ## Data model
 

--- a/nodl_schema/nodl_schema/__init__.py
+++ b/nodl_schema/nodl_schema/__init__.py
@@ -2,6 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """NoDL schema, in-memory models, and validation helpers."""
 
+from nodl_schema.composition import CompositionError, DefaultResolver, Resolver, resolve_document
 from nodl_schema.validator import dump_nodl, load_nodl, load_schema, validate
 
-__all__ = ['dump_nodl', 'load_nodl', 'load_schema', 'validate']
+__all__ = [
+    'CompositionError',
+    'DefaultResolver',
+    'Resolver',
+    'dump_nodl',
+    'load_nodl',
+    'load_schema',
+    'resolve_document',
+    'validate',
+]

--- a/nodl_schema/nodl_schema/__init__.py
+++ b/nodl_schema/nodl_schema/__init__.py
@@ -2,7 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """NoDL schema, in-memory models, and validation helpers."""
 
-from nodl_schema.composition import CompositionError, DefaultResolver, Resolver, resolve_document
+from nodl_schema.composition import (
+    CompositionError,
+    DefaultResolver,
+    Resolver,
+    local_references,
+    resolve_document,
+    rewrite_references,
+)
 from nodl_schema.validator import dump_nodl, load_nodl, load_schema, validate
 
 __all__ = [
@@ -12,6 +19,8 @@ __all__ = [
     'dump_nodl',
     'load_nodl',
     'load_schema',
+    'local_references',
     'resolve_document',
+    'rewrite_references',
     'validate',
 ]

--- a/nodl_schema/nodl_schema/composition.py
+++ b/nodl_schema/nodl_schema/composition.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Composition of NoDL documents via the ``include`` key.
+
+A document may list other NoDL documents under ``include``; each reference is
+resolved, validated, and its interface entities (parameters, publishers,
+subscriptions, service/action servers and clients) are merged into the
+including document. Includes are followed recursively, and a name collision
+within any single category is an error.
+
+Resolution is pluggable through the ``Resolver`` protocol so callers (and tests)
+can supply their own lookup. ``DefaultResolver`` handles the two reference forms
+the schema accepts:
+
+* ``nodl://<package>/<name>`` -- looked up in the ament index as the resource
+  ``nodl_nodes/<package>__<name>`` that ``ament_nodl_register_node`` installs.
+* ``http://`` / ``https://`` -- fetched over the network.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Protocol, runtime_checkable
+
+import yaml
+
+# Timeout, in seconds, for fetching an http(s) reference. Kept finite so a build-time
+# resolvability check cannot hang the build indefinitely on an unreachable host.
+_HTTP_TIMEOUT = 30
+
+# Entity categories merged as name-keyed lists. Parameters are handled separately (a dict).
+_ENTITY_LIST_KEYS = (
+    'publishers',
+    'subscriptions',
+    'service_servers',
+    'service_clients',
+    'action_servers',
+    'action_clients',
+)
+
+_NODL_SCHEME = 'nodl://'
+# Resource type under which ament_nodl_register_node publishes a document; the key is <package>__<name>.
+_AMENT_RESOURCE_TYPE = 'nodl_nodes'
+
+
+class CompositionError(Exception):
+    """Raised when includes cannot be resolved or merged (unresolvable ref, cycle, or name collision)."""
+
+
+@runtime_checkable
+class Resolver(Protocol):
+    """Turns a reference string into the raw text of the referenced NoDL document."""
+
+    def fetch(self, ref: str) -> str: ...
+
+
+class DefaultResolver:
+    """Resolves ``nodl://`` references through the ament index and ``http(s)://`` over the network."""
+
+    def fetch(self, ref: str) -> str:
+        if ref.startswith(_NODL_SCHEME):
+            return self._fetch_ament(ref)
+        if ref.startswith('http://') or ref.startswith('https://'):
+            return self._fetch_http(ref)
+        raise CompositionError(f'unsupported reference scheme: {ref!r} (expected nodl://, http://, or https://)')
+
+    def _fetch_ament(self, ref: str) -> str:
+        package, _, name = ref[len(_NODL_SCHEME) :].partition('/')
+        if not package or not name:
+            raise CompositionError(f'invalid nodl:// reference {ref!r}: expected nodl://<package>/<name>')
+        # Imported lazily and called by attribute so environments without a ROS install can still
+        # use an injected resolver, and so tests can monkeypatch the lookup.
+        try:
+            from ament_index_python import resources
+        except ImportError as exc:
+            raise CompositionError(f'ament_index_python is required to resolve {ref!r}') from exc
+        key = f'{package}__{name}'
+        try:
+            content, _ = resources.get_resource(_AMENT_RESOURCE_TYPE, key)
+        except Exception as exc:
+            raise CompositionError(
+                f'NoDL document not found in ament index for {ref!r} '
+                f'(looked up as {_AMENT_RESOURCE_TYPE}/{key}); '
+                f'is the providing package built and a dependency of this one?'
+            ) from exc
+        return content
+
+    def _fetch_http(self, ref: str) -> str:
+        from urllib.request import urlopen
+
+        try:
+            with urlopen(ref, timeout=_HTTP_TIMEOUT) as response:  # noqa: S310 - scheme is checked above
+                return response.read().decode('utf-8')
+        except Exception as exc:
+            raise CompositionError(f'could not fetch {ref!r}: {exc}') from exc
+
+
+def resolve_document(data: dict, resolver: Resolver | None = None, *, _stack: list[str] | None = None) -> dict:
+    """Return a copy of ``data`` with its ``include`` list resolved and merged in.
+
+    Each referenced document is fetched via ``resolver`` (``DefaultResolver`` if none is
+    given), schema-validated, recursively resolved, and merged. The returned dict has no
+    ``include`` key. The input ``data`` is not mutated.
+
+    Raises ``CompositionError`` on an unresolvable reference, an include cycle, or a name
+    collision within a category; raises ``jsonschema.ValidationError`` if an included
+    document does not satisfy the schema.
+    """
+    if resolver is None:
+        resolver = DefaultResolver()
+    stack = _stack or []
+
+    result = copy.deepcopy(data)
+    includes = result.pop('include', None) or []
+
+    for entry in includes:
+        ref = entry['ref']
+        if ref in stack:
+            chain = ' -> '.join([*stack, ref])
+            raise CompositionError(f'include cycle detected: {chain}')
+
+        text = _fetch(resolver, ref)
+        child = yaml.safe_load(text)
+        if not isinstance(child, dict):
+            raise CompositionError(f'included document {ref!r} is not a YAML/JSON mapping')
+
+        _validate(child, ref)
+        resolved_child = resolve_document(child, resolver, _stack=[*stack, ref])
+        _merge_into(result, resolved_child, ref)
+
+    return result
+
+
+def _fetch(resolver: Resolver, ref: str) -> str:
+    """Fetch through an injected resolver, normalizing its failures to CompositionError."""
+    try:
+        return resolver.fetch(ref)
+    except CompositionError:
+        raise
+    except Exception as exc:
+        raise CompositionError(f'could not resolve include {ref!r}: {exc}') from exc
+
+
+def _validate(document: dict, ref: str) -> None:
+    # Imported lazily to avoid a circular import with the validator module.
+    from nodl_schema.validator import validate
+
+    validate(document)
+
+
+def _singular(category: str) -> str:
+    return category[:-1] if category.endswith('s') else category
+
+
+def _merge_into(dst: dict, src: dict, ref: str) -> None:
+    """Merge ``src``'s entities into ``dst`` in place, erroring on any within-category name collision."""
+    src_params = src.get('parameters') or {}
+    if src_params:
+        dst_params = dst.setdefault('parameters', {})
+        for key, value in src_params.items():
+            if key in dst_params:
+                raise CompositionError(f"duplicate parameter '{key}' from include {ref!r}")
+            dst_params[key] = value
+
+    for category in _ENTITY_LIST_KEYS:
+        src_list = src.get(category) or []
+        if not src_list:
+            continue
+        dst_list = dst.setdefault(category, [])
+        seen = {item.get('name') for item in dst_list}
+        for item in src_list:
+            name = item.get('name')
+            if name in seen:
+                raise CompositionError(f"duplicate {_singular(category)} '{name}' from include {ref!r}")
+            seen.add(name)
+            dst_list.append(item)

--- a/nodl_schema/nodl_schema/composition.py
+++ b/nodl_schema/nodl_schema/composition.py
@@ -8,25 +8,35 @@ subscriptions, service/action servers and clients) are merged into the
 including document. Includes are followed recursively, and a name collision
 within any single category is an error.
 
-Resolution is pluggable through the ``Resolver`` protocol so callers (and tests)
-can supply their own lookup. ``DefaultResolver`` handles the two reference forms
-the schema accepts:
+Two reference forms are accepted:
 
-* ``nodl://<package>/<name>`` -- looked up in the ament index as the resource
+* ``nodl://<package>/<name>`` -- a registered document in an already-installed
+  package, looked up in the ament index as the resource
   ``nodl_nodes/<package>__<name>`` that ``ament_nodl_register_node`` installs.
-* ``http://`` / ``https://`` -- fetched over the network.
+* a relative path -- a document in the same package, resolved against the
+  directory of the document holding the reference. This is the only form that
+  can reach a document in the package currently being built, since it reads the
+  source tree rather than an installed workspace.
+
+A reference is normalized against its document's *origin* before it is fetched,
+so a relative path becomes an absolute ``file://`` reference and the ``Resolver``
+protocol stays a plain ``ref -> text`` function. Adding a reference form later is
+therefore a matter of teaching a resolver a new scheme: nothing downstream of the
+fetch inspects the reference that produced the text.
+
+Relative references are an intra-package authoring convenience and do not survive
+installation. ``ament_nodl_register_node`` rewrites them to their ``nodl://``
+equivalents before installing, using :func:`local_references` to find them and
+:func:`rewrite_references` to replace them.
 """
 
 from __future__ import annotations
 
 import copy
+from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 import yaml
-
-# Timeout, in seconds, for fetching an http(s) reference. Kept finite so a build-time
-# resolvability check cannot hang the build indefinitely on an unreachable host.
-_HTTP_TIMEOUT = 30
 
 # Entity categories merged as name-keyed lists. Parameters are handled separately (a dict).
 _ENTITY_LIST_KEYS = (
@@ -39,6 +49,7 @@ _ENTITY_LIST_KEYS = (
 )
 
 _NODL_SCHEME = 'nodl://'
+_FILE_SCHEME = 'file://'
 # Resource type under which ament_nodl_register_node publishes a document; the key is <package>__<name>.
 _AMENT_RESOURCE_TYPE = 'nodl_nodes'
 
@@ -55,14 +66,17 @@ class Resolver(Protocol):
 
 
 class DefaultResolver:
-    """Resolves ``nodl://`` references through the ament index and ``http(s)://`` over the network."""
+    """Resolves ``nodl://`` references through the ament index and ``file://`` references from disk."""
 
     def fetch(self, ref: str) -> str:
         if ref.startswith(_NODL_SCHEME):
             return self._fetch_ament(ref)
-        if ref.startswith('http://') or ref.startswith('https://'):
-            return self._fetch_http(ref)
-        raise CompositionError(f'unsupported reference scheme: {ref!r} (expected nodl://, http://, or https://)')
+        if ref.startswith(_FILE_SCHEME):
+            return self._fetch_file(ref)
+        raise CompositionError(
+            f'unsupported reference scheme: {ref!r} '
+            f'(expected {_NODL_SCHEME}, or a relative path resolved to {_FILE_SCHEME})'
+        )
 
     def _fetch_ament(self, ref: str) -> str:
         package, _, name = ref[len(_NODL_SCHEME) :].partition('/')
@@ -85,22 +99,64 @@ class DefaultResolver:
             ) from exc
         return content
 
-    def _fetch_http(self, ref: str) -> str:
-        from urllib.request import urlopen
-
+    def _fetch_file(self, ref: str) -> str:
+        path = ref_to_path(ref)
         try:
-            with urlopen(ref, timeout=_HTTP_TIMEOUT) as response:  # noqa: S310 - scheme is checked above
-                return response.read().decode('utf-8')
-        except Exception as exc:
-            raise CompositionError(f'could not fetch {ref!r}: {exc}') from exc
+            return path.read_text(encoding='utf-8')
+        except OSError as exc:
+            raise CompositionError(f'could not read {str(path)!r}: {exc}') from exc
 
 
-def resolve_document(data: dict, resolver: Resolver | None = None, *, _stack: list[str] | None = None) -> dict:
+def is_relative_ref(ref: str) -> bool:
+    """True when ``ref`` is a relative path rather than an absolute, scheme-qualified reference."""
+    return not ref.startswith(_NODL_SCHEME) and not ref.startswith(_FILE_SCHEME)
+
+
+def path_to_ref(path: Path | str) -> str:
+    """Turn a filesystem path into an absolute ``file://`` reference."""
+    return _FILE_SCHEME + str(Path(path).resolve())
+
+
+def ref_to_path(ref: str) -> Path:
+    """Turn a ``file://`` reference back into a filesystem path."""
+    return Path(ref[len(_FILE_SCHEME) :])
+
+
+def _normalize(ref: str, origin: str | None) -> str:
+    """Resolve ``ref`` against ``origin`` so it is absolute and scheme-qualified.
+
+    ``nodl://`` references pass through. A relative path is resolved against the directory of
+    ``origin``, which must itself be a ``file://`` reference: a document fetched from the ament
+    index is text with no location, so nothing inside it can be relative to anything.
+    """
+    if not is_relative_ref(ref):
+        return ref
+    if origin is None:
+        raise CompositionError(
+            f'relative reference {ref!r} has nothing to resolve against; '
+            f'load the document from a file, or pass base= to load_nodl'
+        )
+    if not origin.startswith(_FILE_SCHEME):
+        raise CompositionError(
+            f'relative reference {ref!r} appears in {origin!r}, which was not loaded from a file; '
+            f'a document resolved through the ament index has no location to be relative to'
+        )
+    return path_to_ref(ref_to_path(origin).parent / ref)
+
+
+def resolve_document(
+    data: dict,
+    resolver: Resolver | None = None,
+    *,
+    origin: str | None = None,
+    _stack: list[str] | None = None,
+) -> dict:
     """Return a copy of ``data`` with its ``include`` list resolved and merged in.
 
-    Each referenced document is fetched via ``resolver`` (``DefaultResolver`` if none is
-    given), schema-validated, recursively resolved, and merged. The returned dict has no
-    ``include`` key. The input ``data`` is not mutated.
+    Each reference is normalized against ``origin`` (the reference the document itself was
+    fetched from, if any), fetched via ``resolver`` (``DefaultResolver`` if none is given),
+    schema-validated, recursively resolved, and merged. The returned dict has no ``include``
+    key. The input ``data`` is not mutated.
 
     Raises ``CompositionError`` on an unresolvable reference, an include cycle, or a name
     collision within a category; raises ``jsonschema.ValidationError`` if an included
@@ -114,7 +170,10 @@ def resolve_document(data: dict, resolver: Resolver | None = None, *, _stack: li
     includes = result.pop('include', None) or []
 
     for entry in includes:
-        ref = entry['ref']
+        authored = entry['ref']
+        # Normalizing before the cycle check means two spellings of the same file are recognized
+        # as one document rather than recursing until something else gives way.
+        ref = _normalize(authored, origin)
         if ref in stack:
             chain = ' -> '.join([*stack, ref])
             raise CompositionError(f'include cycle detected: {chain}')
@@ -125,8 +184,70 @@ def resolve_document(data: dict, resolver: Resolver | None = None, *, _stack: li
             raise CompositionError(f'included document {ref!r} is not a YAML/JSON mapping')
 
         _validate(child, ref)
-        resolved_child = resolve_document(child, resolver, _stack=[*stack, ref])
+        resolved_child = resolve_document(child, resolver, origin=ref, _stack=[*stack, ref])
         _merge_into(result, resolved_child, ref)
+
+    return result
+
+
+def local_references(data: dict, origin: str, *, _seen: list[Path] | None = None) -> list[Path]:
+    """Return every document reachable from ``data`` through relative references, transitively.
+
+    ``origin`` is the ``file://`` reference ``data`` was read from. The result is a list of
+    absolute paths in discovery order, deduplicated, and safe against reference cycles.
+
+    ``ament_nodl_register_node`` uses this at configure time for two things: to check that each
+    referenced document has already been registered, and to feed CMake the dependency list so
+    editing a document two levels down still reruns validation.
+    """
+    seen = [] if _seen is None else _seen
+
+    for entry in data.get('include') or []:
+        ref = entry.get('ref')
+        if not ref or not is_relative_ref(ref):
+            continue
+        child_ref = _normalize(ref, origin)
+        path = ref_to_path(child_ref)
+        if path in seen:
+            continue
+        seen.append(path)
+
+        try:
+            child = yaml.safe_load(path.read_text(encoding='utf-8'))
+        except OSError as exc:
+            raise CompositionError(f'could not read {ref!r} from {str(path)!r}: {exc}') from exc
+        if isinstance(child, dict):
+            local_references(child, child_ref, _seen=seen)
+
+    return seen
+
+
+def rewrite_references(data: dict, mapping: dict[Path, str], origin: str) -> dict:
+    """Return a copy of ``data`` with each relative reference replaced by its ``nodl://`` form.
+
+    ``mapping`` maps an absolute path to the ``<package>/<name>`` it was registered as.
+    ``nodl://`` references are left alone, and nothing is merged: this rewrites the reference
+    and changes nothing else, so the result differs from the authored document only in the
+    spelling of its references.
+
+    Rewriting is not recursive. Every registered document is rewritten by its own registration,
+    so a document that includes a document that includes a third one needs no special handling
+    here.
+    """
+    result = copy.deepcopy(data)
+
+    for entry in result.get('include') or []:
+        ref = entry.get('ref')
+        if not ref or not is_relative_ref(ref):
+            continue
+        path = ref_to_path(_normalize(ref, origin))
+        target = mapping.get(path)
+        if target is None:
+            raise CompositionError(
+                f'{ref!r} resolves to {str(path)!r}, which is not registered; '
+                f'register it with ament_nodl_register_node before the document that includes it'
+            )
+        entry['ref'] = _NODL_SCHEME + target
 
     return result
 

--- a/nodl_schema/nodl_schema/models.py
+++ b/nodl_schema/nodl_schema/models.py
@@ -50,6 +50,25 @@ class ArrayType(Enum):
     string_array = 'string_array'
 
 
+class Reference(BaseModel):
+    """
+    A reference to another NoDL document to include.
+
+    """
+
+    class Config:
+        extra = Extra.forbid
+
+    ref: constr(regex=r'^(nodl://[^/]+/.+|https?://.+)$') = Field(
+        ...,
+        description='Location of the NoDL document to include. Either a\n``nodl://<package>/<name>`` URI resolved through the ament index\n(the document registered by ``ament_nodl_register_node`` as the\nresource ``<package>__<name>``), or an ``http://`` / ``https://`` URL.\n',
+        examples=[
+            'nodl://sensor_common/imu_driver',
+            'https://example.com/shared/telemetry.nodl.yaml',
+        ],
+    )
+
+
 class History(Enum):
     """
     History policy.
@@ -436,6 +455,10 @@ class NodlDocument(BaseModel):
 
     nodl_version: int = Field(2, const=True, description='NoDL schema major version this document targets.')
     description: Optional[str] = Field(None, description='Human-readable description of what this node does.')
+    include: Optional[list[Reference]] = Field(
+        None,
+        description='Other NoDL documents whose interface entities are merged into this\none when the document is loaded. Each reference is resolved and its\nparameters, publishers, subscriptions, services, and actions are added\nto this document. A name collision within any single category (for\nexample two publishers named ``/status``) across this document and its\nincludes is an error.\n',
+    )
     parameters: Optional[dict[str, ParameterDefinition]] = Field(
         None,
         description='ROS parameters declared by this node, keyed by parameter name.\nParameter shape is borrowed from ``generate_parameter_library``\n(see ``parameter.schema.yaml``).\n',

--- a/nodl_schema/nodl_schema/models.py
+++ b/nodl_schema/nodl_schema/models.py
@@ -59,13 +59,10 @@ class Reference(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    ref: constr(regex=r'^(nodl://[^/]+/.+|https?://.+)$') = Field(
+    ref: constr(regex=r'^(?:nodl://[^/]+/[^/]+|(?!/)(?!.*://).+)$') = Field(
         ...,
-        description='Location of the NoDL document to include. Either a\n``nodl://<package>/<name>`` URI resolved through the ament index\n(the document registered by ``ament_nodl_register_node`` as the\nresource ``<package>__<name>``), or an ``http://`` / ``https://`` URL.\n',
-        examples=[
-            'nodl://sensor_common/imu_driver',
-            'https://example.com/shared/telemetry.nodl.yaml',
-        ],
+        description='Location of the NoDL document to include.\nTypes of includes are:\n1. A ``nodl://<package>/<name>`` URI naming a registered document in an\n   already-installed package, resolved through the ament index. ``<name>``\n   is a registered name and contains no path separators.\n2. A relative path, resolved against the directory of the document that\n   contains the reference. It names a document in the same package, and is\n   the only form able to reference a document in the package being built.\nAn absolute path is not accepted, since it cannot mean the same thing on\ntwo machines.\n',
+        examples=['nodl://sensor_common/imu_driver', 'common/telemetry.nodl.yaml'],
     )
 
 
@@ -457,7 +454,7 @@ class NodlDocument(BaseModel):
     description: Optional[str] = Field(None, description='Human-readable description of what this node does.')
     include: Optional[list[Reference]] = Field(
         None,
-        description='Other NoDL documents whose interface entities are merged into this\none when the document is loaded. Each reference is resolved and its\nparameters, publishers, subscriptions, services, and actions are added\nto this document. A name collision within any single category (for\nexample two publishers named ``/status``) across this document and its\nincludes is an error.\n',
+        description='Other NoDL documents whose interface entities are merged into this one.\nEach reference is resolved - recursively, following all references until done.\nCircular inclusion is an error.\nAn entity-name collision (for example two publishers named ``/status``) is an error.\n',
     )
     parameters: Optional[dict[str, ParameterDefinition]] = Field(
         None,

--- a/nodl_schema/nodl_schema/schemas/nodl.schema.yaml
+++ b/nodl_schema/nodl_schema/schemas/nodl.schema.yaml
@@ -31,12 +31,10 @@ properties:
   include:
     type: array
     description: |
-      Other NoDL documents whose interface entities are merged into this
-      one when the document is loaded. Each reference is resolved and its
-      parameters, publishers, subscriptions, services, and actions are added
-      to this document. A name collision within any single category (for
-      example two publishers named ``/status``) across this document and its
-      includes is an error.
+      Other NoDL documents whose interface entities are merged into this one.
+      Each reference is resolved - recursively, following all references until done.
+      Circular inclusion is an error.
+      An entity-name collision (for example two publishers named ``/status``) is an error.
     items:
       $ref: '#/definitions/reference'
 
@@ -97,14 +95,20 @@ definitions:
       ref:
         type: string
         description: |
-          Location of the NoDL document to include. Either a
-          ``nodl://<package>/<name>`` URI resolved through the ament index
-          (the document registered by ``ament_nodl_register_node`` as the
-          resource ``<package>__<name>``), or an ``http://`` / ``https://`` URL.
-        pattern: ^(nodl://[^/]+/.+|https?://.+)$
+          Location of the NoDL document to include.
+          Types of includes are:
+          1. A ``nodl://<package>/<name>`` URI naming a registered document in an
+             already-installed package, resolved through the ament index. ``<name>``
+             is a registered name and contains no path separators.
+          2. A relative path, resolved against the directory of the document that
+             contains the reference. It names a document in the same package, and is
+             the only form able to reference a document in the package being built.
+          An absolute path is not accepted, since it cannot mean the same thing on
+          two machines.
+        pattern: ^(?:nodl://[^/]+/[^/]+|(?!/)(?!.*://).+)$
         examples:
           - nodl://sensor_common/imu_driver
-          - https://example.com/shared/telemetry.nodl.yaml
+          - common/telemetry.nodl.yaml
 
   rosName:
     type: string

--- a/nodl_schema/nodl_schema/schemas/nodl.schema.yaml
+++ b/nodl_schema/nodl_schema/schemas/nodl.schema.yaml
@@ -28,6 +28,18 @@ properties:
     type: string
     description: Human-readable description of what this node does.
 
+  include:
+    type: array
+    description: |
+      Other NoDL documents whose interface entities are merged into this
+      one when the document is loaded. Each reference is resolved and its
+      parameters, publishers, subscriptions, services, and actions are added
+      to this document. A name collision within any single category (for
+      example two publishers named ``/status``) across this document and its
+      includes is an error.
+    items:
+      $ref: '#/definitions/reference'
+
   parameters:
     type: object
     description: |
@@ -74,6 +86,26 @@ properties:
       $ref: '#/definitions/action_endpoint'
 
 definitions:
+  reference:
+    type: object
+    description: |
+      A reference to another NoDL document to include.
+    additionalProperties: false
+    required:
+      - ref
+    properties:
+      ref:
+        type: string
+        description: |
+          Location of the NoDL document to include. Either a
+          ``nodl://<package>/<name>`` URI resolved through the ament index
+          (the document registered by ``ament_nodl_register_node`` as the
+          resource ``<package>__<name>``), or an ``http://`` / ``https://`` URL.
+        pattern: ^(nodl://[^/]+/.+|https?://.+)$
+        examples:
+          - nodl://sensor_common/imu_driver
+          - https://example.com/shared/telemetry.nodl.yaml
+
   rosName:
     type: string
     description: |

--- a/nodl_schema/nodl_schema/validator.py
+++ b/nodl_schema/nodl_schema/validator.py
@@ -55,18 +55,35 @@ def validate(data: dict) -> None:
     _make_validator().validate(data)
 
 
-def load_nodl(source: Union[str, bytes, IO]) -> NodlDocument:
+def load_nodl(source: Union[str, bytes, IO], *, resolve: bool = True, resolver=None) -> NodlDocument:
     """Load and validate a NoDL document from a string, bytes, or file-like object.
 
     JSON is a subset of YAML, so both are accepted through yaml.safe_load.
-    Raises jsonschema.ValidationError on schema error or pydantic.ValidationError
-    on type error.
+
+    When ``resolve`` is true (the default) and the document has an ``include``
+    list, each reference is resolved and its entities are merged in (see
+    nodl_schema.composition); the returned document carries the merged
+    interface and no ``include`` key. ``resolver`` overrides the default
+    ament/http resolver, mainly for tests. Pass ``resolve=False`` to parse the
+    document as authored, leaving ``include`` intact and following nothing.
+
+    Raises jsonschema.ValidationError on schema error, pydantic.ValidationError
+    on type error, or composition.CompositionError on an unresolvable or
+    conflicting include.
     """
     data = yaml.safe_load(source)
     if not isinstance(data, dict):
         raise ValueError('NoDL document must be a YAML/JSON mapping at the top level')
 
     validate(data)
+
+    if resolve and data.get('include'):
+        # Imported lazily to avoid a circular import (composition validates included docs via this module).
+        from nodl_schema.composition import resolve_document
+
+        data = resolve_document(data, resolver)
+        validate(data)
+
     # parse_obj is pydantic v1 API, retained as a deprecated alias in v2.
     # Used so this module works against both rosdep-shipped pydantic v1
     # (humble/jazzy/kilted) and v2 (lyrical+).
@@ -105,11 +122,18 @@ def main(argv: list[str] | None = None) -> int:
         description='Validate a NoDL file against the schema.',
     )
     parser.add_argument('file', type=Path, help='Path to the NoDL file to validate.')
+    parser.add_argument(
+        '--no-resolve',
+        dest='resolve',
+        action='store_false',
+        help='Validate the schema only; do not resolve include references. '
+        'By default includes are resolved so the file is checked for resolvability too.',
+    )
     args = parser.parse_args(argv)
 
     try:
         with args.file.open('r') as f:
-            load_nodl(f)
+            load_nodl(f, resolve=args.resolve)
     except Exception as exc:
         print(f'{args.file}: {exc}', file=sys.stderr)
         return 1

--- a/nodl_schema/nodl_schema/validator.py
+++ b/nodl_schema/nodl_schema/validator.py
@@ -55,7 +55,13 @@ def validate(data: dict) -> None:
     _make_validator().validate(data)
 
 
-def load_nodl(source: Union[str, bytes, IO], *, resolve: bool = True, resolver=None) -> NodlDocument:
+def load_nodl(
+    source: Union[str, bytes, IO],
+    *,
+    resolve: bool = True,
+    resolver=None,
+    base: Union[str, Path, None] = None,
+) -> NodlDocument:
     """Load and validate a NoDL document from a string, bytes, or file-like object.
 
     JSON is a subset of YAML, so both are accepted through yaml.safe_load.
@@ -64,13 +70,25 @@ def load_nodl(source: Union[str, bytes, IO], *, resolve: bool = True, resolver=N
     list, each reference is resolved and its entities are merged in (see
     nodl_schema.composition); the returned document carries the merged
     interface and no ``include`` key. ``resolver`` overrides the default
-    ament/http resolver, mainly for tests. Pass ``resolve=False`` to parse the
-    document as authored, leaving ``include`` intact and following nothing.
+    resolver, mainly for tests. Pass ``resolve=False`` to parse the document as
+    authored, leaving ``include`` intact and following nothing.
+
+    ``base`` is the filesystem path this document was read from. Relative
+    references resolve against its directory, so it is required for a document
+    that uses them and ignored for one that does not. When ``source`` is an open
+    file the path is taken from it automatically.
 
     Raises jsonschema.ValidationError on schema error, pydantic.ValidationError
     on type error, or composition.CompositionError on an unresolvable or
     conflicting include.
     """
+    if base is None:
+        # An open file knows where it came from; use it so callers reading a path
+        # do not have to pass the same path twice.
+        name = getattr(source, 'name', None)
+        if isinstance(name, (str, Path)):
+            base = name
+
     data = yaml.safe_load(source)
     if not isinstance(data, dict):
         raise ValueError('NoDL document must be a YAML/JSON mapping at the top level')
@@ -79,9 +97,10 @@ def load_nodl(source: Union[str, bytes, IO], *, resolve: bool = True, resolver=N
 
     if resolve and data.get('include'):
         # Imported lazily to avoid a circular import (composition validates included docs via this module).
-        from nodl_schema.composition import resolve_document
+        from nodl_schema.composition import path_to_ref, resolve_document
 
-        data = resolve_document(data, resolver)
+        origin = path_to_ref(base) if base is not None else None
+        data = resolve_document(data, resolver, origin=origin)
         validate(data)
 
     # parse_obj is pydantic v1 API, retained as a deprecated alias in v2.
@@ -107,12 +126,70 @@ def dump_nodl(doc: Union[NodlDocument, dict], *, format: str = 'yaml') -> str:
     return yaml.dump(data, default_flow_style=False, allow_unicode=True)
 
 
+def _list_references(file: Path) -> int:
+    """Print every document reachable from ``file`` through relative references, one path per line.
+
+    ``ament_nodl_register_node`` reads this at configure time to check that each referenced
+    document is registered and to feed CMake its dependency list.
+    """
+    from nodl_schema.composition import local_references, path_to_ref
+
+    data = yaml.safe_load(file.read_text(encoding='utf-8'))
+    if not isinstance(data, dict):
+        raise ValueError('NoDL document must be a YAML/JSON mapping at the top level')
+    for path in local_references(data, path_to_ref(file)):
+        print(path)
+    return 0
+
+
+def _rewrite(file: Path, output: Path, mappings: list[str]) -> int:
+    """Write ``file`` to ``output`` with each relative reference rewritten to its ``nodl://`` form.
+
+    Each ``mappings`` entry is ``<absolute path>=<package>/<name>``, naming what a referenced
+    document was registered as.
+
+    A document with no relative references is copied through unchanged, byte for byte. Only a
+    document that actually has something to rewrite is re-serialized, and then in the format its
+    extension implies, so a ``.nodl.json`` file stays JSON.
+    """
+    import shutil
+
+    from nodl_schema.composition import is_relative_ref, path_to_ref, ref_to_path, rewrite_references
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    data = yaml.safe_load(file.read_text(encoding='utf-8'))
+    if not isinstance(data, dict):
+        raise ValueError('NoDL document must be a YAML/JSON mapping at the top level')
+
+    if not any(is_relative_ref(entry.get('ref', '')) for entry in data.get('include') or []):
+        shutil.copyfile(file, output)
+        return 0
+
+    mapping = {}
+    for item in mappings:
+        path_text, sep, target = item.partition('=')
+        if not sep or not path_text or not target:
+            raise ValueError(f'malformed --map {item!r}: expected <path>=<package>/<name>')
+        mapping[ref_to_path(path_to_ref(path_text))] = target
+
+    rewritten = rewrite_references(data, mapping, path_to_ref(file))
+    fmt = 'json' if file.suffix == '.json' else 'yaml'
+    output.write_text(dump_nodl(rewritten, format=fmt), encoding='utf-8')
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     """``python -m nodl_schema <file>`` -- validate a NoDL file.
 
     Exits 0 on success, 1 on validation failure or I/O error.
     Designed for invocation from CMake macros (ament_nodl_register_node and
     siblings) so files are checked at build time, not at runtime.
+
+    Two additional modes serve registration rather than authors:
+    ``--list-references`` reports the documents reachable through relative
+    references, and ``--rewrite-to`` emits a copy with those references rewritten
+    into the ``nodl://`` form that survives installation.
     """
     import argparse
     import sys
@@ -129,9 +206,34 @@ def main(argv: list[str] | None = None) -> int:
         help='Validate the schema only; do not resolve include references. '
         'By default includes are resolved so the file is checked for resolvability too.',
     )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        '--list-references',
+        action='store_true',
+        help='Print the documents reachable from this one through relative references, '
+        'transitively, one absolute path per line, instead of validating.',
+    )
+    mode.add_argument(
+        '--rewrite-to',
+        type=Path,
+        metavar='PATH',
+        help='Write a copy of the file to PATH with each relative reference rewritten to '
+        'nodl://<package>/<name>, instead of validating.',
+    )
+    parser.add_argument(
+        '--map',
+        action='append',
+        default=[],
+        metavar='PATH=PACKAGE/NAME',
+        help='What a referenced document was registered as. Repeatable. Used with --rewrite-to.',
+    )
     args = parser.parse_args(argv)
 
     try:
+        if args.list_references:
+            return _list_references(args.file)
+        if args.rewrite_to is not None:
+            return _rewrite(args.file, args.rewrite_to, args.map)
         with args.file.open('r') as f:
             load_nodl(f, resolve=args.resolve)
     except Exception as exc:

--- a/nodl_schema/package.xml
+++ b/nodl_schema/package.xml
@@ -12,6 +12,8 @@
   <depend>python3-jsonschema</depend>
   <depend>python3-pydantic</depend>
   <depend>python3-yaml</depend>
+  <!-- Resolving nodl:// includes looks documents up in the ament index. -->
+  <exec_depend>ament_index_python</exec_depend>
 
   <test_depend>python3-pytest</test_depend>
 

--- a/nodl_schema/test/test_composition.py
+++ b/nodl_schema/test/test_composition.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for NoDL document composition (the ``include`` key).
+
+Resolution is exercised through a fake in-memory resolver so these tests need
+neither an ament index nor network access. The default resolver's nodl:// URI
+parsing is tested separately with a stubbed ament lookup.
+"""
+
+import pytest
+
+from nodl_schema import load_nodl
+from nodl_schema.composition import CompositionError, DefaultResolver, resolve_document
+
+_MIN_QOS = {'history': 'SYSTEM_DEFAULT', 'reliability': 'SYSTEM_DEFAULT'}
+
+
+def _pub(name, type_='std_msgs/msg/String'):
+    return {'name': name, 'type': type_, 'qos': _MIN_QOS}
+
+
+class FakeResolver:
+    """Resolve refs from an in-memory ``{ref: yaml_text}`` mapping."""
+
+    def __init__(self, docs: dict):
+        self._docs = docs
+        self.calls: list[str] = []
+
+    def fetch(self, ref: str) -> str:
+        self.calls.append(ref)
+        try:
+            return self._docs[ref]
+        except KeyError:
+            raise FileNotFoundError(ref)
+
+
+# ---------------------------------------------------------------------------
+# resolve_document: merging
+# ---------------------------------------------------------------------------
+
+
+def test_single_include_merges_entities():
+    resolver = FakeResolver({
+        'nodl://pkg/extra': 'nodl_version: 2\nsubscriptions:\n  - name: /extra\n    type: std_msgs/msg/String\n    qos: {history: SYSTEM_DEFAULT, reliability: SYSTEM_DEFAULT}\n',
+    })
+    base = {
+        'nodl_version': 2,
+        'include': [{'ref': 'nodl://pkg/extra'}],
+        'publishers': [_pub('/base')],
+    }
+    merged = resolve_document(base, resolver)
+    assert 'include' not in merged
+    assert [p['name'] for p in merged['publishers']] == ['/base']
+    assert [s['name'] for s in merged['subscriptions']] == ['/extra']
+
+
+def test_include_merges_parameters():
+    resolver = FakeResolver({
+        'nodl://pkg/params': 'nodl_version: 2\nparameters:\n  gain: {type: double}\n',
+    })
+    base = {
+        'nodl_version': 2,
+        'include': [{'ref': 'nodl://pkg/params'}],
+        'parameters': {'rate': {'type': 'int'}},
+    }
+    merged = resolve_document(base, resolver)
+    assert set(merged['parameters']) == {'rate', 'gain'}
+
+
+def test_nested_include_is_resolved_recursively():
+    resolver = FakeResolver({
+        'nodl://pkg/a': 'nodl_version: 2\ninclude:\n  - ref: nodl://pkg/b\npublishers:\n  - name: /a\n    type: std_msgs/msg/String\n    qos: {history: SYSTEM_DEFAULT, reliability: SYSTEM_DEFAULT}\n',
+        'nodl://pkg/b': 'nodl_version: 2\npublishers:\n  - name: /b\n    type: std_msgs/msg/String\n    qos: {history: SYSTEM_DEFAULT, reliability: SYSTEM_DEFAULT}\n',
+    })
+    base = {'nodl_version': 2, 'include': [{'ref': 'nodl://pkg/a'}]}
+    merged = resolve_document(base, resolver)
+    assert sorted(p['name'] for p in merged['publishers']) == ['/a', '/b']
+
+
+def test_input_document_is_not_mutated():
+    resolver = FakeResolver({
+        'nodl://pkg/x': 'nodl_version: 2\npublishers:\n  - name: /x\n    type: std_msgs/msg/String\n    qos: {history: SYSTEM_DEFAULT, reliability: SYSTEM_DEFAULT}\n'
+    })
+    base = {'nodl_version': 2, 'include': [{'ref': 'nodl://pkg/x'}]}
+    resolve_document(base, resolver)
+    assert base['include'] == [{'ref': 'nodl://pkg/x'}]
+    assert 'publishers' not in base
+
+
+# ---------------------------------------------------------------------------
+# resolve_document: collisions (error-on-collision policy)
+# ---------------------------------------------------------------------------
+
+
+def test_collision_between_base_and_include_errors():
+    resolver = FakeResolver({
+        'nodl://pkg/dup': 'nodl_version: 2\npublishers:\n  - name: /status\n    type: std_msgs/msg/String\n    qos: {history: SYSTEM_DEFAULT, reliability: SYSTEM_DEFAULT}\n'
+    })
+    base = {
+        'nodl_version': 2,
+        'include': [{'ref': 'nodl://pkg/dup'}],
+        'publishers': [_pub('/status')],
+    }
+    with pytest.raises(CompositionError, match='/status'):
+        resolve_document(base, resolver)
+
+
+def test_collision_between_two_includes_errors():
+    resolver = FakeResolver({
+        'nodl://pkg/one': 'nodl_version: 2\npublishers:\n  - name: /shared\n    type: std_msgs/msg/String\n    qos: {history: SYSTEM_DEFAULT, reliability: SYSTEM_DEFAULT}\n',
+        'nodl://pkg/two': 'nodl_version: 2\npublishers:\n  - name: /shared\n    type: std_msgs/msg/String\n    qos: {history: SYSTEM_DEFAULT, reliability: SYSTEM_DEFAULT}\n',
+    })
+    base = {'nodl_version': 2, 'include': [{'ref': 'nodl://pkg/one'}, {'ref': 'nodl://pkg/two'}]}
+    with pytest.raises(CompositionError, match='/shared'):
+        resolve_document(base, resolver)
+
+
+def test_parameter_collision_errors():
+    resolver = FakeResolver({'nodl://pkg/p': 'nodl_version: 2\nparameters:\n  gain: {type: double}\n'})
+    base = {
+        'nodl_version': 2,
+        'include': [{'ref': 'nodl://pkg/p'}],
+        'parameters': {'gain': {'type': 'int'}},
+    }
+    with pytest.raises(CompositionError, match='gain'):
+        resolve_document(base, resolver)
+
+
+def test_same_name_different_category_is_allowed():
+    # A publisher and a subscription may share a topic name; they are different categories.
+    resolver = FakeResolver({
+        'nodl://pkg/sub': 'nodl_version: 2\nsubscriptions:\n  - name: /topic\n    type: std_msgs/msg/String\n    qos: {history: SYSTEM_DEFAULT, reliability: SYSTEM_DEFAULT}\n'
+    })
+    base = {
+        'nodl_version': 2,
+        'include': [{'ref': 'nodl://pkg/sub'}],
+        'publishers': [_pub('/topic')],
+    }
+    merged = resolve_document(base, resolver)
+    assert merged['publishers'][0]['name'] == '/topic'
+    assert merged['subscriptions'][0]['name'] == '/topic'
+
+
+# ---------------------------------------------------------------------------
+# resolve_document: cycles and failures
+# ---------------------------------------------------------------------------
+
+
+def test_cycle_is_detected():
+    resolver = FakeResolver({
+        'nodl://pkg/a': 'nodl_version: 2\ninclude:\n  - ref: nodl://pkg/b\n',
+        'nodl://pkg/b': 'nodl_version: 2\ninclude:\n  - ref: nodl://pkg/a\n',
+    })
+    base = {'nodl_version': 2, 'include': [{'ref': 'nodl://pkg/a'}]}
+    with pytest.raises(CompositionError, match='cycle'):
+        resolve_document(base, resolver)
+
+
+def test_unresolvable_ref_raises_composition_error():
+    resolver = FakeResolver({})
+    base = {'nodl_version': 2, 'include': [{'ref': 'nodl://pkg/missing'}]}
+    with pytest.raises(CompositionError, match='nodl://pkg/missing'):
+        resolve_document(base, resolver)
+
+
+def test_included_document_is_schema_validated():
+    # The included document is itself invalid (bad parameter type); resolution must surface it.
+    resolver = FakeResolver({'nodl://pkg/bad': 'nodl_version: 2\nparameters:\n  p: {type: not_a_type}\n'})
+    base = {'nodl_version': 2, 'include': [{'ref': 'nodl://pkg/bad'}]}
+    with pytest.raises(Exception):
+        resolve_document(base, resolver)
+
+
+# ---------------------------------------------------------------------------
+# load_nodl integration
+# ---------------------------------------------------------------------------
+
+
+def test_load_nodl_resolves_by_default():
+    resolver = FakeResolver({
+        'nodl://pkg/extra': 'nodl_version: 2\nsubscriptions:\n  - name: /extra\n    type: std_msgs/msg/String\n    qos: {history: SYSTEM_DEFAULT, reliability: SYSTEM_DEFAULT}\n'
+    })
+    doc = load_nodl(
+        'nodl_version: 2\ninclude:\n  - ref: nodl://pkg/extra\n',
+        resolver=resolver,
+    )
+    assert doc.subscriptions[0].name == '/extra'
+    assert doc.include is None
+
+
+def test_load_nodl_no_resolve_keeps_include():
+    resolver = FakeResolver({})
+    doc = load_nodl(
+        'nodl_version: 2\ninclude:\n  - ref: nodl://pkg/extra\n',
+        resolve=False,
+        resolver=resolver,
+    )
+    assert doc.include[0].ref == 'nodl://pkg/extra'
+    assert resolver.calls == []
+
+
+def test_load_nodl_without_include_does_not_touch_resolver():
+    resolver = FakeResolver({})
+    load_nodl('nodl_version: 2\n', resolver=resolver)
+    assert resolver.calls == []
+
+
+# ---------------------------------------------------------------------------
+# DefaultResolver URI handling
+# ---------------------------------------------------------------------------
+
+
+def test_default_resolver_nodl_uri_uses_ament_resource(monkeypatch):
+    captured = {}
+
+    def fake_get_resource(resource_type, name):
+        captured['args'] = (resource_type, name)
+        return ('nodl_version: 2\n', '/some/path')
+
+    import ament_index_python.resources as resources
+
+    monkeypatch.setattr(resources, 'get_resource', fake_get_resource)
+    text = DefaultResolver().fetch('nodl://sensor_common/imu_driver')
+    assert captured['args'] == ('nodl_nodes', 'sensor_common__imu_driver')
+    assert 'nodl_version' in text
+
+
+def test_default_resolver_rejects_unknown_scheme():
+    with pytest.raises(CompositionError, match='scheme'):
+        DefaultResolver().fetch('ftp://example.com/x.yaml')

--- a/nodl_schema/test/test_composition.py
+++ b/nodl_schema/test/test_composition.py
@@ -7,10 +7,19 @@ neither an ament index nor network access. The default resolver's nodl:// URI
 parsing is tested separately with a stubbed ament lookup.
 """
 
+from pathlib import Path
+
 import pytest
 
 from nodl_schema import load_nodl
-from nodl_schema.composition import CompositionError, DefaultResolver, resolve_document
+from nodl_schema.composition import (
+    CompositionError,
+    DefaultResolver,
+    local_references,
+    path_to_ref,
+    resolve_document,
+    rewrite_references,
+)
 
 _MIN_QOS = {'history': 'SYSTEM_DEFAULT', 'reliability': 'SYSTEM_DEFAULT'}
 
@@ -228,3 +237,189 @@ def test_default_resolver_nodl_uri_uses_ament_resource(monkeypatch):
 def test_default_resolver_rejects_unknown_scheme():
     with pytest.raises(CompositionError, match='scheme'):
         DefaultResolver().fetch('ftp://example.com/x.yaml')
+
+
+def test_default_resolver_reads_file_ref(tmp_path: Path):
+    doc = tmp_path / 'x.nodl.yaml'
+    doc.write_text('nodl_version: 2\n')
+    assert 'nodl_version' in DefaultResolver().fetch(path_to_ref(doc))
+
+
+def test_default_resolver_missing_file_raises():
+    with pytest.raises(CompositionError):
+        DefaultResolver().fetch(path_to_ref('/nonexistent/nowhere.nodl.yaml'))
+
+
+# ---------------------------------------------------------------------------
+# Relative references: resolved against the origin of the containing document
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return path
+
+
+def test_relative_ref_resolves_against_document_directory(tmp_path: Path):
+    _write(tmp_path / 'common' / 'telemetry.nodl.yaml', f'nodl_version: 2\npublishers:\n  - {_pub("/telem")}\n')
+    main = _write(
+        tmp_path / 'my_node.nodl.yaml',
+        'nodl_version: 2\ninclude:\n  - ref: common/telemetry.nodl.yaml\n',
+    )
+    doc = load_nodl(main.read_text(), base=main)
+    assert [p.name for p in doc.publishers] == ['/telem']
+
+
+def test_relative_ref_resolves_from_open_file_without_explicit_base(tmp_path: Path):
+    # An open file knows its own path, so the CLI does not have to pass it twice.
+    _write(tmp_path / 'shared.nodl.yaml', f'nodl_version: 2\npublishers:\n  - {_pub("/shared")}\n')
+    main = _write(tmp_path / 'main.nodl.yaml', 'nodl_version: 2\ninclude:\n  - ref: shared.nodl.yaml\n')
+    with main.open() as f:
+        doc = load_nodl(f)
+    assert [p.name for p in doc.publishers] == ['/shared']
+
+
+def test_relative_ref_is_relative_to_the_including_document_not_the_root(tmp_path: Path):
+    # b/ leaf.nodl.yaml is named relative to b/mid.nodl.yaml, not to the top-level document.
+    _write(tmp_path / 'b' / 'leaf.nodl.yaml', f'nodl_version: 2\npublishers:\n  - {_pub("/leaf")}\n')
+    _write(tmp_path / 'b' / 'mid.nodl.yaml', 'nodl_version: 2\ninclude:\n  - ref: leaf.nodl.yaml\n')
+    main = _write(tmp_path / 'top.nodl.yaml', 'nodl_version: 2\ninclude:\n  - ref: b/mid.nodl.yaml\n')
+    doc = load_nodl(main.read_text(), base=main)
+    assert [p.name for p in doc.publishers] == ['/leaf']
+
+
+def test_relative_ref_may_walk_upward(tmp_path: Path):
+    _write(tmp_path / 'shared' / 'base.nodl.yaml', f'nodl_version: 2\npublishers:\n  - {_pub("/base")}\n')
+    main = _write(
+        tmp_path / 'nodl' / 'node.nodl.yaml',
+        'nodl_version: 2\ninclude:\n  - ref: ../shared/base.nodl.yaml\n',
+    )
+    doc = load_nodl(main.read_text(), base=main)
+    assert [p.name for p in doc.publishers] == ['/base']
+
+
+def test_relative_ref_without_base_raises(tmp_path: Path):
+    with pytest.raises(CompositionError, match='nothing to resolve against'):
+        load_nodl('nodl_version: 2\ninclude:\n  - ref: common/telemetry.nodl.yaml\n')
+
+
+def test_relative_ref_inside_ament_document_raises():
+    # A document fetched from the index is text with no location, so nothing in it can be relative.
+    resolver = FakeResolver({
+        'nodl://pkg/a': 'nodl_version: 2\ninclude:\n  - ref: sibling.nodl.yaml\n',
+    })
+    base = {'nodl_version': 2, 'include': [{'ref': 'nodl://pkg/a'}]}
+    with pytest.raises(CompositionError, match='no location to be relative to'):
+        resolve_document(base, resolver)
+
+
+def test_relative_cycle_is_detected_across_spellings(tmp_path: Path):
+    # a -> b -> ./a, two spellings of the same file. Normalizing before the cycle check is what
+    # makes this terminate rather than recursing.
+    _write(tmp_path / 'a.nodl.yaml', 'nodl_version: 2\ninclude:\n  - ref: b.nodl.yaml\n')
+    _write(tmp_path / 'b.nodl.yaml', 'nodl_version: 2\ninclude:\n  - ref: ./a.nodl.yaml\n')
+    main = tmp_path / 'a.nodl.yaml'
+    with pytest.raises(CompositionError, match='cycle'):
+        load_nodl(main.read_text(), base=main)
+
+
+def test_missing_relative_ref_raises(tmp_path: Path):
+    main = _write(tmp_path / 'main.nodl.yaml', 'nodl_version: 2\ninclude:\n  - ref: nope.nodl.yaml\n')
+    with pytest.raises(CompositionError, match='nope.nodl.yaml'):
+        load_nodl(main.read_text(), base=main)
+
+
+# ---------------------------------------------------------------------------
+# local_references: what registration needs to know about
+# ---------------------------------------------------------------------------
+
+
+def test_local_references_is_transitive(tmp_path: Path):
+    leaf = _write(tmp_path / 'leaf.nodl.yaml', 'nodl_version: 2\n')
+    mid = _write(tmp_path / 'mid.nodl.yaml', 'nodl_version: 2\ninclude:\n  - ref: leaf.nodl.yaml\n')
+    main = _write(tmp_path / 'main.nodl.yaml', 'nodl_version: 2\ninclude:\n  - ref: mid.nodl.yaml\n')
+    found = local_references({'include': [{'ref': 'mid.nodl.yaml'}]}, path_to_ref(main))
+    assert found == [mid, leaf]
+
+
+def test_local_references_ignores_nodl_uris(tmp_path: Path):
+    main = _write(tmp_path / 'main.nodl.yaml', 'nodl_version: 2\n')
+    data = {'include': [{'ref': 'nodl://other_pkg/thing'}]}
+    assert local_references(data, path_to_ref(main)) == []
+
+
+def test_local_references_survives_a_cycle(tmp_path: Path):
+    a = _write(tmp_path / 'a.nodl.yaml', 'nodl_version: 2\ninclude:\n  - ref: b.nodl.yaml\n')
+    b = _write(tmp_path / 'b.nodl.yaml', 'nodl_version: 2\ninclude:\n  - ref: a.nodl.yaml\n')
+    found = local_references({'include': [{'ref': 'b.nodl.yaml'}]}, path_to_ref(a))
+    assert found == [b, a]
+
+
+def test_local_references_deduplicates(tmp_path: Path):
+    shared = _write(tmp_path / 'shared.nodl.yaml', 'nodl_version: 2\n')
+    main = _write(tmp_path / 'main.nodl.yaml', 'nodl_version: 2\n')
+    data = {'include': [{'ref': 'shared.nodl.yaml'}, {'ref': './shared.nodl.yaml'}]}
+    assert local_references(data, path_to_ref(main)) == [shared]
+
+
+# ---------------------------------------------------------------------------
+# rewrite_references: what registration installs
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_replaces_relative_ref_with_registered_name(tmp_path: Path):
+    shared = _write(tmp_path / 'common' / 'telemetry.nodl.yaml', 'nodl_version: 2\n')
+    main = tmp_path / 'my_node.nodl.yaml'
+    data = {'nodl_version': 2, 'include': [{'ref': 'common/telemetry.nodl.yaml'}]}
+    out = rewrite_references(data, {shared: 'my_pkg/telemetry'}, path_to_ref(main))
+    assert out['include'] == [{'ref': 'nodl://my_pkg/telemetry'}]
+
+
+def test_rewrite_leaves_nodl_uris_alone(tmp_path: Path):
+    main = tmp_path / 'my_node.nodl.yaml'
+    data = {'nodl_version': 2, 'include': [{'ref': 'nodl://other_pkg/thing'}]}
+    out = rewrite_references(data, {}, path_to_ref(main))
+    assert out['include'] == [{'ref': 'nodl://other_pkg/thing'}]
+
+
+def test_rewrite_changes_nothing_else(tmp_path: Path):
+    shared = _write(tmp_path / 'shared.nodl.yaml', 'nodl_version: 2\n')
+    main = tmp_path / 'my_node.nodl.yaml'
+    data = {
+        'nodl_version': 2,
+        'description': 'a node',
+        'include': [{'ref': 'shared.nodl.yaml'}],
+        'publishers': [_pub('/status')],
+    }
+    out = rewrite_references(data, {shared: 'my_pkg/shared'}, path_to_ref(main))
+    assert out['description'] == 'a node'
+    assert out['publishers'] == [_pub('/status')]
+    # Entities are not merged in; only the reference changed.
+    assert 'subscriptions' not in out
+
+
+def test_rewrite_does_not_mutate_input(tmp_path: Path):
+    shared = _write(tmp_path / 'shared.nodl.yaml', 'nodl_version: 2\n')
+    main = tmp_path / 'my_node.nodl.yaml'
+    data = {'nodl_version': 2, 'include': [{'ref': 'shared.nodl.yaml'}]}
+    rewrite_references(data, {shared: 'my_pkg/shared'}, path_to_ref(main))
+    assert data['include'] == [{'ref': 'shared.nodl.yaml'}]
+
+
+def test_rewrite_of_unregistered_reference_raises(tmp_path: Path):
+    main = tmp_path / 'my_node.nodl.yaml'
+    data = {'nodl_version': 2, 'include': [{'ref': 'shared.nodl.yaml'}]}
+    with pytest.raises(CompositionError, match='not registered'):
+        rewrite_references(data, {}, path_to_ref(main))
+
+
+def test_rewrite_is_not_recursive(tmp_path: Path):
+    # mid's own reference is left alone; mid is rewritten by its own registration.
+    mid = _write(tmp_path / 'mid.nodl.yaml', 'nodl_version: 2\ninclude:\n  - ref: leaf.nodl.yaml\n')
+    _write(tmp_path / 'leaf.nodl.yaml', 'nodl_version: 2\n')
+    main = tmp_path / 'main.nodl.yaml'
+    data = {'nodl_version': 2, 'include': [{'ref': 'mid.nodl.yaml'}]}
+    out = rewrite_references(data, {mid: 'my_pkg/mid'}, path_to_ref(main))
+    assert out['include'] == [{'ref': 'nodl://my_pkg/mid'}]
+    assert 'leaf.nodl.yaml' in mid.read_text()

--- a/nodl_schema/test/test_schema.py
+++ b/nodl_schema/test/test_schema.py
@@ -262,8 +262,33 @@ def test_include_nodl_uri_accepted():
     validate({'nodl_version': 2, 'include': [{'ref': 'nodl://sensor_common/imu_driver'}]})
 
 
-def test_include_http_url_accepted():
-    validate({'nodl_version': 2, 'include': [{'ref': 'https://example.com/shared/telemetry.nodl.yaml'}]})
+@pytest.mark.parametrize(
+    'ref',
+    [
+        'telemetry.nodl.yaml',
+        'common/telemetry.nodl.yaml',
+        './telemetry.nodl.yaml',
+        '../shared/telemetry.nodl.yaml',
+    ],
+)
+def test_include_relative_path_accepted(ref):
+    validate({'nodl_version': 2, 'include': [{'ref': ref}]})
+
+
+@pytest.mark.parametrize(
+    'ref',
+    [
+        '/absolute/telemetry.nodl.yaml',  # cannot mean the same thing on two machines
+        'https://example.com/shared/telemetry.nodl.yaml',  # no network form
+        'ftp://example.com/telemetry.nodl.yaml',
+        'nodl://pkg',  # missing name
+        'nodl://pkg/nested/name',  # a registered name has no path separators
+        '',
+    ],
+)
+def test_include_bad_ref_rejected(ref):
+    with pytest.raises(ValidationError):
+        validate({'nodl_version': 2, 'include': [{'ref': ref}]})
 
 
 def test_include_empty_list_accepted():

--- a/nodl_schema/test/test_schema.py
+++ b/nodl_schema/test/test_schema.py
@@ -252,6 +252,44 @@ def test_base_no_longer_allowed():
         validate({'nodl_version': 2, 'base': 'lifecycle_node'})
 
 
+# ---------------------------------------------------------------------------
+# include (composition references) -- schema shape only; resolution is in
+# test_composition.py
+# ---------------------------------------------------------------------------
+
+
+def test_include_nodl_uri_accepted():
+    validate({'nodl_version': 2, 'include': [{'ref': 'nodl://sensor_common/imu_driver'}]})
+
+
+def test_include_http_url_accepted():
+    validate({'nodl_version': 2, 'include': [{'ref': 'https://example.com/shared/telemetry.nodl.yaml'}]})
+
+
+def test_include_empty_list_accepted():
+    validate({'nodl_version': 2, 'include': []})
+
+
+def test_include_missing_ref_rejected():
+    with pytest.raises(ValidationError):
+        validate({'nodl_version': 2, 'include': [{}]})
+
+
+def test_include_extra_key_rejected():
+    with pytest.raises(ValidationError):
+        validate({'nodl_version': 2, 'include': [{'ref': 'nodl://pkg/x', 'when': 'always'}]})
+
+
+def test_include_unsupported_scheme_rejected():
+    with pytest.raises(ValidationError):
+        validate({'nodl_version': 2, 'include': [{'ref': 'ftp://example.com/x.nodl.yaml'}]})
+
+
+def test_include_bare_string_rejected():
+    with pytest.raises(ValidationError):
+        validate({'nodl_version': 2, 'include': ['nodl://pkg/x']})
+
+
 def test_invalid_parameter_type():
     with pytest.raises(ValidationError):
         validate({'nodl_version': 2, 'parameters': {'p': {'type': 'float'}}})

--- a/nodl_schema/test/test_validator_cli.py
+++ b/nodl_schema/test/test_validator_cli.py
@@ -96,3 +96,101 @@ def test_no_resolve_skips_reference_resolution(tmp_path: Path):
     f.write_text(_UNRESOLVABLE_INCLUDE)
     result = _run(f, '--no-resolve')
     assert result.returncode == 0, result.stderr
+
+
+def test_relative_include_validates_against_the_source_tree(tmp_path: Path):
+    # The whole point of the relative form: it resolves at build time, before anything is installed.
+    (tmp_path / 'shared.nodl.yaml').write_text(_VALID)
+    f = tmp_path / 'main.nodl.yaml'
+    f.write_text('nodl_version: 2\ninclude:\n  - ref: shared.nodl.yaml\n')
+    result = _run(f)
+    assert result.returncode == 0, result.stderr
+
+
+def test_missing_relative_include_exits_one(tmp_path: Path):
+    f = tmp_path / 'main.nodl.yaml'
+    f.write_text('nodl_version: 2\ninclude:\n  - ref: absent.nodl.yaml\n')
+    result = _run(f)
+    assert result.returncode == 1
+    assert str(f) in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# --list-references and --rewrite-to: the two modes ament_nodl_register_node uses
+# ---------------------------------------------------------------------------
+
+
+def test_list_references_reports_transitive_paths(tmp_path: Path):
+    (tmp_path / 'leaf.nodl.yaml').write_text('nodl_version: 2\n')
+    (tmp_path / 'mid.nodl.yaml').write_text('nodl_version: 2\ninclude:\n  - ref: leaf.nodl.yaml\n')
+    f = tmp_path / 'main.nodl.yaml'
+    f.write_text('nodl_version: 2\ninclude:\n  - ref: mid.nodl.yaml\n')
+
+    result = _run(f, '--list-references')
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split() == [str(tmp_path / 'mid.nodl.yaml'), str(tmp_path / 'leaf.nodl.yaml')]
+
+
+def test_list_references_is_empty_without_relative_includes(tmp_path: Path):
+    f = tmp_path / 'main.nodl.yaml'
+    f.write_text(_UNRESOLVABLE_INCLUDE)
+    result = _run(f, '--list-references')
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ''
+
+
+def test_rewrite_emits_document_with_nodl_refs(tmp_path: Path):
+    shared = tmp_path / 'common' / 'telemetry.nodl.yaml'
+    shared.parent.mkdir()
+    shared.write_text('nodl_version: 2\n')
+    f = tmp_path / 'main.nodl.yaml'
+    f.write_text('nodl_version: 2\ninclude:\n  - ref: common/telemetry.nodl.yaml\n')
+    out = tmp_path / 'gen' / 'main.nodl.yaml'
+
+    result = _run(f, '--rewrite-to', str(out), '--map', f'{shared}=my_pkg/telemetry')
+    assert result.returncode == 0, result.stderr
+    assert 'nodl://my_pkg/telemetry' in out.read_text()
+
+
+def test_rewrite_without_relative_refs_copies_bytes(tmp_path: Path):
+    # Most documents have nothing to rewrite; those must install exactly as authored.
+    f = tmp_path / 'main.nodl.yaml'
+    f.write_text(_VALID)
+    out = tmp_path / 'out.nodl.yaml'
+    assert _run(f, '--rewrite-to', str(out)).returncode == 0
+    assert out.read_bytes() == f.read_bytes()
+
+
+def test_rewrite_preserves_json_frontend(tmp_path: Path):
+    shared = tmp_path / 'shared.nodl.yaml'
+    shared.write_text('nodl_version: 2\n')
+    f = tmp_path / 'main.nodl.json'
+    f.write_text('{"nodl_version": 2, "include": [{"ref": "shared.nodl.yaml"}]}\n')
+    out = tmp_path / 'out.nodl.json'
+
+    assert _run(f, '--rewrite-to', str(out), '--map', f'{shared}=my_pkg/shared').returncode == 0
+    text = out.read_text()
+    assert '"nodl_version": 2' in text
+    assert 'nodl://my_pkg/shared' in text
+
+
+def test_rewrite_of_unregistered_reference_exits_one(tmp_path: Path):
+    (tmp_path / 'shared.nodl.yaml').write_text('nodl_version: 2\n')
+    f = tmp_path / 'main.nodl.yaml'
+    f.write_text('nodl_version: 2\ninclude:\n  - ref: shared.nodl.yaml\n')
+    result = _run(f, '--rewrite-to', str(tmp_path / 'out.nodl.yaml'))
+    assert result.returncode == 1
+    assert 'not registered' in result.stderr
+
+
+def test_rewritten_document_still_validates(tmp_path: Path):
+    # What gets installed has to be a valid NoDL document in its own right.
+    shared = tmp_path / 'shared.nodl.yaml'
+    shared.write_text('nodl_version: 2\n')
+    f = tmp_path / 'main.nodl.yaml'
+    f.write_text(f'{_VALID}include:\n  - ref: shared.nodl.yaml\n')
+    out = tmp_path / 'out.nodl.yaml'
+
+    assert _run(f, '--rewrite-to', str(out), '--map', f'{shared}=my_pkg/shared').returncode == 0
+    result = _run(out, '--no-resolve')
+    assert result.returncode == 0, result.stderr

--- a/nodl_schema/test/test_validator_cli.py
+++ b/nodl_schema/test/test_validator_cli.py
@@ -28,10 +28,17 @@ parameters:
 
 _INVALID_NOT_A_MAPPING = '- just a list\n'
 
+# A schema-valid document whose include cannot be resolved (no such package in the ament index).
+_UNRESOLVABLE_INCLUDE = """\
+nodl_version: 2
+include:
+  - ref: nodl://no_such_package/no_such_node
+"""
 
-def _run(file: Path) -> subprocess.CompletedProcess:
+
+def _run(file: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(
-        [sys.executable, '-m', 'nodl_schema', str(file)],
+        [sys.executable, '-m', 'nodl_schema', *args, str(file)],
         capture_output=True,
         text=True,
     )
@@ -71,4 +78,21 @@ def test_json_frontend_supported(tmp_path: Path):
     f = tmp_path / 'ok.nodl.json'
     f.write_text('{"nodl_version": 2}\n')
     result = _run(f)
+    assert result.returncode == 0, result.stderr
+
+
+def test_unresolvable_include_exits_one_by_default(tmp_path: Path):
+    # The default (resolving) path is what the CMake macro runs, so an unresolvable include must fail.
+    f = tmp_path / 'inc.nodl.yaml'
+    f.write_text(_UNRESOLVABLE_INCLUDE)
+    result = _run(f)
+    assert result.returncode == 1
+    assert str(f) in result.stderr
+
+
+def test_no_resolve_skips_reference_resolution(tmp_path: Path):
+    # --no-resolve checks the schema only, so an unresolvable include is fine.
+    f = tmp_path / 'inc.nodl.yaml'
+    f.write_text(_UNRESOLVABLE_INCLUDE)
+    result = _run(f, '--no-resolve')
     assert result.returncode == 0, result.stderr

--- a/ros2nodl/ros2nodl/verb/validate.py
+++ b/ros2nodl/ros2nodl/verb/validate.py
@@ -19,10 +19,17 @@ class ValidateVerb(VerbExtension):
             nargs='*',
             help='NoDL files to validate. Reads from stdin if none are given.',
         )
+        parser.add_argument(
+            '--no-resolve',
+            dest='resolve',
+            action='store_false',
+            help='Validate the schema only; do not resolve include references.',
+        )
 
     def main(self, *, args):
+        resolve = getattr(args, 'resolve', True)
         if not args.files:
-            return _validate_source(sys.stdin, '<stdin>')
+            return _validate_source(sys.stdin, '<stdin>', resolve=resolve)
 
         rc = 0
         for path in args.files:
@@ -33,15 +40,15 @@ class ValidateVerb(VerbExtension):
                 rc = 1
                 continue
             try:
-                rc |= _validate_source(source, path)
+                rc |= _validate_source(source, path, resolve=resolve)
             finally:
                 source.close()
         return rc
 
 
-def _validate_source(source, label) -> int:
+def _validate_source(source, label, *, resolve: bool = True) -> int:
     try:
-        load_nodl(source)
+        load_nodl(source, resolve=resolve)
     except ValidationError as e:
         path = ' -> '.join(str(p) for p in e.absolute_path) or '<root>'
         print(f'{label}: INVALID', file=sys.stderr)

--- a/ros2nodl/test/test_verbs.py
+++ b/ros2nodl/test/test_verbs.py
@@ -8,10 +8,14 @@ import io
 from ros2nodl.verb.validate import ValidateVerb
 
 
-def _make_args(files=None):
+def _make_args(files=None, resolve=True):
     args = argparse.Namespace()
     args.files = files or []
+    args.resolve = resolve
     return args
+
+
+_UNRESOLVABLE_INCLUDE = 'nodl_version: 2\ninclude:\n  - ref: nodl://no_such_package/no_such_node\n'
 
 
 class TestValidateVerb:
@@ -86,3 +90,15 @@ class TestValidateVerb:
         bad.write_text('nodl_version: 1\n')
         result = self.verb.main(args=_make_args(files=[str(good), str(bad)]))
         assert result == 1
+
+    def test_unresolvable_include_returns_1_by_default(self, tmp_path):
+        nodl_file = tmp_path / 'inc.yaml'
+        nodl_file.write_text(_UNRESOLVABLE_INCLUDE)
+        result = self.verb.main(args=_make_args(files=[str(nodl_file)]))
+        assert result == 1
+
+    def test_no_resolve_skips_reference_resolution(self, tmp_path):
+        nodl_file = tmp_path / 'inc.yaml'
+        nodl_file.write_text(_UNRESOLVABLE_INCLUDE)
+        result = self.verb.main(args=_make_args(files=[str(nodl_file)], resolve=False))
+        assert result == 0

--- a/test_ament_nodl/CMakeLists.txt
+++ b/test_ament_nodl/CMakeLists.txt
@@ -21,6 +21,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(register_node_tests test/test_register_node.py)
   ament_add_pytest_test(macro_rejection_tests test/test_macro_rejection.py)
+  ament_add_pytest_test(composition_tests test/test_composition.py)
 endif()
 
 ament_package()

--- a/test_ament_nodl/CMakeLists.txt
+++ b/test_ament_nodl/CMakeLists.txt
@@ -17,6 +17,11 @@ ament_nodl_register_node(custom_exe
 # Non-yaml frontend. Make sure the macro is extension-agnostic.
 ament_nodl_register_node(json_node FILE test/fixtures/json_node.nodl.json)
 
+# Relative includes. telemetry must be registered first: composed_node references it by path, and
+# the macro rewrites that path to nodl://test_ament_nodl/telemetry using this registration's name.
+ament_nodl_register_node(telemetry FILE test/fixtures/common/telemetry.nodl.yaml)
+ament_nodl_register_node(composed_node FILE test/fixtures/composed_node.nodl.yaml)
+
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(register_node_tests test/test_register_node.py)

--- a/test_ament_nodl/package.xml
+++ b/test_ament_nodl/package.xml
@@ -13,6 +13,7 @@
 
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_index_python</test_depend>
+  <test_depend>nodl_schema</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/test_ament_nodl/test/fixtures/common/telemetry.nodl.yaml
+++ b/test_ament_nodl/test/fixtures/common/telemetry.nodl.yaml
@@ -1,0 +1,10 @@
+---
+nodl_version: 2
+description: Shared telemetry surface, included by other documents in this package.
+publishers:
+  - name: /telemetry/heartbeat
+    type: std_msgs/msg/String
+    qos:
+      history: KEEP_LAST
+      depth: 1
+      reliability: BEST_EFFORT

--- a/test_ament_nodl/test/fixtures/composed_node.nodl.yaml
+++ b/test_ament_nodl/test/fixtures/composed_node.nodl.yaml
@@ -1,0 +1,12 @@
+---
+nodl_version: 2
+description: Node composed from a relative include, to exercise reference rewriting at registration.
+include:
+  - ref: common/telemetry.nodl.yaml
+subscriptions:
+  - name: /commands
+    type: std_msgs/msg/String
+    qos:
+      history: KEEP_LAST
+      depth: 10
+      reliability: RELIABLE

--- a/test_ament_nodl/test/test_composition.py
+++ b/test_ament_nodl/test/test_composition.py
@@ -8,10 +8,18 @@ default resolver finds it in the installed index and merges its entities. This e
 resolver + ament index + merge path against real registrations, post-install.
 """
 
+from pathlib import Path
+
 import pytest
+from ament_index_python.packages import get_package_share_directory
+from ament_index_python.resources import get_resource
 
 from nodl_schema import load_nodl
 from nodl_schema.composition import CompositionError
+
+
+def _share(pkg: str = 'test_ament_nodl') -> Path:
+    return Path(get_package_share_directory(pkg))
 
 
 def test_nodl_include_resolves_from_ament_index():
@@ -44,3 +52,53 @@ def test_no_resolve_leaves_unresolved_include_untouched():
         resolve=False,
     )
     assert doc.include[0].ref == 'nodl://test_ament_nodl/no_such_node'
+
+
+# ---------------------------------------------------------------------------
+# Relative includes, post-install
+# ---------------------------------------------------------------------------
+#
+# composed_node.nodl.yaml is authored with ``ref: common/telemetry.nodl.yaml``. A consumer reading
+# it back out of the index gets text and nothing else, so that path would have nothing to resolve
+# against. Registration therefore rewrites it to the name telemetry was registered under.
+
+
+def test_installed_document_carries_a_rewritten_reference():
+    content, _ = get_resource('nodl_nodes', 'test_ament_nodl__composed_node')
+    assert 'nodl://test_ament_nodl/telemetry' in content
+    assert 'common/telemetry.nodl.yaml' not in content
+
+
+def test_share_copy_is_rewritten_too():
+    # Both install destinations get the rewritten document, so the two agree.
+    share_copy = (_share() / 'nodl' / 'composed_node.nodl.yaml').read_text()
+    content, _ = get_resource('nodl_nodes', 'test_ament_nodl__composed_node')
+    assert 'nodl://test_ament_nodl/telemetry' in share_copy
+    assert share_copy == content
+
+
+def test_rewrite_preserves_the_rest_of_the_document():
+    # Only the reference changes; everything the author wrote is still there.
+    content, _ = get_resource('nodl_nodes', 'test_ament_nodl__composed_node')
+    assert 'Node composed from a relative include' in content
+    assert '/commands' in content
+
+
+def test_downstream_consumer_resolves_the_rewritten_reference():
+    # The whole point: a consumer with no knowledge of the source layout resolves the chain.
+    content, _ = get_resource('nodl_nodes', 'test_ament_nodl__composed_node')
+    doc = load_nodl(content)
+    assert any(p.name == '/telemetry/heartbeat' for p in doc.publishers)
+    assert any(s.name == '/commands' for s in doc.subscriptions)
+    assert doc.include is None
+
+
+def test_referenced_document_is_registered_in_its_own_right():
+    content, _ = get_resource('nodl_nodes', 'test_ament_nodl__telemetry')
+    assert 'Shared telemetry surface' in content
+
+
+def test_document_without_relative_refs_is_installed_unchanged():
+    # Only documents that actually have something to rewrite are re-serialized.
+    content, _ = get_resource('nodl_nodes', 'test_ament_nodl__basic_node')
+    assert content == (_share() / 'nodl' / 'basic_node.nodl.yaml').read_text()

--- a/test_ament_nodl/test/test_composition.py
+++ b/test_ament_nodl/test/test_composition.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end composition test: resolve a nodl:// include through the real ament index.
+
+The macro registers ``basic_node`` under ``nodl_nodes/test_ament_nodl__basic_node`` (see
+CMakeLists.txt). Here we author a document that includes it via ``nodl://`` and confirm the
+default resolver finds it in the installed index and merges its entities. This exercises the
+resolver + ament index + merge path against real registrations, post-install.
+"""
+
+import pytest
+
+from nodl_schema import load_nodl
+from nodl_schema.composition import CompositionError
+
+
+def test_nodl_include_resolves_from_ament_index():
+    # basic_node contributes a /chatter publisher; the including doc adds its own subscription.
+    doc = load_nodl(
+        'nodl_version: 2\n'
+        'subscriptions:\n'
+        '  - name: /local_input\n'
+        '    type: std_msgs/msg/String\n'
+        '    qos: {history: SYSTEM_DEFAULT, reliability: SYSTEM_DEFAULT}\n'
+        'include:\n'
+        '  - ref: nodl://test_ament_nodl/basic_node\n'
+    )
+    assert any(p.name == '/chatter' for p in doc.publishers)
+    assert any(s.name == '/local_input' for s in doc.subscriptions)
+    # The include key is consumed once resolved.
+    assert doc.include is None
+
+
+def test_unresolvable_nodl_include_raises():
+    with pytest.raises(CompositionError, match='nodl://test_ament_nodl/no_such_node'):
+        load_nodl(
+            'nodl_version: 2\ninclude:\n  - ref: nodl://test_ament_nodl/no_such_node\n',
+        )
+
+
+def test_no_resolve_leaves_unresolved_include_untouched():
+    doc = load_nodl(
+        'nodl_version: 2\ninclude:\n  - ref: nodl://test_ament_nodl/no_such_node\n',
+        resolve=False,
+    )
+    assert doc.include[0].ref == 'nodl://test_ament_nodl/no_such_node'

--- a/test_ament_nodl/test/test_macro_rejection.py
+++ b/test_ament_nodl/test/test_macro_rejection.py
@@ -50,6 +50,32 @@ _INVALID_NODL = textwrap.dedent("""
 """).lstrip()
 
 
+_VALID_NODL = 'nodl_version: 2\n'
+
+# composed.nodl.yaml references shared.nodl.yaml, but nothing registers shared.nodl.yaml.
+# There is no name to rewrite the reference to, so this must fail at configure time.
+_UNREGISTERED_REF_CMAKELISTS = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.22)
+    project(rejection_fixture)
+    find_package(ament_cmake REQUIRED)
+    find_package(ament_nodl REQUIRED)
+    ament_nodl_register_node(composed FILE composed.nodl.yaml)
+    ament_package()
+""")
+
+# Two different files both claiming the name 'thing'. The second registration would take over a
+# name that an already-rewritten reference could point at, so it must fail at configure time.
+_DUPLICATE_NAME_CMAKELISTS = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.22)
+    project(rejection_fixture)
+    find_package(ament_cmake REQUIRED)
+    find_package(ament_nodl REQUIRED)
+    ament_nodl_register_node(thing FILE one.nodl.yaml)
+    ament_nodl_register_node(thing FILE two.nodl.yaml)
+    ament_package()
+""")
+
+
 @pytest.fixture
 def inner_pkg(tmp_path: Path) -> Path:
     pkg = tmp_path / 'rejection_fixture'
@@ -58,6 +84,15 @@ def inner_pkg(tmp_path: Path) -> Path:
     (pkg / 'package.xml').write_text(_INNER_PACKAGE_XML)
     (pkg / 'bad.nodl.yaml').write_text(_INVALID_NODL)
     return pkg
+
+
+def _configure(pkg: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ['cmake', '-S', str(pkg), '-B', str(pkg / 'build')],
+        capture_output=True,
+        text=True,
+        env=os.environ,
+    )
 
 
 @pytest.mark.skipif(shutil.which('cmake') is None, reason='cmake not on PATH')
@@ -84,3 +119,50 @@ def test_macro_rejects_invalid_node(inner_pkg: Path):
     assert 'not_a_real_type' in combined, (
         f'Expected the validator error to appear in the build output, got:\n{combined}'
     )
+
+
+@pytest.mark.skipif(shutil.which('cmake') is None, reason='cmake not on PATH')
+def test_macro_rejects_reference_to_unregistered_document(tmp_path: Path):
+    # The error belongs at configure time, because the fix is the ordering of calls in CMakeLists.
+    pkg = tmp_path / 'rejection_fixture'
+    pkg.mkdir()
+    (pkg / 'CMakeLists.txt').write_text(_UNREGISTERED_REF_CMAKELISTS)
+    (pkg / 'package.xml').write_text(_INNER_PACKAGE_XML)
+    (pkg / 'shared.nodl.yaml').write_text(_VALID_NODL)
+    (pkg / 'composed.nodl.yaml').write_text('nodl_version: 2\ninclude:\n  - ref: shared.nodl.yaml\n')
+
+    result = _configure(pkg)
+    assert result.returncode != 0, 'Expected configure to fail on the unregistered reference'
+    combined = result.stdout + result.stderr
+    assert 'not registered' in combined, f'Expected an unregistered-reference error, got:\n{combined}'
+    assert 'shared.nodl.yaml' in combined
+
+
+@pytest.mark.skipif(shutil.which('cmake') is None, reason='cmake not on PATH')
+def test_macro_rejects_one_name_registered_from_two_files(tmp_path: Path):
+    pkg = tmp_path / 'rejection_fixture'
+    pkg.mkdir()
+    (pkg / 'CMakeLists.txt').write_text(_DUPLICATE_NAME_CMAKELISTS)
+    (pkg / 'package.xml').write_text(_INNER_PACKAGE_XML)
+    (pkg / 'one.nodl.yaml').write_text(_VALID_NODL)
+    (pkg / 'two.nodl.yaml').write_text(_VALID_NODL)
+
+    result = _configure(pkg)
+    assert result.returncode != 0, 'Expected configure to fail on the duplicate name'
+    combined = result.stdout + result.stderr
+    assert 'already registered' in combined, f'Expected a duplicate-name error, got:\n{combined}'
+
+
+@pytest.mark.skipif(shutil.which('cmake') is None, reason='cmake not on PATH')
+def test_macro_rejects_the_same_name_registered_twice_from_one_file(tmp_path: Path):
+    # A repeated call is rejected too, for a plainer reason: each registration creates its own
+    # custom target, so the second one has nowhere to go.
+    pkg = tmp_path / 'rejection_fixture'
+    pkg.mkdir()
+    (pkg / 'CMakeLists.txt').write_text(_DUPLICATE_NAME_CMAKELISTS.replace('FILE two.nodl.yaml', 'FILE one.nodl.yaml'))
+    (pkg / 'package.xml').write_text(_INNER_PACKAGE_XML)
+    (pkg / 'one.nodl.yaml').write_text(_VALID_NODL)
+
+    result = _configure(pkg)
+    assert result.returncode != 0, 'Expected configure to fail on the repeated registration'
+    assert 'already registered' in result.stdout + result.stderr


### PR DESCRIPTION
Replace https://github.com/ros-tooling/nodl/pull/86 with a simpler approach, just allow for including nodl by reference. No other updates to the concepts or schema.