### PR TITLE
feat: Include resolvers always return a Path

### DIFF
--- a/nodl_schema/nodl_schema/__init__.py
+++ b/nodl_schema/nodl_schema/__init__.py
@@ -11,7 +11,7 @@ from nodl_schema.composition import (
     resolver_registered,
     unregister_resolver,
 )
-from nodl_schema.loader import dump_nodl, load_nodl, load_nodl_with_doc_tree, resolve_document
+from nodl_schema.loader import dump_nodl, load_nodl, load_nodl_with_doc_tree, parse_nodl, resolve_document
 from nodl_schema.validation import load_schema, validate
 
 register_resolver(AmentIndexResolver())
@@ -25,6 +25,7 @@ __all__ = [
     'load_nodl_with_doc_tree',
     'load_schema',
     'get_resolvers',
+    'parse_nodl',
     'register_resolver',
     'resolve_document',
     'resolver_registered',

--- a/nodl_schema/nodl_schema/ament_resolver.py
+++ b/nodl_schema/nodl_schema/ament_resolver.py
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
 # SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
 from ament_index_python import resources as ament_index
+from ament_index_python.constants import RESOURCE_INDEX_SUBFOLDER
 
 from nodl_schema.composition import ResolutionError
 
@@ -14,16 +17,17 @@ class AmentIndexResolver:
     def handles(self, ref: str) -> bool:
         return ref.startswith(self.prefix)
 
-    def resolve(self, ref: str) -> str:
+    def resolve(self, ref: str) -> Path:
         package, _, name = ref[len(self.prefix) :].partition('/')
         if not package or not name:
             raise ResolutionError(f'invalid reference {ref!r}: expected nodl://<package>/<name>')
 
         key = f'{package}__{name}'
-        try:
-            content, _ = ament_index.get_resource(self.ament_resource_type, key)
-        except Exception as exc:
+        resource_prefix = ament_index.has_resource(self.ament_resource_type, key)
+        if not resource_prefix:
             raise ResolutionError(
                 f'NoDL document {ref!r} not found in ament index (resource {self.ament_resource_type}/{key})'
-            ) from exc
-        return content
+            )
+
+        resource_path = Path(resource_prefix, RESOURCE_INDEX_SUBFOLDER, self.ament_resource_type, key)
+        return resource_path

--- a/nodl_schema/nodl_schema/ament_resolver.py
+++ b/nodl_schema/nodl_schema/ament_resolver.py
@@ -30,4 +30,7 @@ class AmentIndexResolver:
             )
 
         resource_path = Path(resource_prefix, RESOURCE_INDEX_SUBFOLDER, self.ament_resource_type, key)
+        if not resource_path.exists():
+            raise ResolutionError(f'NoDL document {ref} not found at registered path {resource_path}')
+
         return resource_path

--- a/nodl_schema/nodl_schema/cli.py
+++ b/nodl_schema/nodl_schema/cli.py
@@ -29,8 +29,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        with args.file.open('r') as f:
-            load_nodl(f, resolve=args.resolve)
+        load_nodl(args.file, resolve=args.resolve)
     except Exception as exc:
         print(f'{args.file}: {exc}', file=sys.stderr)
         return 1

--- a/nodl_schema/nodl_schema/composition.py
+++ b/nodl_schema/nodl_schema/composition.py
@@ -34,8 +34,11 @@ class Resolver(Protocol):
         """Whether this resolver recognizes ``ref`` as a form it can resolve."""
         ...
 
-    def resolve(self, ref: str) -> Path | None:
-        """Return the path to the document ``ref`` names. Only called when ``handles`` is true."""
+    def resolve(self, ref: str) -> Path:
+        """Return the path to the document ``ref`` names.
+        Should only called when ``handles`` is true.
+        Raise ResolutionError when ref cannot be resolved.
+        """
         ...
 
 

--- a/nodl_schema/nodl_schema/composition.py
+++ b/nodl_schema/nodl_schema/composition.py
@@ -12,6 +12,7 @@ A resolver returns document text, not a path, since a reference need not name an
 from __future__ import annotations
 
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Generator, Protocol, runtime_checkable
 
 from nodl_schema.models import NodlDocument, ParameterDefinition
@@ -33,8 +34,8 @@ class Resolver(Protocol):
         """Whether this resolver recognizes ``ref`` as a form it can resolve."""
         ...
 
-    def resolve(self, ref: str) -> str:
-        """Return the raw text of the document ``ref`` names. Only called when ``handles`` is true."""
+    def resolve(self, ref: str) -> Path | None:
+        """Return the path to the document ``ref`` names. Only called when ``handles`` is true."""
         ...
 
 
@@ -89,7 +90,7 @@ def resolver_for(ref: str) -> Resolver | None:
     return None
 
 
-def resolve(ref: str) -> str:
+def resolve(ref: str) -> Path:
     """Return the text of the document ``ref`` names, if it can be resolved."""
     resolver = resolver_for(ref)
     if resolver is None:

--- a/nodl_schema/nodl_schema/loader.py
+++ b/nodl_schema/nodl_schema/loader.py
@@ -3,7 +3,8 @@
 import json
 from collections import deque
 from dataclasses import dataclass
-from typing import IO, TypeAlias, Union
+from pathlib import Path
+from typing import TypeAlias, Union
 
 import yaml
 
@@ -70,8 +71,8 @@ def resolve_document(doc: NodlDocument) -> DocumentTree:
     return DocumentTree(root_doc=doc, resolved_includes=root_children)
 
 
-def _load_doc(source: Union[str, bytes, IO]) -> NodlDocument:
-    data = yaml.safe_load(source)
+def _load_doc(source: Path) -> NodlDocument:
+    data = yaml.safe_load(source.read_text())
     if not isinstance(data, dict):
         raise ValueError('NoDL document must be a YAML/JSON mapping at the top level')
 
@@ -84,8 +85,8 @@ def _load_doc(source: Union[str, bytes, IO]) -> NodlDocument:
     return doc
 
 
-def load_nodl(source: Union[str, bytes, IO], *, resolve: bool = True) -> NodlDocument:
-    """Load and validate a NoDL document from a string, bytes, or file-like object containing JSON or YAML text.
+def load_nodl(source: Path, *, resolve: bool = True) -> NodlDocument:
+    """Load and validate a NoDL document from a path containing JSON or YAML text.
 
     When ``resolve`` (default True), ``include`` references are resolved and merged into the resulting document,
     which then has no ``include`` key.
@@ -106,7 +107,7 @@ def load_nodl(source: Union[str, bytes, IO], *, resolve: bool = True) -> NodlDoc
     return result_doc
 
 
-def load_nodl_with_doc_tree(source: Union[str, bytes, IO]) -> tuple[NodlDocument, DocumentTree]:
+def load_nodl_with_doc_tree(source: Path) -> tuple[NodlDocument, DocumentTree]:
     """Load, validate, resolve includes, and return both the merged document and the inclusion tree.
 
     Returns a ``(merged_doc, doc_tree)`` tuple where:

--- a/nodl_schema/nodl_schema/loader.py
+++ b/nodl_schema/nodl_schema/loader.py
@@ -4,7 +4,7 @@ import json
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypeAlias, Union
+from typing import IO, TypeAlias, Union
 
 import yaml
 
@@ -42,26 +42,21 @@ IncludeChain: TypeAlias = list[str]
 
 def resolve_document(doc: NodlDocument) -> DocumentTree:
     # DFS traversal of the includes, detecting non-tree double-inclusions/cycles
-    # NOTE(emerson) there is not currently a way to detect if a reference loops back to _this_ document,
-    # since we don't have our own ref in this context.
-    # Really, we are depending on the package dependency graph to avoid cycles.
-    # Additionally, if "the same" reference were to be found by different resolvers, that is not caught here,
-    # but by merge collision checking.
 
-    visited: dict[Ref, IncludeChain] = {}
+    visited: dict[Path, IncludeChain] = {}
 
     def _resolve_ref(ref: Ref, chain: IncludeChain) -> IncludedDocument:
         current_chain = chain + [ref]
+        resolved_path = resolve(ref)
 
-        if ref in visited:
-            other_chain = visited[ref]
+        if resolved_path in visited:
+            other_chain = visited[resolved_path]
             chain_a = ' > '.join(current_chain)
             chain_b = ' > '.join(other_chain)
             raise ResolutionError(f'Double-inclusion detected. "{chain_a}" and "{chain_b}"')
 
-        visited[ref] = current_chain
-        content = resolve(ref)
-        doc = load_nodl(content, resolve=False)
+        visited[resolved_path] = current_chain
+        doc = load_nodl(resolved_path, resolve=False)
         children = [_resolve_ref(r.ref, current_chain) for r in (doc.include or [])]
 
         return IncludedDocument(ref=ref, doc=doc, resolved_includes=children)
@@ -71,8 +66,8 @@ def resolve_document(doc: NodlDocument) -> DocumentTree:
     return DocumentTree(root_doc=doc, resolved_includes=root_children)
 
 
-def _load_doc(source: Path) -> NodlDocument:
-    data = yaml.safe_load(source.read_text())
+def parse_nodl(data: Union[str, bytes, IO]) -> NodlDocument:
+    data = yaml.safe_load(data)
     if not isinstance(data, dict):
         raise ValueError('NoDL document must be a YAML/JSON mapping at the top level')
 
@@ -102,7 +97,7 @@ def load_nodl(source: Path, *, resolve: bool = True) -> NodlDocument:
     if resolve:
         result_doc, _ = load_nodl_with_doc_tree(source)
     else:
-        result_doc = _load_doc(source)
+        result_doc = parse_nodl(source.read_text())
 
     return result_doc
 
@@ -122,8 +117,8 @@ def load_nodl_with_doc_tree(source: Path) -> tuple[NodlDocument, DocumentTree]:
         Resolvers generally raise ResolutionError on invalid or unfindable references,
         but their custom exceptions are allowed propagate for unforseen cases, for visibility
     """
-    doc = _load_doc(source)
-    doc_tree = resolve_document(doc)
+    doc = parse_nodl(source.read_text())
+    doc_tree = resolve_document(doc, source)
     merged_doc = merge_documents(doc_tree.flatten())
     return merged_doc, doc_tree
 

--- a/nodl_schema/nodl_schema/loader.py
+++ b/nodl_schema/nodl_schema/loader.py
@@ -118,7 +118,7 @@ def load_nodl_with_doc_tree(source: Path) -> tuple[NodlDocument, DocumentTree]:
         but their custom exceptions are allowed propagate for unforseen cases, for visibility
     """
     doc = parse_nodl(source.read_text())
-    doc_tree = resolve_document(doc, source)
+    doc_tree = resolve_document(doc)
     merged_doc = merge_documents(doc_tree.flatten())
     return merged_doc, doc_tree
 

--- a/nodl_schema/test/test_ament_resolver.py
+++ b/nodl_schema/test/test_ament_resolver.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+import pytest
+
+from nodl_schema import AmentIndexResolver, ResolutionError, dump_nodl
+from nodl_schema.models import NodlDocument
+
+
+@pytest.mark.parametrize('ref', ['nodl://sensor_common/imu_driver', 'nodl://pkg/x'])
+def test_ament_resolver_handles_nodl_refs(ref):
+    assert AmentIndexResolver().handles(ref)
+
+
+@pytest.mark.parametrize('ref', ['test://x', 'common/telemetry.nodl.yaml', 'ftp://example.com/x.yaml', ''])
+def test_ament_resolver_does_not_handle_other_forms(ref):
+    assert not AmentIndexResolver().handles(ref)
+
+
+def _write_ament_resource(prefix: Path, key: str, doc: NodlDocument) -> Path:
+    from ament_index_python.constants import RESOURCE_INDEX_SUBFOLDER
+
+    resource_path = Path(prefix, RESOURCE_INDEX_SUBFOLDER, AmentIndexResolver.ament_resource_type, key)
+    resource_path.parent.mkdir(parents=True, exist_ok=True)
+    resource_path.write_text(dump_nodl(doc))
+    return resource_path
+
+
+def test_ament_resolver_looks_up_the_registered_resource(monkeypatch, tmp_path: Path):
+    written_path = _write_ament_resource(tmp_path, 'sensor_common__imu_driver', NodlDocument())
+
+    def fake_has_resource(resource_type: str, resource_name: str):
+        return tmp_path
+
+    import ament_index_python.resources as resources
+
+    monkeypatch.setattr(resources, 'has_resource', fake_has_resource)
+
+    path = AmentIndexResolver().resolve('nodl://sensor_common/imu_driver')
+    assert path == written_path
+
+
+def test_ament_resolver_missing_resource_raises():
+    with pytest.raises(ResolutionError, match='nodl://pkg/absent'):
+        AmentIndexResolver().resolve('nodl://pkg/absent')
+
+
+@pytest.mark.parametrize('ref', ['nodl://pkg', 'nodl://pkg/', 'nodl:///name'])
+def test_ament_resolver_rejects_malformed_uri(ref):
+    # The schema checks URI shape only, so the body is checked here.
+    with pytest.raises(ResolutionError, match='expected nodl://'):
+        AmentIndexResolver().resolve(ref)

--- a/nodl_schema/test/test_composition.py
+++ b/nodl_schema/test/test_composition.py
@@ -446,7 +446,6 @@ def test_registering_shadows_the_built_in_resolver():
     ref = shadow.add('pkg/thing', _pub_doc('/shadowed'))
     with resolver_registered(shadow):
         merged = merge_documents(resolve_document(_including(ref)).flatten())
-
     assert merged.publishers
     assert [p.name for p in merged.publishers] == ['/shadowed']
     assert isinstance(resolver_for(ref), AmentIndexResolver)

--- a/nodl_schema/test/test_composition.py
+++ b/nodl_schema/test/test_composition.py
@@ -3,6 +3,9 @@
 
 """Unit tests for NoDL document composition (the ``include`` key)."""
 
+import tempfile
+from pathlib import Path
+
 import pytest
 
 from nodl_schema import (
@@ -73,15 +76,18 @@ def _including(*refs) -> NodlDocument:
 class FakeResolver:
     """Resolves an in-memory ``test://`` reference format.
 
-    Documents go in as models and come out as text, since that is what a resolver returns.
+    Documents go in as models and come out as a ``Path`` to a temp file, since that is
+    what a resolver returns.
     Use ``add_text`` for content a model cannot hold, such as a deliberately invalid document.
     """
 
     scheme = 'test://'
 
     def __init__(self, docs: dict[str, NodlDocument] | None = None):
-        self.docs: dict[str, str] = {}
+        self.docs: dict[str, Path] = {}
         self.calls: list[str] = []
+        self._dir = Path(tempfile.mkdtemp())
+        self._n = 0
         for name, doc in (docs or {}).items():
             self.add(name, doc)
 
@@ -92,13 +98,17 @@ class FakeResolver:
     def add_text(self, name: str, text: str) -> str:
         """Register raw text, for documents that are deliberately not valid NoDL."""
         ref = f'{self.scheme}{name}'
-        self.docs[ref] = text
+        # Refs may contain '/', so name the file by insertion order rather than by ref.
+        path = self._dir / f'{self._n}.nodl.yaml'
+        self._n += 1
+        path.write_text(text)
+        self.docs[ref] = path
         return ref
 
     def handles(self, ref: str) -> bool:
         return ref.startswith(self.scheme)
 
-    def resolve(self, ref: str) -> str:
+    def resolve(self, ref: str) -> Path:
         self.calls.append(ref)
         try:
             return self.docs[ref]
@@ -450,54 +460,6 @@ def test_register_resolver_without_a_scope_persists_until_removed():
     finally:
         unregister_resolver(resolver)
     assert resolver_for('test://x') is None
-
-
-# ---------------------------------------------------------------------------
-# AmentIndexResolver
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize('ref', ['nodl://sensor_common/imu_driver', 'nodl://pkg/x'])
-def test_ament_resolver_handles_nodl_refs(ref):
-    assert AmentIndexResolver().handles(ref)
-
-
-@pytest.mark.parametrize('ref', ['test://x', 'common/telemetry.nodl.yaml', 'ftp://example.com/x.yaml', ''])
-def test_ament_resolver_does_not_handle_other_forms(ref):
-    assert not AmentIndexResolver().handles(ref)
-
-
-def test_ament_resolver_looks_up_the_registered_resource(monkeypatch):
-    captured = {}
-
-    def fake_get_resource(resource_type, name):
-        captured['args'] = (resource_type, name)
-        return ('nodl_version: 2\n', '/some/prefix')
-
-    import ament_index_python.resources as resources
-
-    monkeypatch.setattr(resources, 'get_resource', fake_get_resource)
-    text = AmentIndexResolver().resolve('nodl://sensor_common/imu_driver')
-    assert captured['args'] == ('nodl', 'sensor_common__imu_driver')
-    assert 'nodl_version' in text
-
-
-def test_ament_resolver_missing_resource_raises(monkeypatch):
-    def fake_get_resource(resource_type, name):
-        raise LookupError(name)
-
-    import ament_index_python.resources as resources
-
-    monkeypatch.setattr(resources, 'get_resource', fake_get_resource)
-    with pytest.raises(ResolutionError, match='nodl://pkg/absent'):
-        AmentIndexResolver().resolve('nodl://pkg/absent')
-
-
-@pytest.mark.parametrize('ref', ['nodl://pkg', 'nodl://pkg/', 'nodl:///name'])
-def test_ament_resolver_rejects_malformed_uri(ref):
-    # The schema checks URI shape only, so the body is checked here.
-    with pytest.raises(ResolutionError, match='expected nodl://'):
-        AmentIndexResolver().resolve(ref)
 
 
 # ---------------------------------------------------------------------------

--- a/nodl_schema/test/test_composition.py
+++ b/nodl_schema/test/test_composition.py
@@ -14,6 +14,7 @@ from nodl_schema import (
     dump_nodl,
     get_resolvers,
     load_nodl,
+    parse_nodl,
     register_resolver,
     resolve_document,
     resolver_registered,
@@ -319,15 +320,13 @@ def test_included_non_mapping_raises(docs):
 
 
 # ---------------------------------------------------------------------------
-# load_nodl integration
+# load/parse nodl
 # ---------------------------------------------------------------------------
-#
-# load_nodl takes a serialized source, so these serialize a model at the call site.
 
 
 def test_load_nodl_resolves_through_the_registry(docs):
     ref = docs.add('extra', _sub_doc('/extra'))
-    doc = load_nodl(dump_nodl(_including(ref)))
+    doc = parse_nodl(dump_nodl(_including(ref)))
     assert doc.subscriptions
     assert doc.subscriptions[0].name == '/extra'
     # The include key is consumed once resolved.
@@ -335,20 +334,21 @@ def test_load_nodl_resolves_through_the_registry(docs):
 
 
 def test_load_nodl_no_resolve_keeps_include(docs):
-    doc = load_nodl(dump_nodl(_including('test://extra')), resolve=False)
+    doc = docs.add('whatever', _including('test://extra'))
+    doc = load_nodl(doc, resolve=False)
     assert doc.include
     assert [r.ref for r in doc.include] == ['test://extra']
     assert docs.calls == []
 
 
 def test_load_nodl_without_include_does_not_touch_resolver(docs):
-    load_nodl(dump_nodl(NodlDocument()))
+    parse_nodl(dump_nodl(NodlDocument()))
     assert docs.calls == []
 
 
 def test_load_nodl_merges_the_resolved_documents(docs):
     ref = docs.add('extra', _sub_doc('/extra'))
-    doc = load_nodl(dump_nodl(NodlDocument(publishers=[_topic('/base')], include=_refs(ref))))
+    doc = parse_nodl(dump_nodl(NodlDocument(publishers=[_topic('/base')], include=_refs(ref))))
     assert doc.publishers
     assert [p.name for p in doc.publishers] == ['/base']
     assert doc.subscriptions

--- a/nodl_schema/test/test_composition.py
+++ b/nodl_schema/test/test_composition.py
@@ -324,18 +324,21 @@ def test_included_non_mapping_raises(docs):
 # ---------------------------------------------------------------------------
 
 
-def test_load_nodl_resolves_through_the_registry(docs):
+def test_load_nodl_resolves_through_the_registry(docs, tmp_path):
     ref = docs.add('extra', _sub_doc('/extra'))
-    doc = parse_nodl(dump_nodl(_including(ref)))
+    source = tmp_path / 'root.nodl.yaml'
+    source.write_text(dump_nodl(_including(ref)))
+    doc = load_nodl(source)
     assert doc.subscriptions
     assert doc.subscriptions[0].name == '/extra'
     # The include key is consumed once resolved.
     assert doc.include is None
 
 
-def test_load_nodl_no_resolve_keeps_include(docs):
-    doc = docs.add('whatever', _including('test://extra'))
-    doc = load_nodl(doc, resolve=False)
+def test_load_nodl_no_resolve_keeps_include(docs, tmp_path):
+    source = tmp_path / 'root.nodl.yaml'
+    source.write_text(dump_nodl(_including('test://extra')))
+    doc = load_nodl(source, resolve=False)
     assert doc.include
     assert [r.ref for r in doc.include] == ['test://extra']
     assert docs.calls == []
@@ -346,9 +349,11 @@ def test_load_nodl_without_include_does_not_touch_resolver(docs):
     assert docs.calls == []
 
 
-def test_load_nodl_merges_the_resolved_documents(docs):
+def test_load_nodl_merges_the_resolved_documents(docs, tmp_path):
     ref = docs.add('extra', _sub_doc('/extra'))
-    doc = parse_nodl(dump_nodl(NodlDocument(publishers=[_topic('/base')], include=_refs(ref))))
+    source = tmp_path / 'root.nodl.yaml'
+    source.write_text(dump_nodl(NodlDocument(publishers=[_topic('/base')], include=_refs(ref))))
+    doc = load_nodl(source)
     assert doc.publishers
     assert [p.name for p in doc.publishers] == ['/base']
     assert doc.subscriptions

--- a/nodl_schema/test/test_schema.py
+++ b/nodl_schema/test/test_schema.py
@@ -8,7 +8,7 @@ import json
 import pytest
 from jsonschema import ValidationError
 
-from nodl_schema import dump_nodl, load_nodl, parse_nodl, validate
+from nodl_schema import dump_nodl, parse_nodl, validate
 from nodl_schema.models import NodlDocument
 from nodl_schema.validation import load_schema
 
@@ -481,7 +481,7 @@ def test_load_nodl_from_json_string():
 
 def test_load_nodl_from_file_like():
     f = io.StringIO('nodl_version: 2\nparameters:\n  p:\n    type: string\n')
-    doc = load_nodl(f)
+    doc = parse_nodl(f)
     assert doc.parameters
     assert 'p' in doc.parameters
 

--- a/nodl_schema/test/test_schema.py
+++ b/nodl_schema/test/test_schema.py
@@ -8,7 +8,7 @@ import json
 import pytest
 from jsonschema import ValidationError
 
-from nodl_schema import dump_nodl, load_nodl, validate
+from nodl_schema import dump_nodl, load_nodl, parse_nodl, validate
 from nodl_schema.models import NodlDocument
 from nodl_schema.validation import load_schema
 
@@ -449,7 +449,7 @@ def test_action_missing_name():
 
 
 # ---------------------------------------------------------------------------
-# load_nodl
+# parse & load
 # ---------------------------------------------------------------------------
 
 
@@ -463,7 +463,7 @@ def test_load_nodl_from_yaml_string():
         '      history: SYSTEM_DEFAULT\n'
         '      reliability: SYSTEM_DEFAULT\n'
     )
-    doc = load_nodl(yaml_text)
+    doc = parse_nodl(yaml_text)
     assert isinstance(doc, NodlDocument)
     assert doc.publishers
     assert doc.publishers[0].name == '/t'
@@ -474,7 +474,7 @@ def test_load_nodl_from_json_string():
         'nodl_version': 2,
         'publishers': [{'name': '/t', 'type': 'std_msgs/msg/String', 'qos': _MIN_QOS}],
     }
-    doc = load_nodl(json.dumps(data))
+    doc = parse_nodl(json.dumps(data))
     assert doc.publishers
     assert doc.publishers[0].name == '/t'
 
@@ -488,7 +488,7 @@ def test_load_nodl_from_file_like():
 
 def test_load_nodl_invalid_raises():
     with pytest.raises(ValidationError):
-        load_nodl('nodl_version: 2\nparameters:\n  p:\n    type: bad_type\n')
+        parse_nodl('nodl_version: 2\nparameters:\n  p:\n    type: bad_type\n')
 
 
 # ---------------------------------------------------------------------------

--- a/ros2nodl/ros2nodl/verb/validate.py
+++ b/ros2nodl/ros2nodl/verb/validate.py
@@ -18,8 +18,9 @@ class ValidateVerb(VerbExtension):
         parser.add_argument(
             'files',
             type=Path,
-            nargs='*',
-            help='NoDL files to validate. Reads from stdin if none are given.',
+            required=True,
+            nargs='+',
+            help='NoDL files to validate.',
         )
         parser.add_argument(
             '--no-resolve',

--- a/ros2nodl/ros2nodl/verb/validate.py
+++ b/ros2nodl/ros2nodl/verb/validate.py
@@ -3,6 +3,7 @@
 """``ros2 nodl validate [files...]`` -- validate NoDL documents against the schema."""
 
 import sys
+from pathlib import Path
 
 from jsonschema import ValidationError
 
@@ -16,6 +17,7 @@ class ValidateVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):
         parser.add_argument(
             'files',
+            type=Path,
             nargs='*',
             help='NoDL files to validate. Reads from stdin if none are given.',
         )
@@ -27,35 +29,22 @@ class ValidateVerb(VerbExtension):
         )
 
     def main(self, *, args):
-        resolve = getattr(args, 'resolve', True)
-        if not args.files:
-            return _validate_source(sys.stdin, '<stdin>', resolve=resolve)
-
         rc = 0
         for path in args.files:
-            try:
-                source = open(path, 'r')
-            except OSError as e:
-                print(f'{path}: {e}', file=sys.stderr)
-                rc = 1
-                continue
-            try:
-                rc |= _validate_source(source, path, resolve=resolve)
-            finally:
-                source.close()
+            rc |= _validate_file(path, resolve=args.resolve)
         return rc
 
 
-def _validate_source(source, label, *, resolve: bool = True) -> int:
+def _validate_file(path: Path, *, resolve: bool = True) -> int:
     try:
-        load_nodl(source, resolve=resolve)
+        load_nodl(path, resolve=resolve)
     except ValidationError as e:
-        path = ' -> '.join(str(p) for p in e.absolute_path) or '<root>'
-        print(f'{label}: INVALID', file=sys.stderr)
-        print(f'  {path}: {e.message}', file=sys.stderr)
+        chain = ' -> '.join(str(p) for p in e.absolute_path) or '<root>'
+        print(f'{path}: INVALID', file=sys.stderr)
+        print(f'  {chain}: {e.message}', file=sys.stderr)
         return 1
     except Exception as e:
-        print(f'{label}: {e}', file=sys.stderr)
+        print(f'{path}: {e}', file=sys.stderr)
         return 1
-    print(f'{label}: ok')
+    print(f'{path}: ok')
     return 0

--- a/ros2nodl/test/test_verbs.py
+++ b/ros2nodl/test/test_verbs.py
@@ -3,7 +3,6 @@
 """Unit tests for the ros2nodl validate verb."""
 
 import argparse
-import io
 
 from ros2nodl.verb.validate import ValidateVerb
 
@@ -33,7 +32,7 @@ class TestValidateVerb:
             '      history: SYSTEM_DEFAULT\n'
             '      reliability: SYSTEM_DEFAULT\n'
         )
-        result = self.verb.main(args=_make_args(files=[str(nodl_file)]))
+        result = self.verb.main(args=_make_args(files=[nodl_file]))
         assert result == 0
 
     def test_valid_json_file(self, tmp_path):
@@ -43,36 +42,31 @@ class TestValidateVerb:
             '{"name": "/t", "type": "std_msgs/msg/String",'
             ' "qos": {"history": "SYSTEM_DEFAULT", "reliability": "SYSTEM_DEFAULT"}}]}'
         )
-        result = self.verb.main(args=_make_args(files=[str(nodl_file)]))
+        result = self.verb.main(args=_make_args(files=[nodl_file]))
         assert result == 0
 
     def test_invalid_file_returns_1(self, tmp_path, capsys):
         nodl_file = tmp_path / 'bad.yaml'
         nodl_file.write_text('nodl_version: 2\nparameters:\n  p:\n    type: not_a_real_type\n')
-        result = self.verb.main(args=_make_args(files=[str(nodl_file)]))
+        result = self.verb.main(args=_make_args(files=[nodl_file]))
         assert result == 1
         assert 'INVALID' in capsys.readouterr().err
-
-    def test_valid_from_stdin(self, monkeypatch):
-        monkeypatch.setattr('sys.stdin', io.StringIO('nodl_version: 2\n'))
-        result = self.verb.main(args=_make_args())
-        assert result == 0
 
     def test_minimal_document_is_valid(self, tmp_path):
         nodl_file = tmp_path / 'min.yaml'
         nodl_file.write_text('nodl_version: 2\n')
-        result = self.verb.main(args=_make_args(files=[str(nodl_file)]))
+        result = self.verb.main(args=_make_args(files=[nodl_file]))
         assert result == 0
 
-    def test_nonexistent_file_returns_1(self, capsys):
-        result = self.verb.main(args=_make_args(files=['/nonexistent/path/file.yaml']))
+    def test_nonexistent_file_returns_1(self, capsys, tmp_path):
+        result = self.verb.main(args=_make_args(files=[tmp_path / 'nonexistent.yaml']))
         assert result == 1
         assert 'No such file' in capsys.readouterr().err
 
     def test_success_prints_ok(self, tmp_path, capsys):
         nodl_file = tmp_path / 'ok.yaml'
         nodl_file.write_text('nodl_version: 2\n')
-        self.verb.main(args=_make_args(files=[str(nodl_file)]))
+        self.verb.main(args=_make_args(files=[nodl_file]))
         assert 'ok' in capsys.readouterr().out
 
     def test_multiple_files_all_valid(self, tmp_path):
@@ -80,7 +74,7 @@ class TestValidateVerb:
         b = tmp_path / 'b.yaml'
         a.write_text('nodl_version: 2\n')
         b.write_text('nodl_version: 2\n')
-        result = self.verb.main(args=_make_args(files=[str(a), str(b)]))
+        result = self.verb.main(args=_make_args(files=[a, b]))
         assert result == 0
 
     def test_multiple_files_one_invalid_returns_1(self, tmp_path):
@@ -88,25 +82,17 @@ class TestValidateVerb:
         bad = tmp_path / 'bad.yaml'
         good.write_text('nodl_version: 2\n')
         bad.write_text('nodl_version: 1\n')
-        result = self.verb.main(args=_make_args(files=[str(good), str(bad)]))
+        result = self.verb.main(args=_make_args(files=[good, bad]))
         assert result == 1
 
     def test_unresolvable_include_returns_1_by_default(self, tmp_path):
         nodl_file = tmp_path / 'inc.yaml'
         nodl_file.write_text(_UNRESOLVABLE_INCLUDE)
-        result = self.verb.main(args=_make_args(files=[str(nodl_file)]))
+        result = self.verb.main(args=_make_args(files=[nodl_file]))
         assert result == 1
 
     def test_no_resolve_skips_reference_resolution(self, tmp_path):
         nodl_file = tmp_path / 'inc.yaml'
         nodl_file.write_text(_UNRESOLVABLE_INCLUDE)
-        result = self.verb.main(args=_make_args(files=[str(nodl_file)], resolve=False))
+        result = self.verb.main(args=_make_args(files=[nodl_file], resolve=False))
         assert result == 0
-
-    def test_resolve_defaults_to_true_when_the_flag_is_absent(self, tmp_path):
-        # The verb tolerates a Namespace built without the flag, so callers that predate it work.
-        nodl_file = tmp_path / 'inc.yaml'
-        nodl_file.write_text(_UNRESOLVABLE_INCLUDE)
-        args = argparse.Namespace()
-        args.files = [str(nodl_file)]
-        assert self.verb.main(args=args) == 1

--- a/test_ament_nodl/test/test_composition.py
+++ b/test_ament_nodl/test/test_composition.py
@@ -24,9 +24,11 @@ _LOCAL_SUBSCRIPTION = (
 )
 
 
-def test_nodl_include_resolves_from_ament_index():
+def test_nodl_include_resolves_from_ament_index(tmp_path):
+    doc_path = tmp_path / 'test.nodl.yaml'
+    doc_path.write_text(f'nodl_version: 2\n{_LOCAL_SUBSCRIPTION}include:\n  - ref: nodl://test_ament_nodl/basic_node\n')
     # basic_node contributes a /chatter publisher; the including document adds its own subscription.
-    doc = load_nodl(f'nodl_version: 2\n{_LOCAL_SUBSCRIPTION}include:\n  - ref: nodl://test_ament_nodl/basic_node\n')
+    doc = load_nodl(doc_path)
     assert doc.publishers
     assert [p.name for p in doc.publishers] == ['/chatter']
     assert doc.subscriptions
@@ -35,9 +37,11 @@ def test_nodl_include_resolves_from_ament_index():
     assert doc.include is None
 
 
-def test_included_qos_survives_the_round_trip():
+def test_included_qos_survives_the_round_trip(tmp_path):
     # The included document is fetched as text and reparsed, so its details must survive.
-    doc = load_nodl('nodl_version: 2\ninclude:\n  - ref: nodl://test_ament_nodl/basic_node\n')
+    source = tmp_path / 'test.nodl.yaml'
+    source.write_text('nodl_version: 2\ninclude:\n  - ref: nodl://test_ament_nodl/basic_node\n')
+    doc = load_nodl(source)
     assert doc.publishers
     qos = doc.publishers[0].qos
     assert qos.depth == 10
@@ -45,26 +49,33 @@ def test_included_qos_survives_the_round_trip():
     assert qos.reliability.value == 'RELIABLE'
 
 
-def test_include_follows_the_package_override_in_the_resource_key():
+def test_include_follows_the_package_override_in_the_resource_key(tmp_path):
     # custom_exe is registered with PACKAGE custom_pkg, so the URI must name custom_pkg.
     # It declares no entities, so this asserts only that the lookup found it.
-    doc = load_nodl('nodl_version: 2\ninclude:\n  - ref: nodl://custom_pkg/custom_exe\n')
+    source = tmp_path / 'custom_pkg.nodl.yaml'
+    source.write_text('nodl_version: 2\ninclude:\n  - ref: nodl://custom_pkg/custom_exe\n')
+    doc = load_nodl(source)
     assert doc.include is None
 
     # The same name under this package is a different key, and nothing registered it.
+    missing = tmp_path / 'missing.nodl.yaml'
+    missing.write_text('nodl_version: 2\ninclude:\n  - ref: nodl://test_ament_nodl/custom_exe\n')
     with pytest.raises(ResolutionError):
-        load_nodl('nodl_version: 2\ninclude:\n  - ref: nodl://test_ament_nodl/custom_exe\n')
+        load_nodl(missing)
 
 
-def test_include_resolves_a_json_document():
+def test_include_resolves_a_json_document(tmp_path):
     # The index holds text, so the frontend the author used does not reach the consumer.
-    doc = load_nodl('nodl_version: 2\ninclude:\n  - ref: nodl://test_ament_nodl/json_node\n')
+    source = tmp_path / 'test.nodl.yaml'
+    source.write_text('nodl_version: 2\ninclude:\n  - ref: nodl://test_ament_nodl/json_node\n')
+    doc = load_nodl(source)
     assert doc.include is None
 
 
-def test_collision_with_an_included_document_raises():
+def test_collision_with_an_included_document_raises(tmp_path):
     # basic_node publishes /chatter, so publishing it here too is a duplicate.
-    source = (
+    source = tmp_path / 'test.nodl.yaml'
+    source.write_text(
         'nodl_version: 2\n'
         'publishers:\n'
         '  - name: /chatter\n'
@@ -76,16 +87,17 @@ def test_collision_with_an_included_document_raises():
         load_nodl(source)
 
 
-def test_unresolvable_nodl_include_raises():
+def test_unresolvable_nodl_include_raises(tmp_path):
+    source = tmp_path / 'test.nodl.yaml'
+    source.write_text('nodl_version: 2\ninclude:\n  - ref: nodl://test_ament_nodl/no_such_node\n')
     with pytest.raises(ResolutionError, match='nodl://test_ament_nodl/no_such_node'):
-        load_nodl('nodl_version: 2\ninclude:\n  - ref: nodl://test_ament_nodl/no_such_node\n')
+        load_nodl(source)
 
 
-def test_no_resolve_leaves_the_include_untouched():
-    doc = load_nodl(
-        'nodl_version: 2\ninclude:\n  - ref: nodl://test_ament_nodl/no_such_node\n',
-        resolve=False,
-    )
+def test_no_resolve_leaves_the_include_untouched(tmp_path):
+    source = tmp_path / 'test.nodl.yaml'
+    source.write_text('nodl_version: 2\ninclude:\n  - ref: nodl://test_ament_nodl/no_such_node\n')
+    doc = load_nodl(source, resolve=False)
     assert doc.include
     assert doc.include[0].ref == 'nodl://test_ament_nodl/no_such_node'
 


### PR DESCRIPTION
Simplifies provenance for local reference resolution. There isn't a concrete use case for having a nodl to load and resolve that isn't associated with a file either locally or in the ament index.