### PR TITLE
Include package-local relative reference

### DIFF
--- a/ament_nodl/cmake/ament_nodl_register_node.cmake
+++ b/ament_nodl/cmake/ament_nodl_register_node.cmake
@@ -13,6 +13,12 @@
 #
 # The source file is also installed under ``share/<package>/nodl/`` for direct filesystem access.
 #
+# If the document uses ``local://`` includes, what installs is a rewritten copy in which each has
+# become ``nodl://<package>/<name>``.
+# A relative reference means nothing to a consumer reading the document out of the index, so it is
+# replaced by a name that does.
+# The referenced document must already be registered by an earlier call, which supplies that name.
+#
 # Example::
 #
 #   ament_nodl_register_node(my_node
@@ -49,31 +55,137 @@ function(ament_nodl_register_node executable_name)
       "ament_nodl_register_node: file not found at configure time: ${_abs_file}")
   endif()
 
-  # Validate the file at build time so authoring errors surface when registering, not downstream when consuming.
-  # This only runs when ${_abs_file} changes.
-  set(_stamp_dir "${CMAKE_CURRENT_BINARY_DIR}/ament_nodl/nodl_nodes")
-  set(_stamp "${_stamp_dir}/${_ARGS_PACKAGE}__${executable_name}.valid.stamp")
-  file(MAKE_DIRECTORY "${_stamp_dir}")
+  _ament_nodl_record_registration("${_abs_file}" "${_ARGS_PACKAGE}" "${executable_name}")
+  _ament_nodl_local_references("${_abs_file}" _local_refs)
+  _ament_nodl_name_map(_map_args)
+
+  # Every local reference must already be registered, so the rewrite cannot fail on a name that
+  # does not exist. Checking at configure time puts the error where the fix is: the order of calls
+  # in this CMakeLists.
+  get_property(_registered GLOBAL PROPERTY _AMENT_NODL_REGISTERED_PATHS)
+  foreach(_ref IN LISTS _local_refs)
+    if(NOT "${_ref}" IN_LIST _registered)
+      message(FATAL_ERROR
+        "ament_nodl_register_node(${executable_name}): ${_abs_file} references ${_ref}, "
+        "which is not registered.\n"
+        "Add an ament_nodl_register_node() call for it above this one.")
+    endif()
+  endforeach()
+
+  # Validate the file at build time so authoring errors surface when registering, not downstream
+  # when consuming. Rewriting reads only ${_abs_file}, but validation follows local references into
+  # the source tree, so this reruns when any of those change too.
+  get_filename_component(_basename "${_abs_file}" NAME)
+  set(_gen_dir "${CMAKE_CURRENT_BINARY_DIR}/ament_nodl/${_ARGS_PACKAGE}__${executable_name}")
+  set(_gen_file "${_gen_dir}/${_basename}")
   add_custom_command(
-    OUTPUT "${_stamp}"
-    DEPENDS "${_abs_file}"
+    OUTPUT "${_gen_file}"
+    DEPENDS "${_abs_file}" ${_local_refs}
     COMMAND "${Python3_EXECUTABLE}" -m nodl_schema "${_abs_file}"
-    COMMAND "${CMAKE_COMMAND}" -E touch "${_stamp}"
+    COMMAND "${Python3_EXECUTABLE}" -m nodl_schema "${_abs_file}"
+      --rewrite-to "${_gen_file}" --package "${_ARGS_PACKAGE}" ${_map_args}
     COMMENT "Validating NoDL node ${_ARGS_PACKAGE}/${executable_name}"
     VERBATIM
   )
   add_custom_target(_ament_nodl_validate_node_${_ARGS_PACKAGE}__${executable_name} ALL
-    DEPENDS "${_stamp}"
+    DEPENDS "${_gen_file}"
   )
 
   # Install to ament index
   install(
-    FILES "${_abs_file}"
+    FILES "${_gen_file}"
     DESTINATION "share/ament_index/resource_index/nodl_nodes"
     RENAME "${_ARGS_PACKAGE}__${executable_name}")
 
   # Install to package's share directory
   install(
-    FILES "${_abs_file}"
+    FILES "${_gen_file}"
     DESTINATION "share/${_ARGS_PACKAGE}/nodl")
+endfunction()
+
+#
+# Record a registration so later calls can rewrite local references pointing at it.
+#
+# Two parallel global lists hold the record: an absolute path, and the ``<package>/<name>`` it was
+# registered as. A name may map to only one file, since a second registration would quietly take
+# over a name that an already-rewritten reference points at.
+#
+function(_ament_nodl_record_registration abs_file package name)
+  get_property(_paths GLOBAL PROPERTY _AMENT_NODL_REGISTERED_PATHS)
+  get_property(_targets GLOBAL PROPERTY _AMENT_NODL_REGISTERED_TARGETS)
+  set(_target "${package}/${name}")
+
+  list(FIND _targets "${_target}" _index)
+  if(NOT _index EQUAL -1)
+    list(GET _paths ${_index} _existing)
+    if(NOT "${_existing}" STREQUAL "${abs_file}")
+      message(FATAL_ERROR
+        "ament_nodl_register_node: ${_target} is already registered from a different file.\n"
+        "  first:  ${_existing}\n"
+        "  second: ${abs_file}\n"
+        "A name may refer to only one document, since references are rewritten to it by name.")
+    endif()
+    message(FATAL_ERROR
+      "ament_nodl_register_node: ${_target} is already registered from ${abs_file}.\n"
+      "Remove the duplicate call.")
+  endif()
+
+  set_property(GLOBAL APPEND PROPERTY _AMENT_NODL_REGISTERED_PATHS "${abs_file}")
+  set_property(GLOBAL APPEND PROPERTY _AMENT_NODL_REGISTERED_TARGETS "${_target}")
+endfunction()
+
+#
+# Return the documents reachable from a file through local references, transitively.
+#
+# Also marks them as configure dependencies, so adding or removing a reference in any of them
+# reruns configure and refreshes this list.
+#
+function(_ament_nodl_local_references abs_file out_var)
+  # A document generated by another custom command does not exist yet, and registering one is
+  # supported (the missing-file case is a warning above, not an error). There is nothing to read.
+  if(NOT EXISTS "${abs_file}")
+    set(${out_var} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  execute_process(
+    COMMAND "${Python3_EXECUTABLE}" -m nodl_schema "${abs_file}" --list-references
+    OUTPUT_VARIABLE _output
+    ERROR_VARIABLE _error
+    RESULT_VARIABLE _result
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  # Reading includes is best-effort. A document that cannot be parsed at configure time still gets
+  # validated at build time, which is where that error belongs and reads better.
+  if(NOT _result EQUAL 0)
+    set(${out_var} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  string(REPLACE "\n" ";" _refs "${_output}")
+  list(REMOVE_ITEM _refs "")
+  if(_refs)
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${_refs})
+  endif()
+  set(${out_var} "${_refs}" PARENT_SCOPE)
+endfunction()
+
+#
+# Build the ``--map <path>=<package>/<name>`` arguments describing every registration so far.
+#
+function(_ament_nodl_name_map out_var)
+  get_property(_paths GLOBAL PROPERTY _AMENT_NODL_REGISTERED_PATHS)
+  get_property(_targets GLOBAL PROPERTY _AMENT_NODL_REGISTERED_TARGETS)
+
+  set(_args "")
+  list(LENGTH _paths _count)
+  if(_count GREATER 0)
+    math(EXPR _last "${_count} - 1")
+    foreach(_i RANGE ${_last})
+      list(GET _paths ${_i} _path)
+      list(GET _targets ${_i} _target)
+      list(APPEND _args "--map" "${_path}=${_target}")
+    endforeach()
+  endif()
+  set(${out_var} "${_args}" PARENT_SCOPE)
 endfunction()

--- a/nodl_schema/nodl_schema/__init__.py
+++ b/nodl_schema/nodl_schema/__init__.py
@@ -4,6 +4,7 @@
 
 from nodl_schema.ament_resolver import AmentIndexResolver
 from nodl_schema.composition import (
+    RebasingResolver,
     ResolutionError,
     Resolver,
     get_resolvers,
@@ -12,12 +13,17 @@ from nodl_schema.composition import (
     unregister_resolver,
 )
 from nodl_schema.loader import dump_nodl, load_nodl, load_nodl_with_doc_tree, resolve_document
+from nodl_schema.local_resolver import LocalResolver
+from nodl_schema.rewrite import local_references, rewrite_file, rewrite_local_references
 from nodl_schema.validation import load_schema, validate
 
 register_resolver(AmentIndexResolver())
+register_resolver(LocalResolver())
 
 __all__ = [
     'AmentIndexResolver',
+    'LocalResolver',
+    'RebasingResolver',
     'ResolutionError',
     'Resolver',
     'dump_nodl',
@@ -25,9 +31,12 @@ __all__ = [
     'load_nodl_with_doc_tree',
     'load_schema',
     'get_resolvers',
+    'local_references',
     'register_resolver',
     'resolve_document',
     'resolver_registered',
+    'rewrite_file',
+    'rewrite_local_references',
     'unregister_resolver',
     'validate',
 ]

--- a/nodl_schema/nodl_schema/cli.py
+++ b/nodl_schema/nodl_schema/cli.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 
 from nodl_schema.loader import load_nodl
+from nodl_schema.local_resolver import path_to_ref
+from nodl_schema.rewrite import includes_only, local_references, rewrite_file
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -13,6 +15,10 @@ def main(argv: list[str] | None = None) -> int:
     Exits 0 on success, 1 on validation failure or I/O error.
 
     Includes are resolved by default, so validating a document also checks that its references resolve.
+
+    Two other modes serve installation rather than authors.
+    ``--list-references`` reports the source-tree documents a document depends on.
+    ``--rewrite-to`` emits a copy whose ``local://`` references have become ``nodl://`` ones.
     """
     parser = argparse.ArgumentParser(
         prog='python -m nodl_schema',
@@ -26,9 +32,35 @@ def main(argv: list[str] | None = None) -> int:
         help='Validate the schema only; do not resolve include references. '
         'By default includes are resolved so the file is checked for resolvability too.',
     )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        '--list-references',
+        action='store_true',
+        help='Print the documents reachable through local:// references, transitively, '
+        'one absolute path per line, instead of validating.',
+    )
+    mode.add_argument(
+        '--rewrite-to',
+        type=Path,
+        metavar='PATH',
+        help='Write a copy of the file to PATH with each local:// reference rewritten to '
+        'nodl://<package>/<name>, instead of validating.',
+    )
+    parser.add_argument('--package', help='Package the rewritten references name. Used with --rewrite-to.')
+    parser.add_argument(
+        '--map',
+        action='append',
+        default=[],
+        metavar='PATH=NAME',
+        help='What a referenced document was registered as. Repeatable. Used with --rewrite-to.',
+    )
     args = parser.parse_args(argv)
 
     try:
+        if args.list_references:
+            return _list_references(args.file)
+        if args.rewrite_to is not None:
+            return _rewrite(args.file, args.rewrite_to, args.package, args.map)
         with args.file.open('r') as f:
             load_nodl(f, resolve=args.resolve)
     except Exception as exc:
@@ -36,4 +68,29 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     print(f'{args.file}: ok')
+    return 0
+
+
+def _list_references(file: Path) -> int:
+    # Deliberately unvalidated: this reports what a document depends on, and a document that does
+    # not validate still has dependencies. Validation is a separate run.
+    doc = includes_only(file.read_text(encoding='utf-8'))
+    for path in local_references(doc, path_to_ref(file)):
+        print(path)
+    return 0
+
+
+def _rewrite(file: Path, output: Path, package: str | None, mappings: list[str]) -> int:
+    if not package:
+        raise ValueError('--package is required with --rewrite-to')
+
+    names: dict[Path, str] = {}
+    for item in mappings:
+        path_text, separator, name = item.partition('=')
+        if not separator or not path_text or not name:
+            raise ValueError(f'malformed --map {item!r}: expected <path>=<name>')
+        names[Path(path_text).resolve()] = name
+
+    rewrite_file(file, output, package=package, names=names)
+    print(f'{file}: ok')
     return 0

--- a/nodl_schema/nodl_schema/composition.py
+++ b/nodl_schema/nodl_schema/composition.py
@@ -38,6 +38,24 @@ class Resolver(Protocol):
         ...
 
 
+@runtime_checkable
+class RebasingResolver(Protocol):
+    """A resolver whose references may be written relative to the document holding them.
+
+    Implement this when a reference means something different depending on where it was written.
+    Resolvers whose references are absolute on their own, such as an index lookup, do not need it.
+    """
+
+    def normalize(self, ref: str, origin: str | None) -> str:
+        """Return ``ref`` in absolute form, resolved against ``origin``.
+
+        ``origin`` is the normalized reference of the document holding this one, or None at the root.
+        The result identifies the document no matter which document referred to it, so it is what
+        cycle detection compares.
+        """
+        ...
+
+
 _RESOLVERS: list[Resolver] = list()
 
 
@@ -89,12 +107,32 @@ def resolver_for(ref: str) -> Resolver | None:
     return None
 
 
-def resolve(ref: str) -> str:
-    """Return the text of the document ``ref`` names, if it can be resolved."""
+def _resolver_or_raise(ref: str) -> Resolver:
     resolver = resolver_for(ref)
     if resolver is None:
         raise ResolutionError(f'No registered resolver handles reference {ref!r}.')
-    return resolver.resolve(ref)
+    return resolver
+
+
+def normalize(ref: str, origin: str | None = None) -> str:
+    """Return ``ref`` in absolute form, resolved against the document that holds it.
+
+    ``origin`` is the normalized reference of that document, or None at the root.
+    A resolver that does not implement RebasingResolver has nothing to rebase, so its
+    references pass through unchanged.
+    """
+    resolver = _resolver_or_raise(ref)
+    if isinstance(resolver, RebasingResolver):
+        return resolver.normalize(ref, origin)
+    return ref
+
+
+def resolve(ref: str) -> str:
+    """Return the text of the document ``ref`` names, if it can be resolved.
+
+    ``ref`` should already be normalized; a relative one has no meaning without its origin.
+    """
+    return _resolver_or_raise(ref).resolve(ref)
 
 
 # --------------------------------

--- a/nodl_schema/nodl_schema/loader.py
+++ b/nodl_schema/nodl_schema/loader.py
@@ -4,10 +4,12 @@ import json
 from collections import deque
 from dataclasses import dataclass
 from typing import IO, TypeAlias, Union
+from pathlib import Path
 
 import yaml
 
-from nodl_schema.composition import ResolutionError, merge_documents, resolve
+from nodl_schema.composition import ResolutionError, merge_documents, normalize, resolve
+from nodl_schema.local_resolver import path_to_ref
 from nodl_schema.models import NodlDocument
 from nodl_schema.validation import validate
 
@@ -65,6 +67,42 @@ def resolve_document(doc: NodlDocument) -> DocumentTree:
 
         return IncludedDocument(ref=ref, doc=doc, resolved_includes=children)
 
+
+def resolve_document(doc: NodlDocument, origin: str | None = None) -> list[NodlDocument]:
+    """Return ``doc`` followed by every document it includes, breadth-first.
+
+    ``origin`` is the normalized reference ``doc`` itself came from, if it has one.
+    It is what relative references inside ``doc`` are resolved against, and it lets a reference
+    that loops back to ``doc`` be caught like any other cycle.
+
+    Each reference is normalized before use, so the same document reached by two different
+    spellings is recognized as one. Raises ResolutionError on a cycle or double inclusion.
+    """
+    visited: dict[str, list[str]] = {}
+    if origin is not None:
+        visited[origin] = [origin]
+
+    ref_queue: deque[tuple[str, str | None, list[str]]] = deque((r.ref, origin, []) for r in (doc.include or []))
+    results = [doc]
+
+    while ref_queue:
+        ref, parent, path = ref_queue.popleft()
+        # Normalizing before the check means two spellings of one document collide here
+        # rather than recursing until something else gives way.
+        this_ref = normalize(ref, parent)
+        this_path = path + [this_ref]
+
+        if this_ref in visited:
+            path_a = ' > '.join(this_path)
+            path_b = ' > '.join(visited[this_ref])
+            raise ResolutionError(f'Double-inclusion detected. "{path_a}" and "{path_b}"')
+
+        included_doc = load_nodl(resolve(this_ref), resolve=False)
+
+        visited[this_ref] = this_path
+        results.append(included_doc)
+        ref_queue.extend((r.ref, this_ref, this_path) for r in (included_doc.include or []))
+
     root_children = [_resolve_ref(r.ref, chain=[]) for r in (doc.include or [])]
 
     return DocumentTree(root_doc=doc, resolved_includes=root_children)
@@ -84,12 +122,18 @@ def _load_doc(source: Union[str, bytes, IO]) -> NodlDocument:
     return doc
 
 
-def load_nodl(source: Union[str, bytes, IO], *, resolve: bool = True) -> NodlDocument:
+def load_nodl(
+    source: Union[str, bytes, IO], *, resolve: bool = True, base: Union[str, Path, None] = None
+) -> NodlDocument:
     """Load and validate a NoDL document from a string, bytes, or file-like object containing JSON or YAML text.
 
     When ``resolve`` (default True), ``include`` references are resolved and merged into the resulting document,
     which then has no ``include`` key.
     Pass ``resolve=False`` to parse the document as authored, leaving ``include`` intact.
+
+    ``base`` is the path this document was read from.
+    Relative references resolve against its directory, so it is required for a document that uses
+    them and ignored for one that does not. An open file supplies it automatically.
 
     Raises jsonschema.ValidationError on schema error
     Raises pydantic.ValidationError on type error
@@ -100,6 +144,25 @@ def load_nodl(source: Union[str, bytes, IO], *, resolve: bool = True) -> NodlDoc
 
     if resolve:
         result_doc, _ = load_nodl_with_doc_tree(source)
+    if base is None:
+        # An open file knows where it came from, so a caller reading a path need not pass it twice.
+        name = getattr(source, 'name', None)
+        if isinstance(name, (str, Path)):
+            base = name
+
+    data = yaml.safe_load(source)
+    if not isinstance(data, dict):
+        raise ValueError('NoDL document must be a YAML/JSON mapping at the top level')
+
+    validate(data)
+
+    # parse_obj is pydantic v1 API, retained as a deprecated alias in v2.
+    # Used so this module works against both rosdep-shipped pydantic v1 (humble/jazzy/kilted) and v2 (lyrical+).
+    doc = NodlDocument.parse_obj(data)
+
+    if resolve:
+        all_docs = resolve_document(doc, path_to_ref(base) if base is not None else None)
+        result_doc = merge_documents(all_docs)
     else:
         result_doc = _load_doc(source)
 

--- a/nodl_schema/nodl_schema/local_resolver.py
+++ b/nodl_schema/nodl_schema/local_resolver.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+from nodl_schema.composition import ResolutionError
+
+PREFIX = 'local://'
+
+
+def path_to_ref(path: Path | str) -> str:
+    """Turn a filesystem path into an absolute ``local://`` reference."""
+    return PREFIX + str(Path(path).resolve())
+
+
+def ref_to_path(ref: str) -> Path:
+    """Turn an absolute ``local://`` reference back into a filesystem path."""
+    if not is_absolute(ref):
+        raise ResolutionError(f'{ref!r} is relative and names no path on its own')
+    return Path(ref[len(PREFIX) :])
+
+
+def is_absolute(ref: str) -> bool:
+    return ref.startswith(PREFIX) and ref[len(PREFIX) :].startswith('/')
+
+
+class LocalResolver:
+    """Resolves ``local://<path>`` from the source tree, relative to the document holding it.
+
+    A reference is written relative to its own document, so ``local://common/telemetry.nodl.yaml``
+    means the same thing wherever that document sits. It is resolved against the document's origin
+    before it is read, which is why this resolver rebases.
+
+    Relative references only work while the source tree is present.
+    They do not survive installation, where a consumer gets document text with no location to be
+    relative to, so ``ament_nodl`` rewrites them to ``nodl://`` references when it installs.
+    """
+
+    prefix = PREFIX
+
+    def handles(self, ref: str) -> bool:
+        return ref.startswith(self.prefix)
+
+    def normalize(self, ref: str, origin: str | None) -> str:
+        if is_absolute(ref):
+            return ref
+
+        body = ref[len(self.prefix) :]
+        if origin is None:
+            raise ResolutionError(
+                f'{ref!r} is relative, but the document holding it has no location. '
+                f'Load it from a file, or pass base= to load_nodl.'
+            )
+        if not is_absolute(origin):
+            raise ResolutionError(
+                f'{ref!r} is relative, but the document holding it came from {origin!r}, '
+                f'which is not a location in the source tree.'
+            )
+        return path_to_ref(ref_to_path(origin).parent / body)
+
+    def resolve(self, ref: str) -> str:
+        path = ref_to_path(ref)
+        try:
+            return path.read_text(encoding='utf-8')
+        except OSError as exc:
+            raise ResolutionError(f'could not read {str(path)!r} for reference {ref!r}: {exc}') from exc

--- a/nodl_schema/nodl_schema/models.py
+++ b/nodl_schema/nodl_schema/models.py
@@ -60,7 +60,7 @@ class Reference(BaseModel):
 
     ref: constr(regex=r'^[a-z][a-z0-9+.-]*://[^\s/][^\s]*$') = Field(
         ...,
-        description='Reference to a NoDL document, as a ``<scheme>://<body>`` URI.\nDynamically egistered resolvers handle these URIs, so the schema does not restrict them.\n``nodl://<package>/<name>`` is the built-in resolver which fetches from the ament index.\n',
+        description='Reference to a NoDL document, as a ``<scheme>://<body>`` URI.\nDynamically egistered resolvers handle these URIs, so the schema does not restrict them.\n``nodl://<package>/<name>`` is the built-in resolver which fetches from the ament index.\n``local://<path>`` names a document in the same package, relative to the file holding the\nreference. It reads the source tree, so it is the only form that can reach a document in\nthe package being built, and ``ament_nodl`` rewrites it to a ``nodl://`` reference on install.\n',
         examples=['nodl://sensor_common/imu_driver'],
     )
 

--- a/nodl_schema/nodl_schema/rewrite.py
+++ b/nodl_schema/nodl_schema/rewrite.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Turning source-tree references into installed ones.
+
+A ``local://`` reference is resolvable only while the source tree is present.
+A consumer reading a document back out of the ament index gets text with no location, so nothing
+in it can be relative to anything. Installation therefore has to replace each ``local://`` reference
+with the ``nodl://`` reference naming the same document.
+
+This is what ``ament_nodl`` calls at install time. It supplies the package being built and the
+names its documents were registered under; everything about reference syntax stays here.
+"""
+
+from pathlib import Path
+
+import yaml
+
+from nodl_schema.composition import ResolutionError, normalize
+from nodl_schema.local_resolver import PREFIX, is_absolute, ref_to_path
+from nodl_schema.models import NodlDocument, Reference
+
+_SUFFIXES = ('.yaml', '.yml', '.json')
+
+
+def default_name(path: Path) -> str:
+    """The name a document is assumed to be registered under: its filename without extensions."""
+    name = path.name
+    for suffix in _SUFFIXES:
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+            break
+    return name[: -len('.nodl')] if name.endswith('.nodl') else name
+
+
+def local_references(doc: NodlDocument, origin: str) -> list[Path]:
+    """Every document reachable from ``doc`` through ``local://`` references, transitively.
+
+    Returned in discovery order, deduplicated, and safe against cycles.
+    ``ament_nodl`` uses this to check that referenced documents are registered, and to tell the
+    build system which files a document depends on.
+    """
+    found: list[Path] = []
+    _walk(doc, origin, found)
+    return found
+
+
+def includes_only(text: str) -> NodlDocument:
+    """Parse just the ``include`` list out of document text, ignoring everything else.
+
+    Collecting dependencies is a structural question, not a check, so this deliberately does not
+    validate. A document that is malformed or invalid still has to report the files it depends on,
+    and the real error belongs to the validation step rather than to this one. References that do
+    not parse are skipped for the same reason.
+    """
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        return NodlDocument()
+
+    references = []
+    for entry in data.get('include') or []:
+        if not isinstance(entry, dict) or not entry.get('ref'):
+            continue
+        try:
+            references.append(Reference(ref=entry['ref']))
+        except Exception:
+            continue
+    return NodlDocument(include=references)
+
+
+def _walk(doc: NodlDocument, origin: str, found: list[Path]) -> None:
+    for reference in doc.include or []:
+        if not reference.ref.startswith(PREFIX):
+            continue
+        child_ref = normalize(reference.ref, origin)
+        path = ref_to_path(child_ref)
+        if path in found:
+            continue
+        found.append(path)
+
+        try:
+            text = path.read_text(encoding='utf-8')
+        except OSError as exc:
+            raise ResolutionError(f'could not read {str(path)!r} for reference {reference.ref!r}: {exc}') from exc
+        _walk(includes_only(text), child_ref, found)
+
+
+def rewrite_local_references(
+    doc: NodlDocument,
+    *,
+    origin: str,
+    package: str,
+    names: dict[Path, str] | None = None,
+) -> NodlDocument:
+    """Return a copy of ``doc`` with each ``local://`` reference replaced by its ``nodl://`` form.
+
+    ``package`` is the package referenced documents belong to by default, and ``names`` maps a
+    document's absolute path to the name it was registered as. A name may be given as
+    ``<package>/<name>`` to point at a document registered under some other package, which is what
+    a registration with a package override needs. A path missing from ``names`` is an error, since
+    guessing would produce a reference to an index entry that may not exist.
+    Pass ``names=None`` to fall back to each file's name, for callers with no registration record.
+
+    ``nodl://`` references are left alone, and nothing else about the document changes, so the
+    result differs from the authored document only in the spelling of its references.
+
+    This does not recurse. Each document is rewritten by its own registration.
+    """
+    rewritten = doc.copy(deep=True)
+
+    for reference in rewritten.include or []:
+        if not reference.ref.startswith(PREFIX) or is_absolute(reference.ref):
+            continue
+        path = ref_to_path(normalize(reference.ref, origin))
+        if names is None:
+            name = default_name(path)
+        elif path in names:
+            name = names[path]
+        else:
+            raise ResolutionError(
+                f'{reference.ref!r} resolves to {str(path)!r}, which is not registered. '
+                f'Register it with ament_nodl_register_node before the document that includes it.'
+            )
+        # A name may already carry its own package, for a document registered under an override.
+        target = name if '/' in name else f'{package}/{name}'
+        reference.ref = f'nodl://{target}'
+
+    return rewritten
+
+
+def rewrite_file(
+    source: Path,
+    output: Path,
+    *,
+    package: str,
+    names: dict[Path, str] | None = None,
+) -> bool:
+    """Write ``source`` to ``output`` with its ``local://`` references rewritten.
+
+    Returns whether anything was rewritten. A document with no local references is copied byte for
+    byte, so registering one is unaffected by any of this. Only a document that actually has a
+    reference to rewrite is re-serialized, and then in the format its extension implies.
+    """
+    import shutil
+
+    from nodl_schema.loader import dump_nodl, load_nodl
+    from nodl_schema.local_resolver import path_to_ref
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    doc = load_nodl(source.read_text(encoding='utf-8'), resolve=False)
+
+    if not any((reference.ref or '').startswith(PREFIX) for reference in doc.include or []):
+        shutil.copyfile(source, output)
+        return False
+
+    rewritten = rewrite_local_references(doc, origin=path_to_ref(source), package=package, names=names)
+    output.write_text(dump_nodl(rewritten, format='json' if source.suffix == '.json' else 'yaml'), encoding='utf-8')
+    return True

--- a/nodl_schema/nodl_schema/schemas/nodl.schema.yaml
+++ b/nodl_schema/nodl_schema/schemas/nodl.schema.yaml
@@ -106,6 +106,9 @@ definitions:
           Reference to a NoDL document, as a ``<scheme>://<body>`` URI.
           Dynamically egistered resolvers handle these URIs, so the schema does not restrict them.
           ``nodl://<package>/<name>`` is the built-in resolver which fetches from the ament index.
+          ``local://<path>`` names a document in the same package, relative to the file holding the
+          reference. It reads the source tree, so it is the only form that can reach a document in
+          the package being built, and ``ament_nodl`` rewrites it to a ``nodl://`` reference on install.
         pattern: ^[a-z][a-z0-9+.-]*://[^\s/][^\s]*$
         examples:
           - nodl://sensor_common/imu_driver

--- a/nodl_schema/test/test_local_references.py
+++ b/nodl_schema/test/test_local_references.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``local://`` references and their rewriting.
+
+These use real files, since resolving against a document's location is the whole point.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from nodl_schema import ResolutionError, dump_nodl, load_nodl, local_references, rewrite_local_references
+from nodl_schema.local_resolver import LocalResolver, is_absolute, path_to_ref
+from nodl_schema.models import History, NodlDocument, QosProfile, Reference, Reliability, TopicEndpoint
+from nodl_schema.rewrite import default_name, rewrite_file
+
+_QOS = QosProfile(history=History.SYSTEM_DEFAULT, reliability=Reliability.SYSTEM_DEFAULT)
+
+
+def _pub_doc(name, *refs) -> NodlDocument:
+    return NodlDocument(
+        publishers=[TopicEndpoint(name=name, type='std_msgs/msg/String', qos=_QOS)],
+        include=[Reference(ref=ref) for ref in refs],
+    )
+
+
+def _write(path: Path, doc: NodlDocument) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dump_nodl(doc))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Resolving against the containing document
+# ---------------------------------------------------------------------------
+
+
+def test_relative_ref_resolves_against_the_document_directory(tmp_path: Path):
+    _write(tmp_path / 'common' / 'telemetry.nodl.yaml', _pub_doc('/telem'))
+    main = _write(tmp_path / 'my_node.nodl.yaml', _pub_doc('/own', 'local://common/telemetry.nodl.yaml'))
+    doc = load_nodl(main.read_text(), base=main)
+    assert sorted(p.name for p in doc.publishers) == ['/own', '/telem']
+
+
+def test_open_file_supplies_its_own_base(tmp_path: Path):
+    _write(tmp_path / 'shared.nodl.yaml', _pub_doc('/shared'))
+    main = _write(tmp_path / 'main.nodl.yaml', NodlDocument(include=[Reference(ref='local://shared.nodl.yaml')]))
+    with main.open() as f:
+        doc = load_nodl(f)
+    assert [p.name for p in doc.publishers] == ['/shared']
+
+
+def test_nested_ref_is_relative_to_its_own_document(tmp_path: Path):
+    # b/leaf is named relative to b/mid, not to the top-level document.
+    _write(tmp_path / 'b' / 'leaf.nodl.yaml', _pub_doc('/leaf'))
+    _write(tmp_path / 'b' / 'mid.nodl.yaml', NodlDocument(include=[Reference(ref='local://leaf.nodl.yaml')]))
+    main = _write(tmp_path / 'top.nodl.yaml', NodlDocument(include=[Reference(ref='local://b/mid.nodl.yaml')]))
+    doc = load_nodl(main.read_text(), base=main)
+    assert [p.name for p in doc.publishers] == ['/leaf']
+
+
+def test_relative_ref_may_walk_upward(tmp_path: Path):
+    _write(tmp_path / 'shared' / 'base.nodl.yaml', _pub_doc('/base'))
+    main = _write(
+        tmp_path / 'nodl' / 'node.nodl.yaml', NodlDocument(include=[Reference(ref='local://../shared/base.nodl.yaml')])
+    )
+    doc = load_nodl(main.read_text(), base=main)
+    assert [p.name for p in doc.publishers] == ['/base']
+
+
+def test_relative_ref_without_a_base_raises(tmp_path: Path):
+    with pytest.raises(ResolutionError, match='no location'):
+        load_nodl(dump_nodl(NodlDocument(include=[Reference(ref='local://common/telemetry.nodl.yaml')])))
+
+
+def test_relative_ref_inside_an_indexed_document_raises(tmp_path: Path):
+    # A document fetched from the index is text with no location, so nothing in it can be relative.
+    resolver = LocalResolver()
+    with pytest.raises(ResolutionError, match='not a location in the source tree'):
+        resolver.normalize('local://sibling.nodl.yaml', 'nodl://pkg/thing')
+
+
+def test_missing_relative_ref_raises(tmp_path: Path):
+    main = _write(tmp_path / 'main.nodl.yaml', NodlDocument(include=[Reference(ref='local://absent.nodl.yaml')]))
+    with pytest.raises(ResolutionError, match='absent.nodl.yaml'):
+        load_nodl(main.read_text(), base=main)
+
+
+def test_cycle_is_detected_across_spellings(tmp_path: Path):
+    # a -> b -> ./a, two spellings of one file. Normalizing before the check is what ends this.
+    _write(tmp_path / 'a.nodl.yaml', NodlDocument(include=[Reference(ref='local://b.nodl.yaml')]))
+    _write(tmp_path / 'b.nodl.yaml', NodlDocument(include=[Reference(ref='local://./a.nodl.yaml')]))
+    main = tmp_path / 'a.nodl.yaml'
+    with pytest.raises(ResolutionError, match='Double-inclusion'):
+        load_nodl(main.read_text(), base=main)
+
+
+def test_reference_looping_back_to_the_root_is_detected(tmp_path: Path):
+    # Knowing the root's own origin is what makes this catchable at all.
+    _write(tmp_path / 'other.nodl.yaml', NodlDocument(include=[Reference(ref='local://root.nodl.yaml')]))
+    main = _write(tmp_path / 'root.nodl.yaml', NodlDocument(include=[Reference(ref='local://other.nodl.yaml')]))
+    with pytest.raises(ResolutionError, match='Double-inclusion'):
+        load_nodl(main.read_text(), base=main)
+
+
+# ---------------------------------------------------------------------------
+# local_references: what installation needs to know about
+# ---------------------------------------------------------------------------
+
+
+def test_local_references_is_transitive(tmp_path: Path):
+    leaf = _write(tmp_path / 'leaf.nodl.yaml', NodlDocument())
+    mid = _write(tmp_path / 'mid.nodl.yaml', NodlDocument(include=[Reference(ref='local://leaf.nodl.yaml')]))
+    main = _write(tmp_path / 'main.nodl.yaml', NodlDocument(include=[Reference(ref='local://mid.nodl.yaml')]))
+    found = local_references(load_nodl(main.read_text(), resolve=False), path_to_ref(main))
+    assert found == [mid, leaf]
+
+
+def test_local_references_ignores_nodl_refs(tmp_path: Path):
+    main = _write(tmp_path / 'main.nodl.yaml', NodlDocument(include=[Reference(ref='nodl://other/thing')]))
+    assert local_references(load_nodl(main.read_text(), resolve=False), path_to_ref(main)) == []
+
+
+def test_local_references_survives_a_cycle(tmp_path: Path):
+    a = _write(tmp_path / 'a.nodl.yaml', NodlDocument(include=[Reference(ref='local://b.nodl.yaml')]))
+    b = _write(tmp_path / 'b.nodl.yaml', NodlDocument(include=[Reference(ref='local://a.nodl.yaml')]))
+    found = local_references(load_nodl(a.read_text(), resolve=False), path_to_ref(a))
+    assert found == [b, a]
+
+
+def test_local_references_deduplicates(tmp_path: Path):
+    shared = _write(tmp_path / 'shared.nodl.yaml', NodlDocument())
+    main = _write(
+        tmp_path / 'main.nodl.yaml',
+        NodlDocument(include=[Reference(ref='local://shared.nodl.yaml'), Reference(ref='local://./shared.nodl.yaml')]),
+    )
+    found = local_references(load_nodl(main.read_text(), resolve=False), path_to_ref(main))
+    assert found == [shared]
+
+
+# ---------------------------------------------------------------------------
+# Rewriting for installation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'filename,expected',
+    [('telemetry.nodl.yaml', 'telemetry'), ('a.nodl.json', 'a'), ('plain.yaml', 'plain'), ('bare', 'bare')],
+)
+def test_default_name_strips_extensions(filename, expected):
+    assert default_name(Path('/x') / filename) == expected
+
+
+def test_rewrite_replaces_local_ref_with_registered_name(tmp_path: Path):
+    shared = _write(tmp_path / 'common' / 'telemetry.nodl.yaml', NodlDocument())
+    main = tmp_path / 'my_node.nodl.yaml'
+    doc = NodlDocument(include=[Reference(ref='local://common/telemetry.nodl.yaml')])
+    out = rewrite_local_references(doc, origin=path_to_ref(main), package='my_pkg', names={shared: 'telemetry'})
+    assert [r.ref for r in out.include] == ['nodl://my_pkg/telemetry']
+
+
+def test_rewrite_honours_a_name_carrying_its_own_package(tmp_path: Path):
+    # A document registered under a PACKAGE override belongs to that package, not the building one.
+    shared = _write(tmp_path / 'shared.nodl.yaml', NodlDocument())
+    main = tmp_path / 'my_node.nodl.yaml'
+    doc = NodlDocument(include=[Reference(ref='local://shared.nodl.yaml')])
+    out = rewrite_local_references(doc, origin=path_to_ref(main), package='my_pkg', names={shared: 'other_pkg/thing'})
+    assert [r.ref for r in out.include] == ['nodl://other_pkg/thing']
+
+
+def test_rewrite_leaves_nodl_refs_alone(tmp_path: Path):
+    doc = NodlDocument(include=[Reference(ref='nodl://other_pkg/thing')])
+    out = rewrite_local_references(doc, origin=path_to_ref(tmp_path / 'x.nodl.yaml'), package='my_pkg', names={})
+    assert [r.ref for r in out.include] == ['nodl://other_pkg/thing']
+
+
+def test_rewrite_changes_nothing_else(tmp_path: Path):
+    shared = _write(tmp_path / 'shared.nodl.yaml', NodlDocument())
+    doc = _pub_doc('/status', 'local://shared.nodl.yaml')
+    doc.description = 'a node'
+    out = rewrite_local_references(
+        doc, origin=path_to_ref(tmp_path / 'x.nodl.yaml'), package='my_pkg', names={shared: 'shared'}
+    )
+    assert out.description == 'a node'
+    assert [p.name for p in out.publishers] == ['/status']
+    # Entities are not merged in; only the reference changed.
+    assert out.subscriptions is None
+
+
+def test_rewrite_does_not_mutate_input(tmp_path: Path):
+    shared = _write(tmp_path / 'shared.nodl.yaml', NodlDocument())
+    doc = NodlDocument(include=[Reference(ref='local://shared.nodl.yaml')])
+    rewrite_local_references(doc, origin=path_to_ref(tmp_path / 'x.nodl.yaml'), package='p', names={shared: 'shared'})
+    assert [r.ref for r in doc.include] == ['local://shared.nodl.yaml']
+
+
+def test_rewrite_of_an_unregistered_reference_raises(tmp_path: Path):
+    _write(tmp_path / 'shared.nodl.yaml', NodlDocument())
+    doc = NodlDocument(include=[Reference(ref='local://shared.nodl.yaml')])
+    with pytest.raises(ResolutionError, match='not registered'):
+        rewrite_local_references(doc, origin=path_to_ref(tmp_path / 'x.nodl.yaml'), package='p', names={})
+
+
+def test_rewrite_is_not_recursive(tmp_path: Path):
+    # mid's own reference is left alone; mid is rewritten by its own registration.
+    mid = _write(tmp_path / 'mid.nodl.yaml', NodlDocument(include=[Reference(ref='local://leaf.nodl.yaml')]))
+    _write(tmp_path / 'leaf.nodl.yaml', NodlDocument())
+    doc = NodlDocument(include=[Reference(ref='local://mid.nodl.yaml')])
+    out = rewrite_local_references(
+        doc, origin=path_to_ref(tmp_path / 'main.nodl.yaml'), package='p', names={mid: 'mid'}
+    )
+    assert [r.ref for r in out.include] == ['nodl://p/mid']
+    assert 'local://leaf.nodl.yaml' in mid.read_text()
+
+
+def test_rewrite_file_without_local_refs_copies_bytes(tmp_path: Path):
+    # Most documents have nothing to rewrite; those must install exactly as authored.
+    source = _write(tmp_path / 'main.nodl.yaml', _pub_doc('/only'))
+    output = tmp_path / 'gen' / 'main.nodl.yaml'
+    assert rewrite_file(source, output, package='p') is False
+    assert output.read_bytes() == source.read_bytes()
+
+
+def test_rewrite_file_preserves_the_json_frontend(tmp_path: Path):
+    shared = _write(tmp_path / 'shared.nodl.yaml', NodlDocument())
+    source = tmp_path / 'main.nodl.json'
+    source.write_text('{"nodl_version": 2, "include": [{"ref": "local://shared.nodl.yaml"}]}\n')
+    output = tmp_path / 'out.nodl.json'
+    assert rewrite_file(source, output, package='p', names={shared: 'shared'}) is True
+    assert '"nodl_version": 2' in output.read_text()
+    assert 'nodl://p/shared' in output.read_text()
+
+
+def test_rewritten_document_still_validates(tmp_path: Path):
+    # What gets installed has to be a valid NoDL document in its own right.
+    shared = _write(tmp_path / 'shared.nodl.yaml', NodlDocument())
+    source = _write(tmp_path / 'main.nodl.yaml', _pub_doc('/status', 'local://shared.nodl.yaml'))
+    output = tmp_path / 'out.nodl.yaml'
+    rewrite_file(source, output, package='p', names={shared: 'shared'})
+    doc = load_nodl(output.read_text(), resolve=False)
+    assert [r.ref for r in doc.include] == ['nodl://p/shared']
+
+
+# ---------------------------------------------------------------------------
+# Reference forms
+# ---------------------------------------------------------------------------
+
+
+def test_absolute_local_ref_is_left_alone_by_normalize():
+    resolver = LocalResolver()
+    absolute = path_to_ref('/tmp/x.nodl.yaml')
+    assert is_absolute(absolute)
+    assert resolver.normalize(absolute, None) == absolute
+
+
+@pytest.mark.parametrize('ref', ['local://x.yaml', 'local://a/b.yaml'])
+def test_local_resolver_handles_local_refs(ref):
+    assert LocalResolver().handles(ref)
+
+
+@pytest.mark.parametrize('ref', ['nodl://pkg/x', 'test://x', ''])
+def test_local_resolver_ignores_other_schemes(ref):
+    assert not LocalResolver().handles(ref)

--- a/test_ament_nodl/CMakeLists.txt
+++ b/test_ament_nodl/CMakeLists.txt
@@ -17,11 +17,17 @@ ament_nodl_register_node(custom_exe
 # Non-yaml frontend. Make sure the macro is extension-agnostic.
 ament_nodl_register_node(json_node FILE test/fixtures/json_node.nodl.json)
 
+# Local includes. telemetry must be registered first: composed_node references it by path, and the
+# macro rewrites that path to nodl://test_ament_nodl/telemetry using this registration's name.
+ament_nodl_register_node(telemetry FILE test/fixtures/common/telemetry.nodl.yaml)
+ament_nodl_register_node(composed_node FILE test/fixtures/composed_node.nodl.yaml)
+
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(register_node_tests test/test_register_node.py)
   ament_add_pytest_test(macro_rejection_tests test/test_macro_rejection.py)
   ament_add_pytest_test(composition_tests test/test_composition.py)
+  ament_add_pytest_test(relative_include_tests test/test_relative_include.py)
 endif()
 
 ament_package()

--- a/test_ament_nodl/test/fixtures/common/telemetry.nodl.yaml
+++ b/test_ament_nodl/test/fixtures/common/telemetry.nodl.yaml
@@ -1,0 +1,10 @@
+---
+nodl_version: 2
+description: Shared telemetry surface, included by other documents in this package.
+publishers:
+  - name: /telemetry/heartbeat
+    type: std_msgs/msg/String
+    qos:
+      history: KEEP_LAST
+      depth: 1
+      reliability: BEST_EFFORT

--- a/test_ament_nodl/test/fixtures/composed_node.nodl.yaml
+++ b/test_ament_nodl/test/fixtures/composed_node.nodl.yaml
@@ -1,0 +1,12 @@
+---
+nodl_version: 2
+description: Node composed from a local include, to exercise reference rewriting at registration.
+include:
+  - ref: local://common/telemetry.nodl.yaml
+subscriptions:
+  - name: /commands
+    type: std_msgs/msg/String
+    qos:
+      history: KEEP_LAST
+      depth: 10
+      reliability: RELIABLE

--- a/test_ament_nodl/test/test_macro_rejection.py
+++ b/test_ament_nodl/test/test_macro_rejection.py
@@ -50,6 +50,41 @@ _INVALID_NODL = textwrap.dedent("""
 """).lstrip()
 
 
+_VALID_NODL = 'nodl_version: 2\n'
+
+# composed.nodl.yaml references shared.nodl.yaml, but nothing registers shared.nodl.yaml.
+# There is no name to rewrite the reference to, so this must fail at configure time.
+_UNREGISTERED_REF_CMAKELISTS = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.22)
+    project(rejection_fixture)
+    find_package(ament_cmake REQUIRED)
+    find_package(ament_nodl REQUIRED)
+    ament_nodl_register_node(composed FILE composed.nodl.yaml)
+    ament_package()
+""")
+
+# Two different files claiming the name 'thing'. The second would take over a name that an
+# already-rewritten reference could point at, so it must fail at configure time.
+_DUPLICATE_NAME_CMAKELISTS = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.22)
+    project(rejection_fixture)
+    find_package(ament_cmake REQUIRED)
+    find_package(ament_nodl REQUIRED)
+    ament_nodl_register_node(thing FILE one.nodl.yaml)
+    ament_nodl_register_node(thing FILE two.nodl.yaml)
+    ament_package()
+""")
+
+
+def _configure(pkg: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ['cmake', '-S', str(pkg), '-B', str(pkg / 'build')],
+        capture_output=True,
+        text=True,
+        env=os.environ,
+    )
+
+
 @pytest.fixture
 def inner_pkg(tmp_path: Path) -> Path:
     pkg = tmp_path / 'rejection_fixture'
@@ -84,3 +119,35 @@ def test_macro_rejects_invalid_node(inner_pkg: Path):
     assert 'not_a_real_type' in combined, (
         f'Expected the validator error to appear in the build output, got:\n{combined}'
     )
+
+
+@pytest.mark.skipif(shutil.which('cmake') is None, reason='cmake not on PATH')
+def test_macro_rejects_reference_to_unregistered_document(tmp_path: Path):
+    # The error belongs at configure time, because the fix is the order of calls in CMakeLists.
+    pkg = tmp_path / 'rejection_fixture'
+    pkg.mkdir()
+    (pkg / 'CMakeLists.txt').write_text(_UNREGISTERED_REF_CMAKELISTS)
+    (pkg / 'package.xml').write_text(_INNER_PACKAGE_XML)
+    (pkg / 'shared.nodl.yaml').write_text(_VALID_NODL)
+    (pkg / 'composed.nodl.yaml').write_text('nodl_version: 2\ninclude:\n  - ref: local://shared.nodl.yaml\n')
+
+    result = _configure(pkg)
+    assert result.returncode != 0, 'Expected configure to fail on the unregistered reference'
+    combined = result.stdout + result.stderr
+    assert 'not registered' in combined, f'Expected an unregistered-reference error, got:\n{combined}'
+    assert 'shared.nodl.yaml' in combined
+
+
+@pytest.mark.skipif(shutil.which('cmake') is None, reason='cmake not on PATH')
+def test_macro_rejects_one_name_registered_from_two_files(tmp_path: Path):
+    pkg = tmp_path / 'rejection_fixture'
+    pkg.mkdir()
+    (pkg / 'CMakeLists.txt').write_text(_DUPLICATE_NAME_CMAKELISTS)
+    (pkg / 'package.xml').write_text(_INNER_PACKAGE_XML)
+    (pkg / 'one.nodl.yaml').write_text(_VALID_NODL)
+    (pkg / 'two.nodl.yaml').write_text(_VALID_NODL)
+
+    result = _configure(pkg)
+    assert result.returncode != 0, 'Expected configure to fail on the duplicate name'
+    combined = result.stdout + result.stderr
+    assert 'already registered' in combined, f'Expected a duplicate-name error, got:\n{combined}'

--- a/test_ament_nodl/test/test_relative_include.py
+++ b/test_ament_nodl/test/test_relative_include.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end test for local:// includes surviving installation.
+
+composed_node.nodl.yaml is authored with ``ref: local://common/telemetry.nodl.yaml``, which is
+resolvable only in the source tree. Registration rewrites it to the name telemetry was registered
+under, so a consumer reading the document out of the index has something it can resolve.
+
+Both documents are registered in CMakeLists.txt, telemetry first.
+"""
+
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
+from ament_index_python.resources import get_resource
+
+from nodl_schema import load_nodl
+
+
+def _installed(name: str = 'composed_node') -> str:
+    content, _ = get_resource('nodl_nodes', f'test_ament_nodl__{name}')
+    return content
+
+
+def _share_copy(filename: str) -> str:
+    return (Path(get_package_share_directory('test_ament_nodl')) / 'nodl' / filename).read_text()
+
+
+def test_installed_document_carries_a_rewritten_reference():
+    content = _installed()
+    assert 'nodl://test_ament_nodl/telemetry' in content
+    assert 'local://' not in content
+
+
+def test_share_copy_matches_the_index_copy():
+    # Both install destinations get the rewritten document, so the two agree.
+    assert _share_copy('composed_node.nodl.yaml') == _installed()
+
+
+def test_rewrite_preserves_the_rest_of_the_document():
+    content = _installed()
+    assert 'Node composed from a local include' in content
+    assert '/commands' in content
+
+
+def test_consumer_resolves_the_rewritten_reference():
+    # The point of rewriting: a consumer with no knowledge of the source layout resolves the chain.
+    doc = load_nodl(_installed())
+    assert any(p.name == '/telemetry/heartbeat' for p in doc.publishers)
+    assert any(s.name == '/commands' for s in doc.subscriptions)
+    assert doc.include is None
+
+
+def test_referenced_document_is_registered_in_its_own_right():
+    assert 'Shared telemetry surface' in _installed('telemetry')
+
+
+def test_document_without_local_refs_is_installed_unchanged():
+    # Only documents that actually have something to rewrite are re-serialized.
+    assert _installed('basic_node') == _share_copy('basic_node.nodl.yaml')


### PR DESCRIPTION
Builds on top of #92 to add a new resolver for local references, relative paths to other nodl docs within the same package.

To enable downstream use of these files when installed, adds the ability to rewrite references at install-time. In this case, rewrites from local relative path to an ament index reference for the same package.

Closes #99 

