### PR TITLE
feat: Add local reference resolver

### DIFF
--- a/nodl_schema/nodl_schema/__init__.py
+++ b/nodl_schema/nodl_schema/__init__.py
@@ -12,9 +12,11 @@ from nodl_schema.composition import (
     unregister_resolver,
 )
 from nodl_schema.loader import dump_nodl, load_nodl, load_nodl_with_doc_tree, parse_nodl, resolve_document
+from nodl_schema.local_resolver import LocalResolver
 from nodl_schema.validation import load_schema, validate
 
 register_resolver(AmentIndexResolver())
+register_resolver(LocalResolver())
 
 __all__ = [
     'AmentIndexResolver',

--- a/nodl_schema/nodl_schema/ament_resolver.py
+++ b/nodl_schema/nodl_schema/ament_resolver.py
@@ -17,7 +17,7 @@ class AmentIndexResolver:
     def handles(self, ref: str) -> bool:
         return ref.startswith(self.prefix)
 
-    def resolve(self, ref: str) -> Path:
+    def resolve(self, ref: str, origin: Path) -> Path:
         package, _, name = ref[len(self.prefix) :].partition('/')
         if not package or not name:
             raise ResolutionError(f'invalid reference {ref!r}: expected nodl://<package>/<name>')

--- a/nodl_schema/nodl_schema/ament_resolver.py
+++ b/nodl_schema/nodl_schema/ament_resolver.py
@@ -17,7 +17,7 @@ class AmentIndexResolver:
     def handles(self, ref: str) -> bool:
         return ref.startswith(self.prefix)
 
-    def resolve(self, ref: str, origin: Path) -> Path:
+    def resolve(self, ref: str, origin: Path | None = None) -> Path:
         package, _, name = ref[len(self.prefix) :].partition('/')
         if not package or not name:
             raise ResolutionError(f'invalid reference {ref!r}: expected nodl://<package>/<name>')

--- a/nodl_schema/nodl_schema/composition.py
+++ b/nodl_schema/nodl_schema/composition.py
@@ -34,10 +34,12 @@ class Resolver(Protocol):
         """Whether this resolver recognizes ``ref`` as a form it can resolve."""
         ...
 
-    def resolve(self, ref: str) -> Path:
+    def resolve(self, ref: str, origin: Path) -> Path:
         """Return the path to the document ``ref`` names.
         Should only called when ``handles`` is true.
         Raise ResolutionError when ref cannot be resolved.
+        @param ref: Exact text of the URI reference
+        @param origin: Document that is making the reference - necessary to resolve local includes
         """
         ...
 
@@ -93,12 +95,12 @@ def resolver_for(ref: str) -> Resolver | None:
     return None
 
 
-def resolve(ref: str) -> Path:
-    """Return the text of the document ``ref`` names, if it can be resolved."""
+def resolve(ref: str, origin: Path) -> Path:
+    """Return the path to the document ``ref`` names, if it can be resolved."""
     resolver = resolver_for(ref)
     if resolver is None:
         raise ResolutionError(f'No registered resolver handles reference {ref!r}.')
-    return resolver.resolve(ref)
+    return resolver.resolve(ref, origin)
 
 
 # --------------------------------

--- a/nodl_schema/nodl_schema/composition.py
+++ b/nodl_schema/nodl_schema/composition.py
@@ -34,7 +34,7 @@ class Resolver(Protocol):
         """Whether this resolver recognizes ``ref`` as a form it can resolve."""
         ...
 
-    def resolve(self, ref: str, origin: Path) -> Path:
+    def resolve(self, ref: str, origin: Path | None = None) -> Path:
         """Return the path to the document ``ref`` names.
         Should only called when ``handles`` is true.
         Raise ResolutionError when ref cannot be resolved.
@@ -95,7 +95,7 @@ def resolver_for(ref: str) -> Resolver | None:
     return None
 
 
-def resolve(ref: str, origin: Path) -> Path:
+def resolve(ref: str, origin: Path | None = None) -> Path:
     """Return the path to the document ``ref`` names, if it can be resolved."""
     resolver = resolver_for(ref)
     if resolver is None:

--- a/nodl_schema/nodl_schema/loader.py
+++ b/nodl_schema/nodl_schema/loader.py
@@ -40,14 +40,14 @@ Ref: TypeAlias = str
 IncludeChain: TypeAlias = list[str]
 
 
-def resolve_document(doc: NodlDocument, origin: Path) -> DocumentTree:
+def resolve_document(doc: NodlDocument, origin: Path | None = None) -> DocumentTree:
     # DFS traversal of the includes, detecting non-tree double-inclusions/cycles
 
     visited: dict[Path, IncludeChain] = {}
 
-    def _resolve_ref(ref: Ref, *, chain: IncludeChain, origin: Path) -> IncludedDocument:
+    def _resolve_ref(ref: Ref, *, chain: IncludeChain, origin: Path | None) -> IncludedDocument:
         current_chain = chain + [ref]
-        resolved_path = resolve(ref)
+        resolved_path = resolve(ref, origin)
 
         if resolved_path in visited:
             other_chain = visited[resolved_path]
@@ -57,7 +57,7 @@ def resolve_document(doc: NodlDocument, origin: Path) -> DocumentTree:
 
         visited[resolved_path] = current_chain
         doc = load_nodl(resolved_path, resolve=False)
-        children = [_resolve_ref(r.ref, current_chain, origin=resolved_path) for r in (doc.include or [])]
+        children = [_resolve_ref(r.ref, chain=current_chain, origin=resolved_path) for r in (doc.include or [])]
 
         return IncludedDocument(ref=ref, doc=doc, resolved_includes=children)
 

--- a/nodl_schema/nodl_schema/loader.py
+++ b/nodl_schema/nodl_schema/loader.py
@@ -40,12 +40,12 @@ Ref: TypeAlias = str
 IncludeChain: TypeAlias = list[str]
 
 
-def resolve_document(doc: NodlDocument) -> DocumentTree:
+def resolve_document(doc: NodlDocument, origin: Path) -> DocumentTree:
     # DFS traversal of the includes, detecting non-tree double-inclusions/cycles
 
     visited: dict[Path, IncludeChain] = {}
 
-    def _resolve_ref(ref: Ref, chain: IncludeChain) -> IncludedDocument:
+    def _resolve_ref(ref: Ref, *, chain: IncludeChain, origin: Path) -> IncludedDocument:
         current_chain = chain + [ref]
         resolved_path = resolve(ref)
 
@@ -57,11 +57,11 @@ def resolve_document(doc: NodlDocument) -> DocumentTree:
 
         visited[resolved_path] = current_chain
         doc = load_nodl(resolved_path, resolve=False)
-        children = [_resolve_ref(r.ref, current_chain) for r in (doc.include or [])]
+        children = [_resolve_ref(r.ref, current_chain, origin=resolved_path) for r in (doc.include or [])]
 
         return IncludedDocument(ref=ref, doc=doc, resolved_includes=children)
 
-    root_children = [_resolve_ref(r.ref, chain=[]) for r in (doc.include or [])]
+    root_children = [_resolve_ref(r.ref, chain=[], origin=origin) for r in (doc.include or [])]
 
     return DocumentTree(root_doc=doc, resolved_includes=root_children)
 
@@ -93,7 +93,6 @@ def load_nodl(source: Path, *, resolve: bool = True) -> NodlDocument:
         Resolvers generally raise ResolutionError on invalid or unfindable references,
         but their custom exceptions are allowed propagate for unforseen cases, for visibility
     """
-
     if resolve:
         result_doc, _ = load_nodl_with_doc_tree(source)
     else:
@@ -118,7 +117,7 @@ def load_nodl_with_doc_tree(source: Path) -> tuple[NodlDocument, DocumentTree]:
         but their custom exceptions are allowed propagate for unforseen cases, for visibility
     """
     doc = parse_nodl(source.read_text())
-    doc_tree = resolve_document(doc)
+    doc_tree = resolve_document(doc, source)
     merged_doc = merge_documents(doc_tree.flatten())
     return merged_doc, doc_tree
 

--- a/nodl_schema/nodl_schema/local_resolver.py
+++ b/nodl_schema/nodl_schema/local_resolver.py
@@ -15,12 +15,11 @@ class LocalResolver(Resolver):
     def handles(self, ref: str) -> bool:
         return ref.startswith(self.prefix)
 
-    def resolve(self, ref: str, origin: Path | None) -> tuple[str, Path | None]:
+    def resolve(self, ref: str, origin: Path | None = None) -> Path:
         assert origin, 'Local resolver requires an originating path'
         assert origin.is_absolute(), 'Originating document path must be absolute'
 
         path = Path(origin.parent, ref[len(self.prefix) :])
-        try:
-            return (path.read_text(encoding='utf-8'), path)
-        except OSError as exc:
-            raise ResolutionError(f'could not read {str(path)!r} for reference {ref!r}: {exc}') from exc
+        if not path.is_file():
+            raise ResolutionError(f'could not read {str(path)!r} for reference {ref!r}')
+        return path

--- a/nodl_schema/nodl_schema/local_resolver.py
+++ b/nodl_schema/nodl_schema/local_resolver.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+from nodl_schema.composition import ResolutionError, Resolver
+
+
+class LocalResolver(Resolver):
+    """
+    Resolves ``local://<path>`` from the source tree, relative to the document holding it.
+    """
+
+    prefix = 'local://'
+
+    def handles(self, ref: str) -> bool:
+        return ref.startswith(self.prefix)
+
+    def resolve(self, ref: str, origin: Path | None) -> tuple[str, Path | None]:
+        assert origin, 'Local resolver requires an originating path'
+        assert origin.is_absolute(), 'Originating document path must be absolute'
+
+        path = Path(origin.parent, ref[len(self.prefix) :])
+        try:
+            return (path.read_text(encoding='utf-8'), path)
+        except OSError as exc:
+            raise ResolutionError(f'could not read {str(path)!r} for reference {ref!r}: {exc}') from exc

--- a/nodl_schema/nodl_schema/models.py
+++ b/nodl_schema/nodl_schema/models.py
@@ -60,7 +60,7 @@ class Reference(BaseModel):
 
     ref: constr(regex=r'^[a-z][a-z0-9+.-]*://[^\s/][^\s]*$') = Field(
         ...,
-        description='Reference to a NoDL document, as a ``<scheme>://<body>`` URI.\nDynamically egistered resolvers handle these URIs, so the schema does not restrict them.\n``nodl://<package>/<name>`` is the built-in resolver which fetches from the ament index.\n',
+        description='Reference to a NoDL document, as a ``<scheme>://<body>`` URI.\nDynamically egistered resolvers handle these URIs, so the schema does not restrict them.\nThese resolver schemes are built in:\n``nodl://<package>/<name>`` fetches from the ament index.\n``local://<relative path to file>`` is another document in the same package, as a relative path.\n',
         examples=['nodl://sensor_common/imu_driver'],
     )
 

--- a/nodl_schema/nodl_schema/schemas/nodl.schema.yaml
+++ b/nodl_schema/nodl_schema/schemas/nodl.schema.yaml
@@ -105,7 +105,9 @@ definitions:
         description: |
           Reference to a NoDL document, as a ``<scheme>://<body>`` URI.
           Dynamically egistered resolvers handle these URIs, so the schema does not restrict them.
-          ``nodl://<package>/<name>`` is the built-in resolver which fetches from the ament index.
+          These resolver schemes are built in:
+          ``nodl://<package>/<name>`` fetches from the ament index.
+          ``local://<relative path to file>`` is another document in the same package, as a relative path.
         pattern: ^[a-z][a-z0-9+.-]*://[^\s/][^\s]*$
         examples:
           - nodl://sensor_common/imu_driver

--- a/nodl_schema/test/test_composition.py
+++ b/nodl_schema/test/test_composition.py
@@ -109,10 +109,10 @@ class FakeResolver:
     def handles(self, ref: str) -> bool:
         return ref.startswith(self.scheme)
 
-    def resolve(self, ref: str) -> Path:
+    def resolve(self, ref: str, origin: Path) -> Path:
         self.calls.append(ref)
         try:
-            return self.docs[ref]
+            return self.docs[ref], None
         except KeyError:
             raise FileNotFoundError(ref)
 

--- a/nodl_schema/test/test_composition.py
+++ b/nodl_schema/test/test_composition.py
@@ -109,10 +109,10 @@ class FakeResolver:
     def handles(self, ref: str) -> bool:
         return ref.startswith(self.scheme)
 
-    def resolve(self, ref: str, origin: Path) -> Path:
+    def resolve(self, ref: str, origin: Path | None = None) -> Path:
         self.calls.append(ref)
         try:
-            return self.docs[ref], None
+            return self.docs[ref]
         except KeyError:
             raise FileNotFoundError(ref)
 

--- a/nodl_schema/test/test_local_resolver.py
+++ b/nodl_schema/test/test_local_resolver.py
@@ -44,7 +44,7 @@ def test_basic_resolve(tmp_path: Path):
     relative_path = Path('relative.yaml')
     dest_path = (tmp_path / relative_path).absolute()
     _write(dest_path, NodlDocument())
-    _, resolved_path = resolver.resolve(f'local://{relative_path.name}', dest_path)
+    resolved_path = resolver.resolve(f'local://{relative_path.name}', dest_path)
 
     assert resolved_path == (tmp_path / relative_path).absolute()
 
@@ -52,17 +52,17 @@ def test_basic_resolve(tmp_path: Path):
 def test_relative_ref_resolves_against_the_document_directory(tmp_path: Path):
     _write(tmp_path / 'common' / 'pub2.nodl.yaml', _pub_doc('/pub2'))
     doc_path = _write(tmp_path / 'pub1.nodl.yaml', _pub_doc('/pub1', 'local://common/pub2.nodl.yaml'))
-    with doc_path.open() as f:
-        doc = load_nodl(f)
+    doc = load_nodl(doc_path)
+    assert doc.publishers
     assert sorted(p.name for p in doc.publishers) == ['/pub1', '/pub2']
 
 
-def test_open_file_supplies_its_own_base(tmp_path: Path):
+def test_load_from_a_path_supplies_its_own_base(tmp_path: Path):
     _write(tmp_path / 'shared.nodl.yaml', _pub_doc('/shared'))
     root = _write(tmp_path / 'main.nodl.yaml', NodlDocument(include=[Reference(ref='local://shared.nodl.yaml')]))
-    with root.open() as f:
-        doc = load_nodl(f)
+    doc = load_nodl(root)
 
+    assert doc.publishers
     assert [p.name for p in doc.publishers] == ['/shared']
 
 
@@ -71,9 +71,9 @@ def test_nested_ref_is_relative_to_its_own_document(tmp_path: Path):
     _write(tmp_path / 'b' / 'leaf.nodl.yaml', _pub_doc('/leaf'))
     _write(tmp_path / 'b' / 'mid.nodl.yaml', NodlDocument(include=[Reference(ref='local://leaf.nodl.yaml')]))
     root = _write(tmp_path / 'top.nodl.yaml', NodlDocument(include=[Reference(ref='local://b/mid.nodl.yaml')]))
-    with root.open() as f:
-        doc = load_nodl(f)
+    doc = load_nodl(root)
 
+    assert doc.publishers
     assert [p.name for p in doc.publishers] == ['/leaf']
 
 
@@ -82,22 +82,22 @@ def test_relative_ref_may_walk_upward(tmp_path: Path):
     root = _write(
         tmp_path / 'nodl' / 'node.nodl.yaml', NodlDocument(include=[Reference(ref='local://../shared/base.nodl.yaml')])
     )
-    with root.open() as f:
-        doc = load_nodl(f)
+    doc = load_nodl(root)
 
+    assert doc.publishers
     assert [p.name for p in doc.publishers] == ['/base']
 
 
-def test_relative_ref_without_a_base_raises(tmp_path: Path):
+def test_relative_ref_without_a_base_raises():
+    # A local ref has no meaning without a document to resolve it against.
     with pytest.raises(AssertionError):
-        load_nodl(dump_nodl(NodlDocument(include=[Reference(ref='local://common/telemetry.nodl.yaml')])))
+        LocalResolver().resolve('local://common/telemetry.nodl.yaml', None)
 
 
 def test_missing_relative_ref_raises(tmp_path: Path):
     root = _write(tmp_path / 'main.nodl.yaml', NodlDocument(include=[Reference(ref='local://absent.nodl.yaml')]))
     with pytest.raises(ResolutionError, match='absent.nodl.yaml'):
-        with root.open() as f:
-            load_nodl(f)
+        load_nodl(root)
 
 
 def test_cycle_is_detected_across_spellings(tmp_path: Path):
@@ -106,8 +106,7 @@ def test_cycle_is_detected_across_spellings(tmp_path: Path):
     _write(tmp_path / 'b.nodl.yaml', NodlDocument(include=[Reference(ref='local://./a.nodl.yaml')]))
     root = tmp_path / 'a.nodl.yaml'
     with pytest.raises(ResolutionError, match='Double-inclusion'):
-        with root.open() as f:
-            load_nodl(f)
+        load_nodl(root)
 
 
 def test_double_inclusion_with_different_relative_paths(tmp_path: Path):
@@ -123,8 +122,7 @@ def test_double_inclusion_with_different_relative_paths(tmp_path: Path):
     _write(tmp_path / 'subdir' / 'c.nodl.yaml', NodlDocument())
 
     with pytest.raises(ResolutionError, match='Double-inclusion'):
-        with root.open() as f:
-            load_nodl(f)
+        load_nodl(root)
 
 
 def test_reference_looping_back_to_the_root_is_detected(tmp_path: Path):
@@ -132,5 +130,4 @@ def test_reference_looping_back_to_the_root_is_detected(tmp_path: Path):
     _write(tmp_path / 'other.nodl.yaml', NodlDocument(include=[Reference(ref='local://root.nodl.yaml')]))
     root = _write(tmp_path / 'root.nodl.yaml', NodlDocument(include=[Reference(ref='local://other.nodl.yaml')]))
     with pytest.raises(ResolutionError, match='Double-inclusion'):
-        with root.open() as f:
-            load_nodl(f)
+        load_nodl(root)

--- a/nodl_schema/test/test_local_resolver.py
+++ b/nodl_schema/test/test_local_resolver.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``local://`` references and their rewriting.
+
+These use real files, since resolving against a document's location is the whole point.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from nodl_schema import ResolutionError, dump_nodl, load_nodl
+from nodl_schema.local_resolver import LocalResolver
+from nodl_schema.models import History, NodlDocument, QosProfile, Reference, Reliability, TopicEndpoint
+
+
+def _write(path: Path, doc: NodlDocument) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = dump_nodl(doc)
+    path.write_text(text)
+    return path
+
+
+def _pub_doc(name, *refs) -> NodlDocument:
+    qos = QosProfile(history=History.SYSTEM_DEFAULT, reliability=Reliability.SYSTEM_DEFAULT)
+    return NodlDocument(
+        publishers=[TopicEndpoint(name=name, type='std_msgs/msg/String', qos=qos)],
+        include=[Reference(ref=ref) for ref in refs],
+    )
+
+
+@pytest.mark.parametrize('ref', ['local://x.nodl.yaml', 'local://a/b.jsonl'])
+def test_local_resolver_handles_local_refs(ref):
+    assert LocalResolver().handles(ref)
+
+
+@pytest.mark.parametrize('ref', ['nodl://pkg/x', 'test://x', ''])
+def test_local_resolver_ignores_other_schemes(ref):
+    assert not LocalResolver().handles(ref)
+
+
+def test_basic_resolve(tmp_path: Path):
+    resolver = LocalResolver()
+    relative_path = Path('relative.yaml')
+    dest_path = (tmp_path / relative_path).absolute()
+    _write(dest_path, NodlDocument())
+    _, resolved_path = resolver.resolve(f'local://{relative_path.name}', dest_path)
+
+    assert resolved_path == (tmp_path / relative_path).absolute()
+
+
+def test_relative_ref_resolves_against_the_document_directory(tmp_path: Path):
+    _write(tmp_path / 'common' / 'pub2.nodl.yaml', _pub_doc('/pub2'))
+    doc_path = _write(tmp_path / 'pub1.nodl.yaml', _pub_doc('/pub1', 'local://common/pub2.nodl.yaml'))
+    with doc_path.open() as f:
+        doc = load_nodl(f)
+    assert sorted(p.name for p in doc.publishers) == ['/pub1', '/pub2']
+
+
+def test_open_file_supplies_its_own_base(tmp_path: Path):
+    _write(tmp_path / 'shared.nodl.yaml', _pub_doc('/shared'))
+    root = _write(tmp_path / 'main.nodl.yaml', NodlDocument(include=[Reference(ref='local://shared.nodl.yaml')]))
+    with root.open() as f:
+        doc = load_nodl(f)
+
+    assert [p.name for p in doc.publishers] == ['/shared']
+
+
+def test_nested_ref_is_relative_to_its_own_document(tmp_path: Path):
+    # b/leaf is named relative to b/mid, not to the top-level document.
+    _write(tmp_path / 'b' / 'leaf.nodl.yaml', _pub_doc('/leaf'))
+    _write(tmp_path / 'b' / 'mid.nodl.yaml', NodlDocument(include=[Reference(ref='local://leaf.nodl.yaml')]))
+    root = _write(tmp_path / 'top.nodl.yaml', NodlDocument(include=[Reference(ref='local://b/mid.nodl.yaml')]))
+    with root.open() as f:
+        doc = load_nodl(f)
+
+    assert [p.name for p in doc.publishers] == ['/leaf']
+
+
+def test_relative_ref_may_walk_upward(tmp_path: Path):
+    _write(tmp_path / 'shared' / 'base.nodl.yaml', _pub_doc('/base'))
+    root = _write(
+        tmp_path / 'nodl' / 'node.nodl.yaml', NodlDocument(include=[Reference(ref='local://../shared/base.nodl.yaml')])
+    )
+    with root.open() as f:
+        doc = load_nodl(f)
+
+    assert [p.name for p in doc.publishers] == ['/base']
+
+
+def test_relative_ref_without_a_base_raises(tmp_path: Path):
+    with pytest.raises(AssertionError):
+        load_nodl(dump_nodl(NodlDocument(include=[Reference(ref='local://common/telemetry.nodl.yaml')])))
+
+
+def test_missing_relative_ref_raises(tmp_path: Path):
+    root = _write(tmp_path / 'main.nodl.yaml', NodlDocument(include=[Reference(ref='local://absent.nodl.yaml')]))
+    with pytest.raises(ResolutionError, match='absent.nodl.yaml'):
+        with root.open() as f:
+            load_nodl(f)
+
+
+def test_cycle_is_detected_across_spellings(tmp_path: Path):
+    # a -> b -> ./a, two spellings of one file.
+    _write(tmp_path / 'a.nodl.yaml', NodlDocument(include=[Reference(ref='local://b.nodl.yaml')]))
+    _write(tmp_path / 'b.nodl.yaml', NodlDocument(include=[Reference(ref='local://./a.nodl.yaml')]))
+    root = tmp_path / 'a.nodl.yaml'
+    with pytest.raises(ResolutionError, match='Double-inclusion'):
+        with root.open() as f:
+            load_nodl(f)
+
+
+def test_double_inclusion_with_different_relative_paths(tmp_path: Path):
+    # a -> b -> ./a, two spellings of one file.
+    root = tmp_path / 'a.nodl.yaml'
+    _write(
+        root,
+        NodlDocument(
+            include=[Reference(ref='local://subdir/b.nodl.yaml'), Reference(ref='local://subdir/c.nodl.yaml')]
+        ),
+    )
+    _write(tmp_path / 'subdir' / 'b.nodl.yaml', NodlDocument(include=[Reference(ref='local://c.nodl.yaml')]))
+    _write(tmp_path / 'subdir' / 'c.nodl.yaml', NodlDocument())
+
+    with pytest.raises(ResolutionError, match='Double-inclusion'):
+        with root.open() as f:
+            load_nodl(f)
+
+
+def test_reference_looping_back_to_the_root_is_detected(tmp_path: Path):
+    # Knowing the root's own origin is what makes this catchable at all.
+    _write(tmp_path / 'other.nodl.yaml', NodlDocument(include=[Reference(ref='local://root.nodl.yaml')]))
+    root = _write(tmp_path / 'root.nodl.yaml', NodlDocument(include=[Reference(ref='local://other.nodl.yaml')]))
+    with pytest.raises(ResolutionError, match='Double-inclusion'):
+        with root.open() as f:
+            load_nodl(f)


### PR DESCRIPTION
Smaller scoped beginning to #100
Part of #99 

This adds a new `LocalResolver` that can resolve `include: local://` references to paths relative to the document making the reference. Introduces the pattern that the originating `Path` of the document being processed is passed around along with the model, so that this resolution can be made.

Intentionally left out of scope for dedicated diff: `ament_nodl` installation rewriting includes from `local://` to `nodl://` ament index ones.

