### PR TITLE
lint: bump precommit hook version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/polymathrobotics/polymath_code_standard
-    rev: v2.1.3
+    rev: v2.4.0
     hooks:
       # Basic checks and fixes that apply to any text file and the git repository itself
       - id: polymath-general


### PR DESCRIPTION
No-op formatting change, but nice to just keep up to date.