### PR TITLE
Skip docs-only Test runs and cancel superseded PR runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,15 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**/doc/**'
   workflow_dispatch:
+
+# Supersede obsolete runs for the same PR; never cancel a push to main.
+concurrency:
+  group: test-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build_and_test:


### PR DESCRIPTION
## Summary
- skip the Test workflow for pull requests containing only Markdown files and package doc/ trees
- cancel superseded Test runs for the same pull request
- retain the full five-distro Test matrix for non-documentation pull requests and all pushes to main

## Verification
- YAML valid
- 