### PR TITLE
feat: rename ament_nodl_register_node to ament_nodl_register

### DIFF
--- a/ament_nodl/CMakeLists.txt
+++ b/ament_nodl/CMakeLists.txt
@@ -5,9 +5,10 @@ project(ament_nodl)
 
 find_package(ament_cmake REQUIRED)
 
-install(FILES
-  cmake/ament_nodl_register_node.cmake
-  DESTINATION share/${PROJECT_NAME}/cmake)
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
+)
 
 install(FILES package.xml
   DESTINATION share/${PROJECT_NAME})

--- a/ament_nodl/ament_nodl-extras.cmake.in
+++ b/ament_nodl/ament_nodl-extras.cmake.in
@@ -1,4 +1,4 @@
 # Resolves ${Python3_EXECUTABLE} for the build-time validation step the macros invoke.
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
-include("${CMAKE_CURRENT_LIST_DIR}/ament_nodl_register_node.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/ament_nodl_register.cmake")

--- a/ament_nodl/cmake/ament_nodl_register.cmake
+++ b/ament_nodl/cmake/ament_nodl_register.cmake
@@ -1,28 +1,26 @@
 # SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Register a NoDL document for an executable in the ament resource index.
+# Register a NoDL document in the ament resource index.
 #
-# Publishes the contents of a NoDL file under the ``nodl_nodes`` resource type.
-# The resource key is ``<package>__<executable>``.
-# Tools like ``nodl_test`` and ``nodl_docgen`` use this to locate the spec by package and executable name.
+# Publishes the contents of a NoDL file under the ``nodl`` resource type.
+# The resource key is ``<package>__<resource_name>``.
 #
-# Consumers retrieve the content via::
+# Consumers may retrieve the content via::
 #
-#   ament_index_python.packages.get_resource('nodl_nodes', '<pkg>__<exe>')
+#   ament_index_python.packages.get_resource('nodl', '<pkg>__<name>')
 #
 # The source file is also installed under ``share/<package>/nodl/`` for direct filesystem access.
 #
 # Example::
 #
-#   ament_nodl_register_node(my_node
+#   ament_nodl_register(my_node
 #     FILE nodl/my_node.nodl.yaml
 #   )
 #
-# :param executable_name: name of the executable this NoDL document describes.
-#   Combined with PACKAGE to form the resource key.
-# :type executable_name: string
-# :param FILE: path to the NoDL file describing the executable's interface.
+# :param resource_name: target name for this NoDL document.
+# :type resource_name: string
+# :param FILE: Required path to the NoDL file describing the executable's interface.
 #   May be absolute or relative to ``CMAKE_CURRENT_SOURCE_DIR``.
 # :type FILE: string
 # :param PACKAGE: package name to use in the resource key.
@@ -31,11 +29,12 @@
 #
 # @public
 #
-function(ament_nodl_register_node executable_name)
+function(ament_nodl_register resource_name)
   cmake_parse_arguments(_ARGS "" "FILE;PACKAGE" "" ${ARGN})
+  set(_NODL_RESOURCE_TYPE "nodl")
 
   if(NOT _ARGS_FILE)
-    message(FATAL_ERROR "ament_nodl_register_node: FILE is required")
+    message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION}: FILE is required")
   endif()
   if(NOT _ARGS_PACKAGE)
     set(_ARGS_PACKAGE "${PROJECT_NAME}")
@@ -46,31 +45,31 @@ function(ament_nodl_register_node executable_name)
 
   if(NOT EXISTS "${_abs_file}")
     message(WARNING
-      "ament_nodl_register_node: file not found at configure time: ${_abs_file}")
+      "${CMAKE_CURRENT_FUNCTION}: file not found at configure time: ${_abs_file}")
   endif()
 
   # Validate the file at build time so authoring errors surface when registering, not downstream when consuming.
   # This only runs when ${_abs_file} changes.
-  set(_stamp_dir "${CMAKE_CURRENT_BINARY_DIR}/ament_nodl/nodl_nodes")
-  set(_stamp "${_stamp_dir}/${_ARGS_PACKAGE}__${executable_name}.valid.stamp")
+  set(_stamp_dir "${CMAKE_CURRENT_BINARY_DIR}/ament_nodl/${_NODL_RESOURCE_TYPE}")
+  set(_stamp "${_stamp_dir}/${_ARGS_PACKAGE}__${resource_name}.valid.stamp")
   file(MAKE_DIRECTORY "${_stamp_dir}")
   add_custom_command(
     OUTPUT "${_stamp}"
     DEPENDS "${_abs_file}"
     COMMAND "${Python3_EXECUTABLE}" -m nodl_schema "${_abs_file}"
     COMMAND "${CMAKE_COMMAND}" -E touch "${_stamp}"
-    COMMENT "Validating NoDL node ${_ARGS_PACKAGE}/${executable_name}"
+    COMMENT "Validating NoDL ${_ARGS_PACKAGE}/${resource_name}"
     VERBATIM
   )
-  add_custom_target(_ament_nodl_validate_node_${_ARGS_PACKAGE}__${executable_name} ALL
+  add_custom_target(_ament_nodl_validate_node_${_ARGS_PACKAGE}__${resource_name} ALL
     DEPENDS "${_stamp}"
   )
 
   # Install to ament index
   install(
     FILES "${_abs_file}"
-    DESTINATION "share/ament_index/resource_index/nodl_nodes"
-    RENAME "${_ARGS_PACKAGE}__${executable_name}")
+    DESTINATION "share/ament_index/resource_index/${_NODL_RESOURCE_TYPE}"
+    RENAME "${_ARGS_PACKAGE}__${resource_name}")
 
   # Install to package's share directory
   install(

--- a/ament_nodl/doc/overview.md
+++ b/ament_nodl/doc/overview.md
@@ -5,20 +5,20 @@ tools can locate a node's interface specification by package and executable name
 
 For what a NoDL document declares, see {external+nodl:doc}`concepts`.
 
-## `ament_nodl_register_node`
+## `ament_nodl_register`
 
-Register a NoDL document for an executable. This does three things:
+Register a NoDL document with the ament index. This does three things:
 
 1. Validates the file at build time (via `python -m nodl_schema`), so authoring errors surface when registering
    rather than downstream when a consumer reads the spec.
    If the document uses `include`, this step also checks that its references resolve.
-2. Installs the file into the ament index under the `nodl_nodes` resource type, keyed `<package>__<executable>`.
+2. Installs the file into the ament index under the `nodl` resource type, keyed `<package>__<name>`.
 3. Installs the file under `share/<package>/nodl/` for direct filesystem access.
 
 ```cmake
 find_package(ament_nodl REQUIRED)
 
-ament_nodl_register_node(my_node
+ament_nodl_register(my_node
   FILE nodl/my_node.nodl.yaml
 )
 ```
@@ -38,7 +38,7 @@ This feature is upcoming in a followup pass.
 :`FILE`: Path to the NoDL file. Absolute, or relative to `CMAKE_CURRENT_SOURCE_DIR`. Required.
 :`PACKAGE`: Package name used in the resource key. Defaults to `${PROJECT_NAME}`.
 
-See the macro source at {repo}`ament_nodl/cmake/ament_nodl_register_node.cmake`.
+See the macro source at {repo}`ament_nodl/cmake/ament_nodl_register.cmake`.
 
 ## Consuming registered documents
 
@@ -47,7 +47,7 @@ Tools retrieve a registered document by its resource key:
 ```python
 from ament_index_python.packages import get_resource
 
-content, path = get_resource('nodl_nodes', 'my_package__my_node')
+content, path = get_resource('nodl', 'my_package__my_node')
 ```
 
 The validation step shells out to `nodl_schema`, which is this package's runtime dependency.

--- a/nodl_schema/nodl_schema/ament_resolver.py
+++ b/nodl_schema/nodl_schema/ament_resolver.py
@@ -9,7 +9,7 @@ class AmentIndexResolver:
     """Resolves ``nodl://<package>/<name>`` through the ament index."""
 
     prefix = 'nodl://'
-    ament_resource_type = 'nodl_nodes'
+    ament_resource_type = 'nodl'
 
     def handles(self, ref: str) -> bool:
         return ref.startswith(self.prefix)

--- a/nodl_schema/test/test_composition.py
+++ b/nodl_schema/test/test_composition.py
@@ -464,7 +464,7 @@ def test_ament_resolver_looks_up_the_registered_resource(monkeypatch):
 
     monkeypatch.setattr(resources, 'get_resource', fake_get_resource)
     text = AmentIndexResolver().resolve('nodl://sensor_common/imu_driver')
-    assert captured['args'] == ('nodl_nodes', 'sensor_common__imu_driver')
+    assert captured['args'] == ('nodl', 'sensor_common__imu_driver')
     assert 'nodl_version' in text
 
 

--- a/nodl_schema/test/test_validator_cli.py
+++ b/nodl_schema/test/test_validator_cli.py
@@ -82,8 +82,7 @@ def test_json_frontend_supported(tmp_path: Path):
 
 
 def test_unresolvable_include_exits_one_by_default(tmp_path: Path):
-    # The default (resolving) path is what ament_nodl_register_node runs, so a broken reference
-    # has to fail the build next to the schema check.
+    # a broken reference has to fail the build next to the schema check
     f = tmp_path / 'inc.nodl.yaml'
     f.write_text(_UNRESOLVABLE_INCLUDE)
     result = _run(f)

--- a/test_ament_nodl/CMakeLists.txt
+++ b/test_ament_nodl/CMakeLists.txt
@@ -7,15 +7,15 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_nodl REQUIRED)
 
 # Default PACKAGE resolves to ${PROJECT_NAME}.
-ament_nodl_register_node(basic_node FILE test/fixtures/basic_node.nodl.yaml)
+ament_nodl_register(basic_node FILE test/fixtures/basic_node.nodl.yaml)
 
 # Explicit PACKAGE override. The resource key and install destination both pick it up.
-ament_nodl_register_node(custom_exe
+ament_nodl_register(custom_exe
   FILE test/fixtures/alt_pkg_node.nodl.yaml
   PACKAGE custom_pkg)
 
 # Non-yaml frontend. Make sure the macro is extension-agnostic.
-ament_nodl_register_node(json_node FILE test/fixtures/json_node.nodl.json)
+ament_nodl_register(json_node FILE test/fixtures/json_node.nodl.json)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)

--- a/test_ament_nodl/test/fixtures/basic_node.nodl.yaml
+++ b/test_ament_nodl/test/fixtures/basic_node.nodl.yaml
@@ -1,6 +1,6 @@
 ---
 nodl_version: 2
-description: Basic test node used to exercise ament_nodl_register_node default args.
+description: Basic test node used to exercise ament_nodl_register default args.
 publishers:
   - name: /chatter
     type: std_msgs/msg/String

--- a/test_ament_nodl/test/test_composition.py
+++ b/test_ament_nodl/test/test_composition.py
@@ -88,6 +88,6 @@ def test_no_resolve_leaves_the_include_untouched():
 
 def test_registered_document_is_installed_as_authored():
     # Registration does not rewrite, so a consumer resolves the document as authored.
-    content, _ = get_resource('nodl_nodes', 'test_ament_nodl__basic_node')
+    content, _ = get_resource('nodl', 'test_ament_nodl__basic_node')
     assert 'include' not in content
     assert '/chatter' in content

--- a/test_ament_nodl/test/test_macro_rejection.py
+++ b/test_ament_nodl/test/test_macro_rejection.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
 # SPDX-License-Identifier: Apache-2.0
-"""End-to-end test that the ament_nodl_register_node macro propagates validator failures as build failures.
+"""End-to-end test that the ament_nodl_register macro propagates validator failures as build failures.
 
 Writes a tiny inner ament_cmake project that registers an intentionally-invalid NoDL file via the macro,
 then spawns cmake to configure and build it; the build is expected to fail with the validator error.
@@ -23,7 +23,7 @@ _INNER_CMAKELISTS = textwrap.dedent("""
     project(rejection_fixture)
     find_package(ament_cmake REQUIRED)
     find_package(ament_nodl REQUIRED)
-    ament_nodl_register_node(bad_exe FILE bad.nodl.yaml)
+    ament_nodl_register(bad_exe FILE bad.nodl.yaml)
     ament_package()
 """)
 

--- a/test_ament_nodl/test/test_register_node.py
+++ b/test_ament_nodl/test/test_register_node.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
 # SPDX-License-Identifier: Apache-2.0
-"""Integration tests for the ament_nodl_register_node CMake macro.
+"""Integration tests for the ament_nodl_register CMake macro.
 
 The macro is exercised at configure / install time by this package's
 CMakeLists.txt; here we assert on the resulting ament index and install
@@ -30,26 +30,26 @@ def _share(pkg: str = 'test_ament_nodl') -> Path:
 
 def test_default_package_uses_project_name():
     # No PACKAGE arg means the macro defaults to ${PROJECT_NAME}, so the key is test_ament_nodl__basic_node.
-    content, prefix = get_resource('nodl_nodes', 'test_ament_nodl__basic_node')
+    content, prefix = get_resource('nodl', 'test_ament_nodl__basic_node')
     assert prefix
     assert 'Basic test node' in content
 
 
 def test_explicit_package_override():
     # PACKAGE custom_pkg makes the key custom_pkg__custom_exe even though the registering package is test_ament_nodl.
-    content, _ = get_resource('nodl_nodes', 'custom_pkg__custom_exe')
+    content, _ = get_resource('nodl', 'custom_pkg__custom_exe')
     assert 'explicit PACKAGE override' in content
 
 
 def test_extension_agnostic_frontend():
     # The macro reads bytes and writes bytes; a .nodl.json file round-trips just like yaml.
-    content, _ = get_resource('nodl_nodes', 'test_ament_nodl__json_node')
+    content, _ = get_resource('nodl', 'test_ament_nodl__json_node')
     assert '"nodl_version": 2' in content
 
 
 def test_resource_content_matches_source():
     # The registered resource should be byte-identical to the source file.
-    content, _ = get_resource('nodl_nodes', 'test_ament_nodl__basic_node')
+    content, _ = get_resource('nodl', 'test_ament_nodl__basic_node')
     on_disk = (_share() / 'nodl' / 'basic_node.nodl.yaml').read_text()
     assert content == on_disk
 


### PR DESCRIPTION
This registration had too much focus on "nodes" and "executables" and semantically clashed with some of the more generalized capabilities I want to build out like "node mixins", meaning partial nodes that may only be a library and not an executable. 

Loosened up the naming and language to just "registering a document", including naming the ament resource just `nodl` instead of `nodl_nodes`