### PR TITLE
Add `codgen` key to schema

### DIFF
--- a/nodl_schema/doc/overview.md
+++ b/nodl_schema/doc/overview.md
@@ -77,6 +77,29 @@ Double-inclusions of the same reference (including cycles) are rejected.
 The same entity type with the same name declared twice is an error.
 Resolution failures raise `ResolutionError`, and collisions raise `MergeError`.
 
+## Code generation metadata: the `codegen` key
+
+A document can carry an optional `codegen` field with opaque metadata for code generation tools.
+The field is keyed by target language or tool (e.g. `cpp`, `python`). Each value is an object whose
+contents are tool-defined and the NoDL schema does not constrain them:
+
+```yaml
+nodl_version: 2
+codegen:
+  cpp:
+    role: base_class
+    header: rclcpp/rclcpp.hpp
+    class: rclcpp::Node
+
+publishers:
+  - name: /rosout
+    type: rcl_interfaces/msg/Log
+    qos: {history: KEEP_LAST, depth: 1000, reliability: RELIABLE}
+```
+
+`nodl_schema` validates that `codegen` is an object of objects, but does not inspect the contents.
+Interpretation is left to the consuming code generation tool.
+
 ## Data model
 
 The typed model lives in {repo}`nodl_schema/nodl_schema/models.py`.

--- a/nodl_schema/nodl_schema/models.py
+++ b/nodl_schema/nodl_schema/models.py
@@ -451,6 +451,10 @@ class NodlDocument(BaseModel):
 
     nodl_version: int = Field(2, const=True, description='NoDL schema major version this document targets.')
     description: Optional[str] = Field(None, description='Human-readable description of what this node does.')
+    codegen: Optional[dict[str, dict[str, Any]]] = Field(
+        None,
+        description='Opaque metadata for code generation tools, keyed by target language or tool\n(e.g. ``cpp``, ``python``). Each value is an object whose contents are\ntool-defined. The NoDL schema does not constrain them.\n',
+    )
     include: Optional[list[Reference]] = Field(
         None,
         description='Other NoDL documents whose interface entities are merged into this one.\nEach reference is resolved - recursively, following all references until done.\nCircular inclusion is an error.\nAn entity-name collision (for example two publishers named ``/status``) is an error.\n',

--- a/nodl_schema/nodl_schema/schemas/nodl.schema.yaml
+++ b/nodl_schema/nodl_schema/schemas/nodl.schema.yaml
@@ -28,6 +28,15 @@ properties:
     type: string
     description: Human-readable description of what this node does.
 
+  codegen:
+    type: object
+    description: |
+      Opaque metadata for code generation tools, keyed by target language or tool
+      (e.g. ``cpp``, ``python``). Each value is an object whose contents are
+      tool-defined. The NoDL schema does not constrain them.
+    additionalProperties:
+      type: object
+
   include:
     type: array
     description: |

--- a/nodl_schema/test/test_composition.py
+++ b/nodl_schema/test/test_composition.py
@@ -495,5 +495,5 @@ def test_codegen_on_included_document_survives_resolution(docs):
     codegen = {'cpp': {'role': 'base_class', 'header': 'rclcpp/rclcpp.hpp'}}
     ref = docs.add('with_cg', NodlDocument(publishers=[_topic('/t')], codegen=codegen))
     resolved = resolve_document(_including(ref))
-    included = resolved[1]
+    included = resolved.resolved_includes[0].doc
     assert included.codegen == codegen

--- a/nodl_schema/test/test_composition.py
+++ b/nodl_schema/test/test_composition.py
@@ -484,3 +484,16 @@ def test_ament_resolver_rejects_malformed_uri(ref):
     # The schema checks URI shape only, so the body is checked here.
     with pytest.raises(ResolutionError, match='expected nodl://'):
         AmentIndexResolver().resolve(ref)
+
+
+# ---------------------------------------------------------------------------
+# codegen field
+# ---------------------------------------------------------------------------
+
+
+def test_codegen_on_included_document_survives_resolution(docs):
+    codegen = {'cpp': {'role': 'base_class', 'header': 'rclcpp/rclcpp.hpp'}}
+    ref = docs.add('with_cg', NodlDocument(publishers=[_topic('/t')], codegen=codegen))
+    resolved = resolve_document(_including(ref))
+    included = resolved[1]
+    assert included.codegen == codegen

--- a/nodl_schema/test/test_schema.py
+++ b/nodl_schema/test/test_schema.py
@@ -49,6 +49,34 @@ def test_description_field():
     validate({'nodl_version': 2, 'description': 'A simple node'})
 
 
+def test_codegen_accepted():
+    validate({'nodl_version': 2, 'codegen': {'cpp': {'role': 'base_class', 'header': 'rclcpp/rclcpp.hpp'}}})
+
+
+def test_codegen_multiple_tool_keys():
+    validate({
+        'nodl_version': 2,
+        'codegen': {
+            'cpp': {'role': 'base_class', 'header': 'rclcpp/rclcpp.hpp'},
+            'python': {'module': 'rclpy.node'},
+        },
+    })
+
+
+def test_codegen_empty_accepted():
+    validate({'nodl_version': 2, 'codegen': {}})
+
+
+def test_codegen_non_object_value_rejected():
+    with pytest.raises(ValidationError):
+        validate({'nodl_version': 2, 'codegen': {'cpp': 'a string'}})
+
+
+def test_codegen_non_object_rejected():
+    with pytest.raises(ValidationError):
+        validate({'nodl_version': 2, 'codegen': 'a string'})
+
+
 @pytest.mark.parametrize(
     'ptype,default',
     [


### PR DESCRIPTION
Add an optional, opaque `codgen` field to the document root. The schema doesn't constrain its contents - its left to the downstream code generator to parse and validate.