### PR TITLE
Expose the include tree from load_nodl                                                                                                                                                       

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 /.ruff.toml
+/.vscode/
 /build/
 /install/
 /log/

--- a/nodl_schema/nodl_schema/__init__.py
+++ b/nodl_schema/nodl_schema/__init__.py
@@ -11,7 +11,7 @@ from nodl_schema.composition import (
     resolver_registered,
     unregister_resolver,
 )
-from nodl_schema.loader import dump_nodl, load_nodl, resolve_document
+from nodl_schema.loader import dump_nodl, load_nodl, load_nodl_with_doc_tree, resolve_document
 from nodl_schema.validation import load_schema, validate
 
 register_resolver(AmentIndexResolver())
@@ -22,6 +22,7 @@ __all__ = [
     'Resolver',
     'dump_nodl',
     'load_nodl',
+    'load_nodl_with_doc_tree',
     'load_schema',
     'get_resolvers',
     'register_resolver',

--- a/nodl_schema/nodl_schema/loader.py
+++ b/nodl_schema/nodl_schema/loader.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import json
 from collections import deque
-from typing import IO, Union
+from dataclasses import dataclass
+from typing import IO, TypeAlias, Union
 
 import yaml
 
@@ -11,40 +12,62 @@ from nodl_schema.models import NodlDocument
 from nodl_schema.validation import validate
 
 
-def resolve_document(doc: NodlDocument) -> list[NodlDocument]:
-    # Do breadth-first traversal of the includes, detecting non-tree double-inclusions/cycles
+@dataclass
+class IncludedDocument:
+    ref: str
+    doc: NodlDocument
+    resolved_includes: list['IncludedDocument']
+
+
+@dataclass
+class DocumentTree:
+    # NOTE(alistair) this is a special case of a IncludedDocument because we dont have the root ref
+    root_doc: NodlDocument
+    resolved_includes: list[IncludedDocument]
+
+    def flatten(self) -> list[NodlDocument]:
+        result = [self.root_doc]
+        queue = deque(self.resolved_includes)
+        while queue:
+            included_doc = queue.popleft()
+            result.append(included_doc.doc)
+            queue.extend(included_doc.resolved_includes)
+        return result
+
+
+Ref: TypeAlias = str
+IncludeChain: TypeAlias = list[str]
+
+
+def resolve_document(doc: NodlDocument) -> DocumentTree:
+    # DFS traversal of the includes, detecting non-tree double-inclusions/cycles
     # NOTE(emerson) there is not currently a way to detect if a reference loops back to _this_ document,
     # since we don't have our own ref in this context.
     # Really, we are depending on the package dependency graph to avoid cycles.
     # Additionally, if "the same" reference were to be found by different resolvers, that is not caught here,
     # but by merge collision checking.
-    visited: dict[str, list[str]] = {}
-    initial_refs = [(r.ref, []) for r in (doc.include or [])]
-    ref_queue: deque[tuple[str, list[str]]] = deque(initial_refs)
 
-    results = [doc]
+    visited: dict[Ref, IncludeChain] = {}
 
-    while ref_queue:
-        ref, path = ref_queue.popleft()
-        this_path = path + [ref]
+    def _resolve_ref(ref: Ref, chain: IncludeChain) -> IncludedDocument:
+        current_chain = chain + [ref]
 
-        # Detect cycle/double-inclusion
         if ref in visited:
-            other_path = visited[ref]
-            path_a = ' > '.join(this_path)
-            path_b = ' > '.join(other_path)
-            raise ResolutionError(f'Double-inclusion detected. "{path_a}" and "{path_b}"')
+            other_chain = visited[ref]
+            chain_a = ' > '.join(current_chain)
+            chain_b = ' > '.join(other_chain)
+            raise ResolutionError(f'Double-inclusion detected. "{chain_a}" and "{chain_b}"')
 
-        # Process
+        visited[ref] = current_chain
         content = resolve(ref)
-        included_doc = load_nodl(content, resolve=False)
+        doc = load_nodl(content, resolve=False)
+        children = [_resolve_ref(r.ref, current_chain) for r in (doc.include or [])]
 
-        # Accumulate
-        visited[ref] = this_path
-        results.append(included_doc)
-        ref_queue.extend(((r.ref, this_path) for r in (included_doc.include or [])))
+        return IncludedDocument(ref=ref, doc=doc, resolved_includes=children)
 
-    return results
+    root_children = [_resolve_ref(r.ref, chain=[]) for r in (doc.include or [])]
+
+    return DocumentTree(root_doc=doc, resolved_includes=root_children)
 
 
 def load_nodl(source: Union[str, bytes, IO], *, resolve: bool = True) -> NodlDocument:
@@ -71,8 +94,8 @@ def load_nodl(source: Union[str, bytes, IO], *, resolve: bool = True) -> NodlDoc
     doc = NodlDocument.parse_obj(data)
 
     if resolve:
-        all_docs = resolve_document(doc)
-        result_doc = merge_documents(all_docs)
+        doc_tree = resolve_document(doc)
+        result_doc = merge_documents(doc_tree.flatten())
     else:
         result_doc = doc
 

--- a/nodl_schema/nodl_schema/loader.py
+++ b/nodl_schema/nodl_schema/loader.py
@@ -70,6 +70,20 @@ def resolve_document(doc: NodlDocument) -> DocumentTree:
     return DocumentTree(root_doc=doc, resolved_includes=root_children)
 
 
+def _load_doc(source: Union[str, bytes, IO]) -> NodlDocument:
+    data = yaml.safe_load(source)
+    if not isinstance(data, dict):
+        raise ValueError('NoDL document must be a YAML/JSON mapping at the top level')
+
+    validate(data)
+
+    # parse_obj is pydantic v1 API, retained as a deprecated alias in v2.
+    # Used so this module works against both rosdep-shipped pydantic v1 (humble/jazzy/kilted) and v2 (lyrical+).
+    doc = NodlDocument.parse_obj(data)
+
+    return doc
+
+
 def load_nodl(source: Union[str, bytes, IO], *, resolve: bool = True) -> NodlDocument:
     """Load and validate a NoDL document from a string, bytes, or file-like object containing JSON or YAML text.
 
@@ -83,23 +97,34 @@ def load_nodl(source: Union[str, bytes, IO], *, resolve: bool = True) -> NodlDoc
         Resolvers generally raise ResolutionError on invalid or unfindable references,
         but their custom exceptions are allowed propagate for unforseen cases, for visibility
     """
-    data = yaml.safe_load(source)
-    if not isinstance(data, dict):
-        raise ValueError('NoDL document must be a YAML/JSON mapping at the top level')
-
-    validate(data)
-
-    # parse_obj is pydantic v1 API, retained as a deprecated alias in v2.
-    # Used so this module works against both rosdep-shipped pydantic v1 (humble/jazzy/kilted) and v2 (lyrical+).
-    doc = NodlDocument.parse_obj(data)
 
     if resolve:
-        doc_tree = resolve_document(doc)
-        result_doc = merge_documents(doc_tree.flatten())
+        result_doc, _ = load_nodl_with_doc_tree(source)
     else:
-        result_doc = doc
+        result_doc = _load_doc(source)
 
     return result_doc
+
+
+def load_nodl_with_doc_tree(source: Union[str, bytes, IO]) -> tuple[NodlDocument, DocumentTree]:
+    """Load, validate, resolve includes, and return both the merged document and the inclusion tree.
+
+    Returns a ``(merged_doc, doc_tree)`` tuple where:
+
+    - ``merged_doc`` is the fully resolved document (no ``include`` key), identical to
+      what ``load_nodl(source)`` would return.
+    - ``doc_tree`` is the :class:`DocumentTree` capturing the recursive structure of the document includes.
+
+    Raises jsonschema.ValidationError on schema error
+    Raises pydantic.ValidationError on type error
+    Raises composition.ResolutionError when no appropriate resolver found for reference
+        Resolvers generally raise ResolutionError on invalid or unfindable references,
+        but their custom exceptions are allowed propagate for unforseen cases, for visibility
+    """
+    doc = _load_doc(source)
+    doc_tree = resolve_document(doc)
+    merged_doc = merge_documents(doc_tree.flatten())
+    return merged_doc, doc_tree
 
 
 def dump_nodl(doc: Union[NodlDocument, dict], *, format: str = 'yaml') -> str:

--- a/nodl_schema/test/test_composition.py
+++ b/nodl_schema/test/test_composition.py
@@ -157,6 +157,55 @@ def test_document_without_includes_touches_no_resolver(docs):
 
 
 # ---------------------------------------------------------------------------
+# resolve_document tree structure
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_no_includes_returns_empty_tree(docs):
+    base = NodlDocument(publishers=[_topic('/only')])
+    tree = resolve_document(base)
+    assert tree.root_doc is base
+    assert tree.resolved_includes == []
+
+
+def test_resolve_single_include_has_one_child(docs):
+    ref = docs.add('x', _pub_doc('/x'))
+    tree = resolve_document(_including(ref))
+    assert len(tree.resolved_includes) == 1
+    child = tree.resolved_includes[0]
+    assert child.ref == ref
+    assert child.doc.publishers[0].name == '/x'
+    assert child.resolved_includes == []
+
+
+def test_resolve_nested_includes_builds_tree(docs):
+    inner = docs.add('inner', _pub_doc('/inner'))
+    outer = docs.add('outer', _pub_doc('/outer', inner))
+    tree = resolve_document(_including(outer))
+    assert len(tree.resolved_includes) == 1
+    outer_node = tree.resolved_includes[0]
+    assert outer_node.ref == outer
+    assert len(outer_node.resolved_includes) == 1
+    inner_node = outer_node.resolved_includes[0]
+    assert inner_node.ref == inner
+    assert inner_node.resolved_includes == []
+
+
+def test_flatten_nested_tree_contains_all_documents(docs):
+    inner = docs.add('inner', _pub_doc('/inner'))
+    outer = docs.add('outer', _pub_doc('/outer', inner))
+    base = NodlDocument(publishers=[_topic('/root')], include=_refs(outer))
+    flat = resolve_document(base).flatten()
+    names = {d.publishers[0].name for d in flat}
+    assert names == {'/root', '/outer', '/inner'}
+
+
+def test_flatten_no_includes_returns_only_root(docs):
+    base = NodlDocument(publishers=[_topic('/only')])
+    assert resolve_document(base).flatten() == [base]
+
+
+# ---------------------------------------------------------------------------
 # Collisions (error-on-collision policy)
 # ---------------------------------------------------------------------------
 

--- a/nodl_schema/test/test_composition.py
+++ b/nodl_schema/test/test_composition.py
@@ -121,7 +121,7 @@ def docs():
 def test_single_include_merges_entities(docs):
     ref = docs.add('extra', _sub_doc('/extra'))
     base = NodlDocument(publishers=[_topic('/base')], include=_refs(ref))
-    merged = merge_documents(resolve_document(base))
+    merged = merge_documents(resolve_document(base).flatten())
     assert merged.include is None
     assert [p.name for p in merged.publishers] == ['/base']
     assert [s.name for s in merged.subscriptions] == ['/extra']
@@ -130,28 +130,28 @@ def test_single_include_merges_entities(docs):
 def test_include_merges_parameters(docs):
     ref = docs.add('params', _param_doc(gain='double'))
     base = NodlDocument(parameters={'rate': ParameterDefinition(type='int')}, include=_refs(ref))
-    merged = merge_documents(resolve_document(base))
+    merged = merge_documents(resolve_document(base).flatten())
     assert set(merged.parameters) == {'rate', 'gain'}
 
 
 def test_nested_include_is_resolved_recursively(docs):
     inner = docs.add('b', _pub_doc('/b'))
     ref = docs.add('a', _pub_doc('/a', inner))
-    merged = merge_documents(resolve_document(_including(ref)))
+    merged = merge_documents(resolve_document(_including(ref)).flatten())
     assert sorted(p.name for p in merged.publishers) == ['/a', '/b']
 
 
 def test_input_document_is_not_mutated(docs):
     ref = docs.add('x', _pub_doc('/x'))
     base = _including(ref)
-    merge_documents(resolve_document(base))
+    merge_documents(resolve_document(base).flatten())
     assert [r.ref for r in base.include] == [ref]
     assert base.publishers is None
 
 
 def test_document_without_includes_touches_no_resolver(docs):
     base = NodlDocument(publishers=[_topic('/only')])
-    merged = merge_documents(resolve_document(base))
+    merged = merge_documents(resolve_document(base).flatten())
     assert docs.calls == []
     assert [p.name for p in merged.publishers] == ['/only']
 
@@ -165,35 +165,35 @@ def test_collision_between_base_and_include_errors(docs):
     ref = docs.add('dup', _pub_doc('/status'))
     base = NodlDocument(publishers=[_topic('/status')], include=_refs(ref))
     with pytest.raises(MergeError, match='/status'):
-        merge_documents(resolve_document(base))
+        merge_documents(resolve_document(base).flatten())
 
 
 def test_collision_between_two_includes_errors(docs):
     one = docs.add('one', _pub_doc('/shared'))
     two = docs.add('two', _pub_doc('/shared'))
     with pytest.raises(MergeError, match='/shared'):
-        merge_documents(resolve_document(_including(one, two)))
+        merge_documents(resolve_document(_including(one, two)).flatten())
 
 
 def test_parameter_collision_errors(docs):
     ref = docs.add('p', _param_doc(gain='double'))
     base = NodlDocument(parameters={'gain': ParameterDefinition(type='int')}, include=_refs(ref))
     with pytest.raises(MergeError, match='gain'):
-        merge_documents(resolve_document(base))
+        merge_documents(resolve_document(base).flatten())
 
 
 def test_service_collision_errors(docs):
     ref = docs.add('svc', NodlDocument(service_servers=[_service('/reset')]))
     base = NodlDocument(service_servers=[_service('/reset')], include=_refs(ref))
     with pytest.raises(MergeError, match='/reset'):
-        merge_documents(resolve_document(base))
+        merge_documents(resolve_document(base).flatten())
 
 
 def test_same_name_different_category_is_allowed(docs):
     # A publisher and a subscription may share a topic name; they are different categories.
     ref = docs.add('sub', _sub_doc('/topic'))
     base = NodlDocument(publishers=[_topic('/topic')], include=_refs(ref))
-    merged = merge_documents(resolve_document(base))
+    merged = merge_documents(resolve_document(base).flatten())
     assert merged.publishers[0].name == '/topic'
     assert merged.subscriptions[0].name == '/topic'
 
@@ -204,7 +204,7 @@ def test_diamond_surfaces_as_a_collision(docs):
     left = docs.add('left', _including(shared))
     right = docs.add('right', _including(shared))
     with pytest.raises(ResolutionError, match='/shared|nclusion'):
-        merge_documents(resolve_document(_including(left, right)))
+        merge_documents(resolve_document(_including(left, right)).flatten())
 
 
 # ---------------------------------------------------------------------------
@@ -374,7 +374,7 @@ def test_registering_shadows_the_built_in_resolver():
     shadow = NodlShadow()
     ref = shadow.add('pkg/thing', _pub_doc('/shadowed'))
     with resolver_registered(shadow):
-        merged = merge_documents(resolve_document(_including(ref)))
+        merged = merge_documents(resolve_document(_including(ref)).flatten())
     assert [p.name for p in merged.publishers] == ['/shadowed']
     assert isinstance(resolver_for(ref), AmentIndexResolver)
 


### PR DESCRIPTION
Add `load_nodl_with_doc_tree()`, which returns both the merged NoDL document and the tree structure that produced it.

This is groundwork for codegen provenance: downstream tools need the tree structure to figure out which interfaces come from an included implementation vs. which ones need to be scaffolded. Until now the tree was built and immediately flattened, so there was no way to get at it.