### PR TITLE
feat: Add sphinx directive for invoking nodl_docgen

### DIFF
--- a/.github/workflows/rosdoc2.yml
+++ b/.github/workflows/rosdoc2.yml
@@ -44,7 +44,9 @@ jobs:
           # it is not in the ros-base image. Harmless for the Python/CMake-macro packages, which never invoke it.
           apt-get install -y python3-pip python3-colcon-common-extensions doxygen
           rosdep update
-          rosdep install --from-paths src --ignore-src -y
+          # Skip the debian Sphinx (an exec_depend of nodl_docgen): pip cannot upgrade over it
+          # (no RECORD file), and the pip install below provides a newer Sphinx that satisfies it anyway.
+          rosdep install --from-paths src --ignore-src -y --skip-keys python3-sphinx
           # rosdoc2 imports each package to autodoc it, so it must share the workspace Python.
           # PEP 668 override comes from PIP_BREAK_SYSTEM_PACKAGES in the job env.
           pip install rosdoc2

--- a/nodl_docgen/nodl_docgen/__init__.py
+++ b/nodl_docgen/nodl_docgen/__init__.py
@@ -2,5 +2,31 @@
 # SPDX-License-Identifier: Apache-2.0
 """Sphinx rendering of NoDL documents.
 
+Adding ``'nodl_docgen'`` to a project's ``extensions`` registers the ``nodl-node`` directive.
+
 The summary core is deliberately not re-exported here, ``.summarize`` stays importable without Sphinx installed.
 """
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+
+def setup(app: 'Sphinx') -> dict[str, Any]:
+    """Register the extension's directives with ``app``.
+
+    Rendering reads the NoDL file and writes only its own nodes, sharing nothing between documents,
+    so reading and writing are both parallel safe.
+    """
+    import importlib.metadata
+
+    from nodl_docgen.directives import NodlNodeDirective
+
+    app.add_directive('nodl-node', NodlNodeDirective)
+
+    return {
+        'version': importlib.metadata.version('nodl_docgen'),
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/nodl_docgen/nodl_docgen/directives.py
+++ b/nodl_docgen/nodl_docgen/directives.py
@@ -1,0 +1,318 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""The ``nodl-node`` directive: a NoDL document rendered into a page as docutils nodes.
+
+The rendering is a function from a :class:`~nodl_docgen.summarize.NodeSummary` to a titled section,
+so it can be exercised with a summary and a docutils import, and nothing else.
+The directive around it only finds the file, loads it, and hands the summary over.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Generic, Sequence, TypeVar
+
+from docutils import nodes
+from docutils.parsers.rst import directives
+from sphinx.util.docutils import SphinxDirective
+
+from nodl_docgen.summarize import ActionRow, EndpointRow, NodeSummary, ParameterRow, summarize_tree
+from nodl_schema import load_nodl_with_doc_tree
+from nodl_schema.composition import resolve, resolver_for
+from nodl_schema.loader import DocumentTree, IncludedDocument
+
+# --------------------------------
+# Cells
+# --------------------------------
+
+
+def code_cell(text: str) -> list[nodes.Node]:
+    """A cell holding one code span, for a name, a type, or a value.
+
+    Empty text yields an empty cell rather than an empty code span,
+    so a column that nothing fills in can be recognized and dropped.
+    """
+    return [nodes.literal(text, text)] if text else []
+
+
+def parameter_description_cell(row: ParameterRow) -> list[nodes.Node]:
+    """A parameter's prose, its validator constraints as a list, and any prose constraints after them.
+
+    The constraints live with the description because they are what the description would otherwise have to say.
+    """
+    return [
+        *paragraphs(row.description),
+        *([bullet_list(row.constraints)] if row.constraints else []),
+        *paragraphs(row.additional_constraints),
+    ]
+
+
+def paragraphs(text: str) -> list[nodes.paragraph]:
+    """One paragraph per blank-line-separated block of ``text``, and nothing at all for empty text."""
+    return [nodes.paragraph(block, block) for block in re.split(r'\n\s*\n', text.strip()) if block]
+
+
+def prose_item(text: str) -> nodes.paragraph:
+    """One line of prose as a list item's body."""
+    return nodes.paragraph(text, text)
+
+
+def code_item(text: str) -> nodes.paragraph:
+    """One code span as a list item's body, for a name that is a reference rather than prose."""
+    paragraph = nodes.paragraph()
+    paragraph += code_cell(text)
+    return paragraph
+
+
+def bullet_list(items: Sequence[str], item: Callable[[str], nodes.Node] = prose_item) -> nodes.bullet_list:
+    """A bullet list of one-line items, each drawn by ``item``."""
+    listing = nodes.bullet_list()
+    for text in items:
+        entry = nodes.list_item()
+        entry += item(text)
+        listing += entry
+    return listing
+
+
+# --------------------------------
+# Tables
+# --------------------------------
+
+RowT = TypeVar('RowT')
+
+
+@dataclass(frozen=True)
+class Column(Generic[RowT]):
+    """One table column: its heading, and how a row fills its cell.
+
+    A column that no row fills in is dropped, unless it is ``always`` present.
+    That keeps a QoS column off a table of services that declare none,
+    without making the column set depend on which category is being drawn.
+    """
+
+    header: str
+    cell: Callable[[RowT], Sequence[nodes.Node]]
+    always: bool = False
+
+
+def build_table(columns: Sequence[Column[RowT]], rows: Sequence[RowT]) -> nodes.table:
+    """A table of ``rows``, one column per entry in ``columns`` that has something to show."""
+    cells = [[column.cell(row) for column in columns] for row in rows]
+    shown = [index for index, column in enumerate(columns) if column.always or any(row[index] for row in cells)]
+
+    group = nodes.tgroup(cols=len(shown))
+    for _ in shown:
+        group += nodes.colspec(colwidth=1)
+    group += _table_head([columns[index].header for index in shown])
+    group += _table_body([[row[index] for index in shown] for row in cells])
+
+    table = nodes.table()
+    table += group
+    return table
+
+
+def _table_head(headers: Sequence[str]) -> nodes.thead:
+    head = nodes.thead()
+    head += _table_row([[nodes.paragraph(header, header)] for header in headers])
+    return head
+
+
+def _table_body(rows: Sequence[Sequence[Sequence[nodes.Node]]]) -> nodes.tbody:
+    body = nodes.tbody()
+    for cells in rows:
+        body += _table_row(cells)
+    return body
+
+
+def _table_row(cells: Sequence[Sequence[nodes.Node]]) -> nodes.row:
+    row = nodes.row()
+    for content in cells:
+        entry = nodes.entry()
+        entry += content
+        row += entry
+    return row
+
+
+PARAMETER_COLUMNS: tuple[Column[ParameterRow], ...] = (
+    Column('Name', lambda row: code_cell(row.name), always=True),
+    Column('Type', lambda row: code_cell(row.type), always=True),
+    Column('Default', lambda row: code_cell(row.default)),
+    Column('Read-only', lambda row: paragraphs(row.read_only)),
+    Column('Description', parameter_description_cell),
+)
+
+ENDPOINT_COLUMNS: tuple[Column[EndpointRow], ...] = (
+    Column('Name', lambda row: code_cell(row.name), always=True),
+    Column('Type', lambda row: code_cell(row.type), always=True),
+    Column('QoS', lambda row: paragraphs(row.qos)),
+    Column('Description', lambda row: paragraphs(row.description)),
+)
+
+ACTION_COLUMNS: tuple[Column[ActionRow], ...] = (
+    Column('Name', lambda row: code_cell(row.name), always=True),
+    Column('Type', lambda row: code_cell(row.type), always=True),
+    Column('Description', lambda row: paragraphs(row.description)),
+)
+
+
+# --------------------------------
+# Sections
+# --------------------------------
+
+
+@dataclass(frozen=True)
+class Category(Generic[RowT]):
+    """One interface category of a summary: its heading, how to read its rows, and how to tabulate them."""
+
+    title: str
+    rows: Callable[[NodeSummary], Sequence[RowT]]
+    columns: tuple[Column[RowT], ...]
+
+
+# Order is the order a reader meets the node: what it is configured with, then what it talks to.
+CATEGORIES: tuple[Category[Any], ...] = (
+    Category('Parameters', lambda summary: summary.parameters, PARAMETER_COLUMNS),
+    Category('Publishers', lambda summary: summary.publishers, ENDPOINT_COLUMNS),
+    Category('Subscriptions', lambda summary: summary.subscriptions, ENDPOINT_COLUMNS),
+    Category('Service Servers', lambda summary: summary.service_servers, ENDPOINT_COLUMNS),
+    Category('Service Clients', lambda summary: summary.service_clients, ENDPOINT_COLUMNS),
+    Category('Action Servers', lambda summary: summary.action_servers, ACTION_COLUMNS),
+    Category('Action Clients', lambda summary: summary.action_clients, ACTION_COLUMNS),
+)
+
+
+def build_section(title: str, body: Sequence[nodes.Node]) -> nodes.section:
+    """A titled section holding ``body``.
+
+    The section carries a name but no id.
+    Ids belong to whoever owns the document, which assigns unique ones through ``note_implicit_target``,
+    so two nodes documented on one page cannot collide.
+    """
+    section = nodes.section(names=[nodes.fully_normalize_name(title)])
+    section += nodes.title(title, title)
+    section += list(body)
+    return section
+
+
+def build_includes_note(refs: Sequence[str]) -> nodes.note:
+    """A note naming the documents this interface is composed from."""
+    intro = 'This interface includes:'
+    note = nodes.note()
+    note += nodes.paragraph(intro, intro)
+    note += bullet_list(refs, code_item)
+    return note
+
+
+def build_category_section(category: Category[RowT], rows: Sequence[RowT]) -> nodes.section:
+    """One category as a titled section holding its table."""
+    return build_section(category.title, [build_table(category.columns, rows)])
+
+
+def build_node_section(summary: NodeSummary, title: str) -> nodes.section:
+    """A whole node interface as one titled section.
+
+    The body is the description, a note on what the document includes, and a subsection per populated category.
+    An empty summary is a bare titled section, which is the truthful rendering of a document that declares nothing.
+    """
+    return build_section(
+        title,
+        [
+            *paragraphs(summary.description),
+            *([build_includes_note(summary.includes)] if summary.includes else []),
+            *(build_category_section(category, rows) for category in CATEGORIES if (rows := category.rows(summary))),
+        ],
+    )
+
+
+# --------------------------------
+# Locating the document
+# --------------------------------
+
+# Suffixes a NoDL file is written with, stripped from a filename to leave the node's name.
+DOCUMENT_SUFFIXES = ('.yaml', '.yml', '.json')
+
+
+def default_title_for_path(path: Path) -> str:
+    """The heading to use for a file the author did not title: its name without NoDL suffixes."""
+    name = path.name
+    for suffix in DOCUMENT_SUFFIXES:
+        name = name.removesuffix(suffix)
+    return name.removesuffix('.nodl')
+
+
+def default_title_for_ref(ref: str) -> str:
+    """The heading to use for a reference the author did not title: the reference without its scheme."""
+    _, _, remainder = ref.partition('://')
+    return remainder or ref
+
+
+def include_paths(tree: DocumentTree, origin: Path) -> list[Path]:
+    """Every file the tree includes, transitively, in traversal order.
+
+    A ``DocumentTree`` keeps the refs it resolved but not the paths it resolved them to,
+    so each ref is resolved again against the document that made it.
+    Resolution is deterministic, and the tree was built by the same walk, so this recovers the same files.
+    """
+
+    def walk(included: IncludedDocument, parent: Path) -> list[Path]:
+        path = resolve(included.ref, parent)
+        return [path, *(descendant for child in included.resolved_includes for descendant in walk(child, path))]
+
+    return [path for child in tree.resolved_includes for path in walk(child, origin)]
+
+
+# --------------------------------
+# The directive
+# --------------------------------
+
+
+class NodlNodeDirective(SphinxDirective):
+    """Render a NoDL document's effective interface.
+
+    The argument is either a path to the document, resolved the way ``literalinclude`` resolves one
+    (relative to the containing page, or to the source root when it starts with ``/``),
+    or a reference such as ``nodl://<package>/<name>`` resolved through the registered NoDL resolvers,
+    which is how a page documents a dependency it does not ship.
+
+    The document is loaded, resolved, and merged, so the rendering is what the node actually exposes.
+    """
+
+    has_content = False
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+    option_spec = {'title': directives.unchanged_required}
+
+    def run(self) -> list[nodes.Node]:
+        reference = self.arguments[0]
+        try:
+            path, default_title = self._locate(reference)
+            # The merged document is discarded: the summary merges the tree itself.
+            # Loading through the documented entry point keeps validation identical to the CLI's.
+            _, tree = load_nodl_with_doc_tree(path)
+            dependencies = [path, *include_paths(tree, path)]
+        except Exception as error:
+            # Any failure to produce the whole interface fails the build here,
+            # rather than leaving a page that silently documents less than the node does.
+            raise self.error(f'nodl-node {reference}: {error}') from error
+
+        for dependency in dependencies:
+            self.env.note_dependency(dependency)
+
+        section = build_node_section(summarize_tree(tree), self.options.get('title', default_title))
+        self.set_source_info(section)
+        # Every section produced here, the node section itself included, takes its id from the document,
+        # which keeps ids unique across every node documented on this page.
+        for produced in section.findall(nodes.section):
+            self.state.document.note_implicit_target(produced)
+        return [section]
+
+    def _locate(self, reference: str) -> tuple[Path, str]:
+        """The file ``reference`` names, and the heading to use when the author gave no title."""
+        origin = Path(self.env.doc2path(self.env.docname))
+        if resolver_for(reference) is not None:
+            return resolve(reference, origin), default_title_for_ref(reference)
+        _, absolute = self.env.relfn2path(reference)
+        return Path(absolute), default_title_for_path(Path(absolute))

--- a/nodl_docgen/package.xml
+++ b/nodl_docgen/package.xml
@@ -10,6 +10,7 @@
 
   <exec_depend>nodl_schema</exec_depend>
   <exec_depend>python3-jinja2</exec_depend>
+  <exec_depend>python3-sphinx</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
 
   <test_depend>python3-pytest</test_depend>

--- a/nodl_docgen/test/test_directives.py
+++ b/nodl_docgen/test/test_directives.py
@@ -1,0 +1,461 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ``nodl-node`` directive.
+
+Two layers, matching the module under test:
+the node builders are exercised directly with a ``NodeSummary``, needing nothing but docutils,
+and the directive itself is exercised through a real Sphinx build of a throwaway project.
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+from docutils import nodes
+
+from nodl_docgen.directives import (
+    ACTION_COLUMNS,
+    ENDPOINT_COLUMNS,
+    PARAMETER_COLUMNS,
+    build_node_section,
+    build_table,
+    default_title_for_path,
+    default_title_for_ref,
+    include_paths,
+)
+from nodl_docgen.summarize import ActionRow, EndpointRow, NodeSummary, ParameterRow
+from nodl_schema import load_nodl_with_doc_tree
+
+pytest_plugins = ['sphinx.testing.fixtures']
+
+
+# --------------------------------
+# Reading the produced doctree
+# --------------------------------
+
+
+def _titles(node: nodes.Element) -> list[str]:
+    """Every section title in document order, the top section's included."""
+    return [section[0].astext() for section in node.findall(nodes.section)]
+
+
+def _tables(node: nodes.Element) -> list[nodes.table]:
+    return list(node.findall(nodes.table))
+
+
+def _headers(table: nodes.table) -> list[str]:
+    return [entry.astext() for head in table.findall(nodes.thead) for entry in head.findall(nodes.entry)]
+
+
+def _body_rows(table: nodes.table) -> list[list[str]]:
+    return [
+        [entry.astext() for entry in row.findall(nodes.entry)]
+        for body in table.findall(nodes.tbody)
+        for row in body.findall(nodes.row)
+    ]
+
+
+def _section_named(node: nodes.Element, title: str) -> nodes.section:
+    matches = [section for section in node.findall(nodes.section) if section[0].astext() == title]
+    assert matches, f'no section titled {title!r} in {_titles(node)}'
+    return matches[0]
+
+
+# --------------------------------
+# Tables
+# --------------------------------
+
+
+def test_table_shape_matches_its_columns_and_rows():
+    rows = (
+        EndpointRow(name='/scan', type='sensor_msgs/msg/LaserScan', qos='KEEP_LAST(5)', description='Raw scans.'),
+        EndpointRow(name='/map', type='nav_msgs/msg/OccupancyGrid'),
+    )
+    table = build_table(ENDPOINT_COLUMNS, rows)
+
+    assert _headers(table) == ['Name', 'Type', 'QoS', 'Description']
+    assert _body_rows(table) == [
+        ['/scan', 'sensor_msgs/msg/LaserScan', 'KEEP_LAST(5)', 'Raw scans.'],
+        ['/map', 'nav_msgs/msg/OccupancyGrid', '', ''],
+    ]
+    assert next(table.findall(nodes.tgroup))['cols'] == 4
+
+
+def test_a_column_no_row_fills_in_is_dropped():
+    # Services rarely state a QoS profile, and a column of empty cells is noise rather than information.
+    rows = (EndpointRow(name='~/reset', type='std_srvs/srv/Trigger'),)
+    table = build_table(ENDPOINT_COLUMNS, rows)
+
+    assert _headers(table) == ['Name', 'Type']
+    assert _body_rows(table) == [['~/reset', 'std_srvs/srv/Trigger']]
+
+
+def test_name_and_type_columns_stay_even_when_empty():
+    table = build_table(ACTION_COLUMNS, (ActionRow(name='', type=''),))
+    assert _headers(table) == ['Name', 'Type']
+
+
+def test_a_parameter_row_reads_its_constraints_in_the_description_cell():
+    rows = (
+        ParameterRow(
+            name='rate',
+            type='double',
+            default='1.0',
+            description='How often to publish.',
+            read_only='yes',
+            constraints=('must be greater than 0.0', 'must be less than 100.0'),
+            additional_constraints='must divide the control period',
+        ),
+    )
+    table = build_table(PARAMETER_COLUMNS, rows)
+
+    assert _headers(table) == ['Name', 'Type', 'Default', 'Read-only', 'Description']
+    assert _body_rows(table) == [
+        [
+            'rate',
+            'double',
+            '1.0',
+            'yes',
+            'How often to publish.\n\nmust be greater than 0.0\n\nmust be less than 100.0'
+            '\n\nmust divide the control period',
+        ]
+    ]
+    # The constraint sentences are a list rather than run-on prose.
+    assert len(list(table.findall(nodes.bullet_list))) == 1
+
+
+def test_types_and_values_are_rendered_as_code():
+    table = build_table(ACTION_COLUMNS, (ActionRow(name='/dock', type='nav2_msgs/action/Dock', description='Dock.'),))
+    literals = [literal.astext() for literal in table.findall(nodes.literal)]
+    assert literals == ['/dock', 'nav2_msgs/action/Dock']
+
+
+# --------------------------------
+# Sections
+# --------------------------------
+
+
+def test_an_empty_summary_is_a_bare_titled_section():
+    section = build_node_section(NodeSummary(), 'my_node')
+
+    assert _titles(section) == ['my_node']
+    assert _tables(section) == []
+
+
+def test_categories_appear_in_a_fixed_order_and_only_when_populated():
+    summary = NodeSummary(
+        parameters=(ParameterRow(name='rate', type='double'),),
+        subscriptions=(EndpointRow(name='/cmd_vel', type='geometry_msgs/msg/Twist'),),
+        action_clients=(ActionRow(name='/dock', type='nav2_msgs/action/Dock'),),
+    )
+
+    assert _titles(build_node_section(summary, 'my_node')) == [
+        'my_node',
+        'Parameters',
+        'Subscriptions',
+        'Action Clients',
+    ]
+
+
+def test_every_category_gets_its_own_subsection():
+    endpoint = (EndpointRow(name='/topic', type='std_msgs/msg/String'),)
+    action = (ActionRow(name='/action', type='nav2_msgs/action/Dock'),)
+    summary = NodeSummary(
+        parameters=(ParameterRow(name='rate', type='double'),),
+        publishers=endpoint,
+        subscriptions=endpoint,
+        service_servers=endpoint,
+        service_clients=endpoint,
+        action_servers=action,
+        action_clients=action,
+    )
+
+    assert _titles(build_node_section(summary, 'my_node')) == [
+        'my_node',
+        'Parameters',
+        'Publishers',
+        'Subscriptions',
+        'Service Servers',
+        'Service Clients',
+        'Action Servers',
+        'Action Clients',
+    ]
+
+
+def test_the_description_becomes_one_paragraph_per_block():
+    summary = NodeSummary(description='First line.\n\nSecond block.')
+    section = build_node_section(summary, 'my_node')
+
+    assert [paragraph.astext() for paragraph in section.findall(nodes.paragraph)] == ['First line.', 'Second block.']
+
+
+def test_includes_are_noted_only_when_present():
+    assert list(build_node_section(NodeSummary(), 'my_node').findall(nodes.note)) == []
+
+    section = build_node_section(NodeSummary(includes=('nodl://sensor_common/imu',)), 'my_node')
+    notes = list(section.findall(nodes.note))
+
+    assert len(notes) == 1
+    assert 'nodl://sensor_common/imu' in notes[0].astext()
+
+
+def test_sections_carry_names_but_leave_ids_to_the_document():
+    # Ids are assigned by whoever owns the document, so two nodes on one page cannot collide.
+    section = build_node_section(NodeSummary(parameters=(ParameterRow(name='rate', type='double'),)), 'My Node')
+
+    assert section['names'] == ['my node']
+    assert section['ids'] == []
+    assert _section_named(section, 'Parameters')['names'] == ['parameters']
+
+
+# --------------------------------
+# Locating the document
+# --------------------------------
+
+
+@pytest.mark.parametrize(
+    ('name', 'expected'),
+    [
+        ('my_node.nodl.yaml', 'my_node'),
+        ('my_node.nodl.yml', 'my_node'),
+        ('my_node.nodl.json', 'my_node'),
+        ('my_node.yaml', 'my_node'),
+        ('my_node', 'my_node'),
+    ],
+)
+def test_the_default_title_of_a_path_is_its_stem(name: str, expected: str):
+    assert default_title_for_path(Path('/doc/nodl') / name) == expected
+
+
+def test_the_default_title_of_a_ref_drops_only_the_scheme():
+    assert default_title_for_ref('nodl://sensor_common/imu') == 'sensor_common/imu'
+    assert default_title_for_ref('local://shared.nodl.yaml') == 'shared.nodl.yaml'
+
+
+# --------------------------------
+# Build dependencies
+# --------------------------------
+
+LEAF = 'nodl_version: 2\n'
+MIDDLE = 'nodl_version: 2\ninclude:\n  - ref: local://leaf.nodl.yaml\n'
+ROOT = 'nodl_version: 2\ndescription: Root.\ninclude:\n  - ref: local://middle.nodl.yaml\n'
+
+
+def test_include_paths_recovers_every_file_in_the_tree(tmp_path: Path):
+    (tmp_path / 'leaf.nodl.yaml').write_text(LEAF)
+    (tmp_path / 'middle.nodl.yaml').write_text(MIDDLE)
+    root = tmp_path / 'root.nodl.yaml'
+    root.write_text(ROOT)
+
+    _, tree = load_nodl_with_doc_tree(root)
+
+    assert include_paths(tree, root) == [tmp_path / 'middle.nodl.yaml', tmp_path / 'leaf.nodl.yaml']
+
+
+def test_a_document_with_no_includes_has_no_extra_dependencies(tmp_path: Path):
+    root = tmp_path / 'root.nodl.yaml'
+    root.write_text(LEAF)
+
+    _, tree = load_nodl_with_doc_tree(root)
+
+    assert include_paths(tree, root) == []
+
+
+# --------------------------------
+# The directive, in a real Sphinx build
+# --------------------------------
+
+DOCUMENT = """
+nodl_version: 2
+description: Watches the world.
+parameters:
+  rate:
+    type: double
+    default_value: 2.0
+    description: Publish rate.
+    validation:
+      gt: [0.0]
+publishers:
+  - name: /scan
+    type: sensor_msgs/msg/LaserScan
+    qos:
+      history: KEEP_LAST
+      depth: 5
+      reliability: BEST_EFFORT
+action_servers:
+  - name: /navigate
+    type: nav2_msgs/action/NavigateToPose
+"""
+
+CONF = """
+extensions = {extensions}
+exclude_patterns = ['_build']
+"""
+
+
+@pytest.fixture(autouse=True)
+def _sphinx_warnings_propagate():
+    """Let Sphinx see its own warnings, which the ROS environment otherwise hides.
+
+    ``launch_testing`` registers itself as a pytest plugin, and importing it installs a logger class
+    that turns propagation off for every logger created afterwards, Sphinx's included.
+    Sphinx counts warnings with a handler on its root ``sphinx`` logger,
+    so without propagation a page that failed to render would look like a clean build.
+    """
+    previous = logging.getLoggerClass()
+    logging.setLoggerClass(logging.Logger)
+    for name, logger in list(logging.Logger.manager.loggerDict.items()):
+        if name.startswith('sphinx.') and isinstance(logger, logging.Logger):
+            logger.propagate = True
+    yield
+    logging.setLoggerClass(previous)
+
+
+def _project(
+    root: Path,
+    *,
+    body: str,
+    suffix: str = '.rst',
+    document: str = DOCUMENT,
+    extensions: tuple[str, ...] = ('nodl_docgen',),
+) -> Path:
+    """Write a one-page Sphinx project rooted at ``root`` and return its source directory."""
+    source = root / 'source'
+    (source / 'nodl').mkdir(parents=True)
+    (source / 'nodl' / 'my_node.nodl.yaml').write_text(document)
+    (source / 'conf.py').write_text(CONF.format(extensions=list(extensions)))
+    (source / f'index{suffix}').write_text(body)
+    return source
+
+
+def _build(make_app, source: Path, root: Path):
+    """Build ``source`` with warnings as errors, the way a documentation CI job does."""
+    app = make_app('html', srcdir=source, builddir=root / 'build', warningiserror=True, freshenv=True)
+    app.build()
+    return app
+
+
+def _build_clean(make_app, source: Path, root: Path):
+    """Build ``source`` and insist the build reported nothing, since a warning here is a build failure."""
+    app = _build(make_app, source, root)
+    assert app.statuscode == 0, app.warning.getvalue()
+    return app
+
+
+RST_PAGE = """
+Index
+=====
+
+.. nodl-node:: nodl/my_node.nodl.yaml
+"""
+
+
+def test_a_directive_renders_the_document_it_names(make_app, tmp_path: Path):
+    app = _build_clean(make_app, _project(tmp_path, body=RST_PAGE), tmp_path)
+    doctree = app.env.get_doctree('index')
+
+    assert _titles(doctree) == ['Index', 'my_node', 'Parameters', 'Publishers', 'Action Servers']
+    assert 'Watches the world.' in doctree.astext()
+    assert _body_rows(_tables(_section_named(doctree, 'Parameters'))[0]) == [
+        ['rate', 'double', '2.0', 'Publish rate.\n\nmust be greater than 0.0']
+    ]
+    assert _body_rows(_tables(_section_named(doctree, 'Publishers'))[0]) == [
+        ['/scan', 'sensor_msgs/msg/LaserScan', 'KEEP_LAST(5), BEST_EFFORT']
+    ]
+
+
+def test_a_leading_slash_means_the_source_root(make_app, tmp_path: Path):
+    source = _project(tmp_path, body=RST_PAGE)
+    (source / 'guide').mkdir()
+    (source / 'guide' / 'page.rst').write_text('Page\n====\n\n.. nodl-node:: /nodl/my_node.nodl.yaml\n')
+    (source / 'index.rst').write_text('Index\n=====\n\n.. toctree::\n\n   guide/page\n')
+
+    app = _build_clean(make_app, source, tmp_path)
+
+    assert _titles(app.env.get_doctree('guide/page')) == [
+        'Page',
+        'my_node',
+        'Parameters',
+        'Publishers',
+        'Action Servers',
+    ]
+
+
+def test_the_title_option_overrides_the_default_heading(make_app, tmp_path: Path):
+    page = 'Index\n=====\n\n.. nodl-node:: nodl/my_node.nodl.yaml\n   :title: Observer node\n'
+    app = _build_clean(make_app, _project(tmp_path, body=page), tmp_path)
+
+    assert _titles(app.env.get_doctree('index'))[1] == 'Observer node'
+
+
+def test_the_document_and_its_includes_are_build_dependencies(make_app, tmp_path: Path):
+    source = _project(tmp_path, body=RST_PAGE, document=ROOT)
+    (source / 'nodl' / 'middle.nodl.yaml').write_text(MIDDLE)
+    (source / 'nodl' / 'leaf.nodl.yaml').write_text(LEAF)
+
+    app = _build_clean(make_app, source, tmp_path)
+
+    assert app.env.dependencies['index'] >= {
+        source / 'nodl' / 'my_node.nodl.yaml',
+        source / 'nodl' / 'middle.nodl.yaml',
+        source / 'nodl' / 'leaf.nodl.yaml',
+    }
+
+
+def test_two_nodes_on_one_page_do_not_collide(make_app, tmp_path: Path):
+    page = (
+        'Index\n=====\n\n'
+        '.. nodl-node:: nodl/my_node.nodl.yaml\n\n'
+        '.. nodl-node:: nodl/my_node.nodl.yaml\n   :title: Second\n'
+    )
+    app = _build_clean(make_app, _project(tmp_path, body=page), tmp_path)
+    doctree = app.env.get_doctree('index')
+
+    identifiers = [section['ids'] for section in doctree.findall(nodes.section)]
+    assert all(len(ids) == 1 for ids in identifiers), identifiers
+    assert len({ids[0] for ids in identifiers}) == len(identifiers)
+
+
+@pytest.mark.parametrize(
+    ('body', 'document'),
+    [
+        ('Index\n=====\n\n.. nodl-node:: nodl/missing.nodl.yaml\n', DOCUMENT),
+        ('Index\n=====\n\n.. nodl-node:: nodl/my_node.nodl.yaml\n', 'nodl_version: 2\nparameters: 7\n'),
+        ('Index\n=====\n\n.. nodl-node:: nodl/my_node.nodl.yaml\n', 'nodl_version: 2\ninclude:\n  - ref: bad://x\n'),
+        ('Index\n=====\n\n.. nodl-node:: nodl://absent_package/absent\n', DOCUMENT),
+    ],
+    ids=['missing-file', 'invalid-document', 'unresolvable-include', 'unknown-index-entry'],
+)
+def test_a_document_that_cannot_be_rendered_fails_the_build(make_app, tmp_path: Path, body: str, document: str):
+    app = _build(make_app, _project(tmp_path, body=body, document=document), tmp_path)
+    reported = app.warning.getvalue()
+
+    # Under warnings as errors, this warning is what makes the build report failure.
+    assert app.statuscode != 0, reported
+    assert 'nodl-node' in reported
+    # The report points at the directive, which is on the fourth line of every page above.
+    assert 'index.rst:4' in reported
+
+
+MYST_PAGE = """
+# Index
+
+```{nodl-node} nodl/my_node.nodl.yaml
+:title: From markdown
+```
+"""
+
+
+def test_the_directive_works_from_a_markdown_source(make_app, tmp_path: Path):
+    pytest.importorskip('myst_parser', reason='MyST is only needed to prove markdown parity')
+
+    source = _project(tmp_path, body=MYST_PAGE, suffix='.md', extensions=('myst_parser', 'nodl_docgen'))
+    app = _build_clean(make_app, source, tmp_path)
+
+    assert _titles(app.env.get_doctree('index')) == [
+        'Index',
+        'From markdown',
+        'Parameters',
+        'Publishers',
+        'Action Servers',
+    ]


### PR DESCRIPTION
Closes https://github.com/ros-tooling/nodl/issues/129

Implements phase 2 of the [docgen design](https://github.com/ros-tooling/nodl/blob/main/design/docgen.md)

Adds a Sphinx directive to invoke nodl_docgen as part of a package's documentation creation.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>