### PR TITLE
doc: Document nodl_docgen package and usage

### DIFF
--- a/.github/workflows/rosdoc2.yml
+++ b/.github/workflows/rosdoc2.yml
@@ -27,7 +27,13 @@ jobs:
       matrix:
         # One job per documented package. The nodl metapackage is covered by the top-level site; test_ament_nodl
         # is a test fixture. A ROS-distro axis could be added here later to mirror the per-distro buildfarm.
-        package: [nodl_schema, nodl_observe, ros2nodl, ament_nodl, nodl_generator_cpp]
+        package:
+          - ament_nodl
+          - nodl_docgen
+          - nodl_generator_cpp
+          - nodl_observe
+          - nodl_schema
+          - ros2nodl
     container:
       # A ROS base image gives us ros2cli (ros2nodl imports it) and the ament build tooling already installed.
       image: ros:jazzy-ros-base

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,8 @@ sphinx:
 
 python:
   install:
+    - path: nodl_schema
+    - path: nodl_docgen
     - path: nodl/doc
       extra_requirements:
         - docs

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Find complete documentation at https://nodl.readthedocs.io/en/latest/
 - [ament_nodl/](./ament_nodl/): CMake macros to register NoDL documents with the ament index
 - [nodl/](./nodl/): Metapackage that pulls in the other packages as dependencies. Acts as an easy default for those who don't want a-la-carte.
   - [doc/](./nodl/doc/): Documentation source for the ReadTheDocs page
+- [nodl_docgen](./nodl_docgen/): Sphinx extension rendering a NoDL document into a documentation page at build time.
 - [nodl_schema/](./nodl_schema/): Package providing the NoDL schema, plus a Python package with validation tools and typed data model to work with it.
     [nodl.schema.yaml](./nodl_schema/nodl_schema/schemas/nodl.schema.yaml): The NoDL schema, key to this whole thing!
 - [nodl_observe/](./nodl_observe/): C++ (`ament_cmake`) package that observes a running ROS 2 node and produces its runtime interface as a `rosgraph_msgs/Node` message — a reusable `observe_node(...)` library plus an `observe` executable. Stage one of Observe → Describe.

--- a/nodl/doc/conf.py
+++ b/nodl/doc/conf.py
@@ -23,6 +23,8 @@ extensions = [
     'sphinx_immaterial.apidoc.json.domain',
     'sphinx.ext.extlinks',
     'sphinx.ext.intersphinx',
+    # Dogfood our own extension by rendering an example NoDL
+    'nodl_docgen',
 ]
 
 # -- Cross-references between packages and the top-level site ----------------

--- a/nodl/doc/documenting.md
+++ b/nodl/doc/documenting.md
@@ -1,0 +1,101 @@
+# Documenting your node's interface
+
+A node's NoDL document already states its parameters, topics, services, and actions.
+The `nodl_docgen` extension renders that document into your package's documentation while the docs are being built,
+so the interface page is generated from the same file the rest of the toolchain reads.
+
+Nothing is pasted, so nothing goes stale.
+If the document changes, the page changes with it.
+If the document stops loading, the build reports an error at the directive,
+rather than publishing a page that no longer matches the node.
+
+This page is the authoring walkthrough.
+For the directive's full option surface, see the
+{doc}`nodl_docgen package page <_generated/packages/nodl_docgen/overview>`.
+
+## 1. Depend on the extension
+
+`nodl_docgen` is only needed when documentation is built, which is what `doc_depend` means:
+
+```xml
+<doc_depend>nodl_docgen</doc_depend>
+```
+
+## 2. Enable the extension
+
+Add it to `extensions` in your package's `doc/conf.py`:
+
+```python
+extensions = [
+    'myst_parser',
+    'nodl_docgen',
+]
+```
+
+## 3. Render the document
+
+Point the `nodl-node` directive at the NoDL file:
+
+````markdown
+```{nodl-node} /../nodl/my_node.nodl.yaml
+:title: my_node
+```
+````
+
+The same directive in a reStructuredText page:
+
+```rst
+.. nodl-node:: /../nodl/my_node.nodl.yaml
+   :title: my_node
+```
+
+The argument is a path, resolved like `literalinclude` resolves one:
+relative to the page, or relative to the Sphinx source root when it starts with `/`.
+NoDL files usually live outside `doc/`, hence the `/../nodl/...` above,
+which climbs out of a `doc/` directory at the package root.
+
+Use a path, not a `nodl://` reference, for your own package's documents.
+`rosdoc2` builds a package's docs from source with its dependencies installed but not the package itself,
+so a package's own NoDL is not yet in the ament index while its docs are being built.
+A `nodl://<package>/<name>` reference is for documenting a node that comes from a dependency.
+
+`:title:` is the heading, and is worth setting:
+a NoDL document carries no name of its own, because a node's identity comes from the package that registers it.
+
+## A rendered example
+
+This site dogfoods the directive.
+The document below is checked in at {repo}`nodl/doc/examples/battery_monitor.nodl.yaml`:
+
+```{literalinclude} examples/battery_monitor.nodl.yaml
+:language: yaml
+```
+
+Rendered by pointing the directive at that file, with `:title: battery_monitor`:
+
+```{nodl-node} examples/battery_monitor.nodl.yaml
+:title: battery_monitor
+```
+
+## Reading the output
+
+A few things in that rendering are worth pointing out, because they are decisions rather than a straight field dump:
+
+- Each interface category that has entries becomes a subsection with a table,
+  and one that has none is left out entirely.
+- A column no row fills in is dropped.
+  The service server above declares no QoS profile, so its table has no QoS column, while the topic tables do.
+- A QoS profile is summarized in one line, naming only what differs from the system default.
+- A parameter's validators are read out as constraint sentences,
+  and its default is shown as the YAML literal you would write in a parameter file.
+  An empty default means the parameter has none and has to be set at startup, like `cell_count` above.
+
+Descriptions are rendered as plain text.
+Write them as prose rather than as markup: they are read by every NoDL consumer, not only by Sphinx.
+
+## Next steps
+
+- {doc}`concepts` covers what a NoDL document declares.
+- {doc}`schema` is the field-by-field reference for writing one.
+- The {doc}`nodl_docgen page <_generated/packages/nodl_docgen/overview>` documents the directive's argument forms,
+  options, `include` merging, failure behavior, and the summary core underneath it.

--- a/nodl/doc/examples/battery_monitor.nodl.yaml
+++ b/nodl/doc/examples/battery_monitor.nodl.yaml
@@ -1,0 +1,54 @@
+---
+nodl_version: 2
+description: |
+  Watches a battery pack and reports its state of charge.
+
+  Publishes a diagnostic warning while the charge is below a configurable threshold,
+  and offers an action that runs a full calibration cycle.
+
+parameters:
+  publish_rate_hz:
+    type: double
+    default_value: 1.0
+    description: How often the pack state is published.
+    validation:
+      gt: [0.0]
+      lt_eq: [100.0]
+  low_charge_fraction:
+    type: double
+    default_value: 0.2
+    description: Charge fraction below which the monitor warns.
+    validation:
+      bounds: [0.0, 1.0]
+  cell_count:
+    type: int
+    read_only: true
+    description: Number of cells in the pack. Fixed by the hardware, and has no sensible default.
+    validation:
+      one_of: [[4, 6, 8]]
+
+publishers:
+  - name: ~/state
+    type: sensor_msgs/msg/BatteryState
+    qos: {history: KEEP_LAST, depth: 5, reliability: RELIABLE}
+    description: Current pack state, published at the configured rate.
+  - name: /diagnostics
+    type: diagnostic_msgs/msg/DiagnosticArray
+    qos: {history: KEEP_LAST, depth: 1, reliability: BEST_EFFORT}
+    description: A warning entry while the charge is low.
+
+subscriptions:
+  - name: /power/raw_cells
+    type: sensor_msgs/msg/BatteryState
+    qos: {history: KEEP_LAST, depth: 10, reliability: BEST_EFFORT}
+    description: Per-cell readings from the power board driver.
+
+service_servers:
+  - name: ~/reset_fuel_gauge
+    type: std_srvs/srv/Trigger
+    description: Clears the accumulated charge estimate.
+
+action_servers:
+  - name: ~/calibrate
+    type: example_robot_msgs/action/CalibrateBattery
+    description: Runs a full discharge and charge cycle to recalibrate the gauge.

--- a/nodl/doc/index.md
+++ b/nodl/doc/index.md
@@ -14,6 +14,7 @@ NoDL (Node Definition Language) is a schema and toolkit to describe a ROS 2 node
 Home <self>
 concepts
 schema
+documenting
 roadmap
 ```
 
@@ -26,6 +27,7 @@ roadmap
 - **`ros2nodl`** — `ros2 nodl <verb>` ros2cli extension providing NoDL operations.
   See the [Describe guide](_generated/packages/ros2nodl/describe.md).
 - **`ament_nodl`** — CMake macros for registering NoDL documents with the ament index.
+- **`nodl_docgen`** — Tools to generate documentation from NoDL documents.
 
 Each package's own documentation is staged into this site from its `doc/` tree at build time
 (see {repo}`nodl/doc/package_docs.py`); the same sources build standalone under `rosdoc2` for docs.ros.org.
@@ -39,6 +41,7 @@ nodl_observe <_generated/packages/nodl_observe/overview>
 ros2nodl <_generated/packages/ros2nodl/overview>
 ament_nodl <_generated/packages/ament_nodl/overview>
 nodl_generator_cpp <_generated/packages/nodl_generator_cpp/overview>
+nodl_docgen <_generated/packages/nodl_docgen/overview>
 ```
 
 ## Source

--- a/nodl/doc/package_docs.py
+++ b/nodl/doc/package_docs.py
@@ -19,7 +19,7 @@ PACKAGES_DST = _HERE / '_generated' / 'packages'
 
 # Packages that ship per-package docs, in the order they appear in the combined toctree.
 # The ``nodl`` metapackage is documented by this top-level site itself; ``test_ament_nodl`` is a test fixture.
-PACKAGES = ['nodl_schema', 'nodl_observe', 'ros2nodl', 'ament_nodl', 'nodl_generator_cpp']
+PACKAGES = ['nodl_schema', 'nodl_observe', 'ros2nodl', 'ament_nodl', 'nodl_generator_cpp', 'nodl_docgen']
 
 # Toctree entries, relative to the Sphinx source dir (== _HERE), mirrored by the "Packages" toctree in index.md.
 # Each package's landing page is overview.md, not index.md: rosdoc2 reserves index for its own generated wrapper,

--- a/nodl/doc/pyproject.toml
+++ b/nodl/doc/pyproject.toml
@@ -20,7 +20,21 @@ docs = [
     # Enables json_schema_validate so a malformed schema fails the build.
     "jsonschema>=4",
     "poethepoet>=0.27",
+    "nodl-docgen",
+    # Runtime dependencies of nodl_docgen/nodl_schema, which are in package.xml which this can't read.
+    "nodl-schema",
+    "pydantic>=2",
+    "pyyaml>=6",
+    "ruamel.yaml>=0.17",
+    "ament-index-python @ git+https://github.com/ament/ament_index@1.9.0#subdirectory=ament_index_python",
 ]
+
+# The two NoDL packages live in this repo, not on an index.
+# Install editable so a doc build renders the working tree.
+# This is a uv-only table, pip reads the plain requirements above.
+[tool.uv.sources]
+nodl-sphinx = { path = "../../nodl_sphinx", editable = true }
+nodl-schema = { path = "../../nodl_schema", editable = true }
 
 # This project exists only to pull in the docs dependencies, it ships no importable modules.
 # Disable setuptools' flat-layout discovery, which would otherwise fail on finding multiple top-level modules.

--- a/nodl/doc/pyproject.toml
+++ b/nodl/doc/pyproject.toml
@@ -33,7 +33,7 @@ docs = [
 # Install editable so a doc build renders the working tree.
 # This is a uv-only table, pip reads the plain requirements above.
 [tool.uv.sources]
-nodl-sphinx = { path = "../../nodl_sphinx", editable = true }
+nodl-docgen = { path = "../../nodl_docgen", editable = true }
 nodl-schema = { path = "../../nodl_schema", editable = true }
 
 # This project exists only to pull in the docs dependencies, it ships no importable modules.

--- a/nodl/doc/uv.lock
+++ b/nodl/doc/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -14,6 +14,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b", size = 13929, upload-time = "2024-07-26T18:15:02.05Z" },
+]
+
+[[package]]
+name = "ament-index-python"
+version = "1.9.0"
+source = { git = "https://github.com/ament/ament_index?subdirectory=ament_index_python&rev=1.9.0#186831ac95e05632936b1399f8eda34d9f2199f4" }
+dependencies = [
+    { name = "setuptools" },
 ]
 
 [[package]]
@@ -266,7 +274,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version < '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
@@ -282,7 +290,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version >= '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
@@ -404,12 +412,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
@@ -425,12 +433,12 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "jinja2", marker = "python_full_version >= '3.11'" },
-    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/dc/603751677fff302f34396e206b610f556a59d7fe58b9a2145f54e96b48e8/myst_parser-5.1.0.tar.gz", hash = "sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02", size = 101182, upload-time = "2026-05-13T09:38:19.361Z" }
@@ -439,16 +447,34 @@ wheels = [
 ]
 
 [[package]]
+name = "nodl-docgen"
+version = "0.0.0"
+source = { editable = "../../nodl_docgen" }
+
+[package.metadata]
+requires-dist = [
+    { name = "pyright", marker = "extra == 'test'" },
+    { name = "pytest", marker = "extra == 'test'" },
+]
+provides-extras = ["test"]
+
+[[package]]
 name = "nodl-docs"
 version = "0.0.0"
 source = { editable = "." }
 
 [package.optional-dependencies]
 docs = [
+    { name = "ament-index-python" },
     { name = "jsonschema" },
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "myst-parser", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "nodl-docgen" },
+    { name = "nodl-schema" },
     { name = "poethepoet" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "ruamel-yaml" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -457,13 +483,31 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ament-index-python", marker = "extra == 'docs'", git = "https://github.com/ament/ament_index?subdirectory=ament_index_python&rev=1.9.0" },
     { name = "jsonschema", marker = "extra == 'docs'", specifier = ">=4" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2" },
+    { name = "nodl-docgen", marker = "extra == 'docs'", editable = "../../nodl_docgen" },
+    { name = "nodl-schema", marker = "extra == 'docs'", editable = "../../nodl_schema" },
     { name = "poethepoet", marker = "extra == 'docs'", specifier = ">=0.27" },
+    { name = "pydantic", marker = "extra == 'docs'", specifier = ">=2" },
+    { name = "pyyaml", marker = "extra == 'docs'", specifier = ">=6" },
+    { name = "ruamel-yaml", marker = "extra == 'docs'", specifier = ">=0.17" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7" },
     { name = "sphinx-immaterial", marker = "extra == 'docs'", specifier = ">=0.12" },
 ]
 provides-extras = ["docs"]
+
+[[package]]
+name = "nodl-schema"
+version = "0.0.0"
+source = { editable = "../../nodl_schema" }
+
+[package.metadata]
+requires-dist = [
+    { name = "pyright", marker = "extra == 'test'" },
+    { name = "pytest", marker = "extra == 'test'" },
+]
+provides-extras = ["test"]
 
 [[package]]
 name = "packaging"
@@ -1020,6 +1064,24 @@ wheels = [
 ]
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "84.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
+]
+
+[[package]]
 name = "snowballstemmer"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1036,23 +1098,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -1067,23 +1129,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
-    { name = "babel", marker = "python_full_version == '3.11.*'" },
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "requests", marker = "python_full_version == '3.11.*'" },
-    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -1098,23 +1160,23 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [

--- a/nodl/package.xml
+++ b/nodl/package.xml
@@ -12,9 +12,11 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>ament_nodl</exec_depend>
+  <exec_depend>nodl_generator_cpp</exec_depend>
   <exec_depend>nodl_schema</exec_depend>
   <exec_depend>ros2nodl</exec_depend>
-  <exec_depend>nodl_generator_cpp</exec_depend>
+
+  <doc_depend>nodl_docgen</doc_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nodl_docgen/doc/conf.py
+++ b/nodl_docgen/doc/conf.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Sphinx configuration for this standalone package.
+
+This config only takes effect when rosdoc2 builds the package on its own.
+"""
+
+extensions = [
+    'myst_parser',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.extlinks',
+]
+
+# Resolve {external+nodl:...} references against the published top-level site.
+# rosdoc2 also seeds intersphinx from package.xml dependencies; this entry adds the top-level docs explicitly,
+# since the metapackage that hosts them is not a build dependency of this package.
+intersphinx_mapping = {
+    'nodl': ('https://nodl.readthedocs.io/en/latest/', None),
+}
+
+# {repo}`path` links to a file in the GitHub repo, matching the top-level site's role (see nodl/doc/conf.py).
+# Standalone builds have no RTD ref to pin, so they point at main.
+extlinks = {
+    'repo': ('https://github.com/ros-tooling/nodl/blob/main/%s', '%s'),
+}

--- a/nodl_docgen/doc/overview.md
+++ b/nodl_docgen/doc/overview.md
@@ -1,0 +1,153 @@
+# nodl_docgen
+
+`nodl_docgen` is a Sphinx extension that renders a NoDL document into a documentation page at build time.
+It provides one directive, `nodl-node`, which reads a NoDL file and emits the node's interface as prose and tables.
+
+Because the rendering happens during the doc build, the page cannot drift from the NoDL source:
+the file that describes the node is the file the page is drawn from,
+and a document that no longer loads becomes a build error rather than a stale page.
+
+For what a NoDL document declares, see {external+nodl:doc}`concepts`.
+This page documents the extension's surface.
+
+% The authoring guide is linked by URL rather than through the nodl intersphinx inventory,
+% which only holds pages that are already published:
+% an {external+nodl:doc} reference to a page added in the same change fails the combined build.
+
+The authoring walkthrough, with a rendered example, is
+[Documenting your node's interface](https://nodl.readthedocs.io/en/latest/documenting.html).
+
+## Enabling the extension
+
+These edits, in the package whose docs should carry the rendering:
+
+1. Declare the dependency in `package.xml`, so the buildfarm installs the extension for the doc build:
+
+   ```xml
+   <doc_depend>nodl_docgen</doc_depend>
+   ```
+
+2. Enable it in the package's `doc/conf.py`:
+
+   ```python
+   extensions = [
+       'myst_parser',
+       'nodl_docgen',
+   ]
+   ```
+
+3. Use the directive in a page:
+
+   ````markdown
+   ```{nodl-node} /../nodl/my_node.nodl.yaml
+   :title: my_node
+   ```
+   ````
+
+## The `nodl-node` directive
+
+### Argument
+
+The single required argument names the document to render, in one of two forms.
+
+A **path** is resolved the way `literalinclude` resolves one:
+relative to the page containing the directive, or relative to the Sphinx source root when it starts with `/`.
+A package's own NoDL files usually sit outside `doc/`, so the path leaves the doc tree:
+`/../nodl/my_node.nodl.yaml` from a `doc/` at the package root.
+
+A **reference** is a URI handled by one of `nodl_schema`'s registered resolvers.
+`nodl://<package>/<name>` resolves through the ament index,
+which is how a page documents a node it does not ship but depends on.
+`local://<relative path>` resolves relative to the page, like a plain path.
+
+Use a path for your own package's documents.
+`rosdoc2` builds a package from source with its dependencies installed but not the package itself,
+so a package's own NoDL is not in the ament index at the time its docs are built.
+References are for documents that come from somewhere else.
+
+### Options
+
+`:title:` sets the heading of the rendered section.
+Without it the heading is derived from the argument:
+a path becomes its filename with the `.nodl`, `.yaml`, `.yml`, and `.json` suffixes stripped,
+so `my_node.nodl.yaml` becomes `my_node`,
+and a reference becomes itself without its scheme, so `nodl://sensor_common/imu` becomes `sensor_common/imu`.
+
+A NoDL document has no name field, since a node's identity comes from the package that registers it,
+so the heading is the author's to choose.
+
+### What it renders
+
+The directive emits one section, titled as above, holding:
+
+- the document's `description`, one paragraph per blank-line-separated block,
+- a note listing the direct `include` references, when the document has any,
+- one subsection per interface category that has entries, in a fixed order:
+  Parameters, Publishers, Subscriptions, Service Servers, Service Clients, Action Servers, Action Clients.
+
+Each subsection is a table of that category's entries, in document order.
+A document that declares nothing renders as a bare titled section, rather than as a page of empty tables.
+
+Includes are resolved and merged before rendering,
+so the tables are the node's whole effective interface, not just the part written in this file.
+The note names where the rest came from.
+
+A column that no row fills in is dropped:
+a table of service servers that declare no QoS profile carries no QoS column.
+Name and Type always stay, since they are what a reader looks a row up by.
+
+Values are rendered the way an author writes them:
+a parameter default is a YAML literal (`true`, `[1.0, 2.0]`),
+and an empty Default cell means the parameter has no default and must be set at startup.
+A parameter's validators become constraint sentences in its Description cell ("must be greater than 0.0"),
+the convention `generate_parameter_library` uses in the markdown it generates.
+A QoS profile collapses to one line naming only what differs from the system default,
+so `KEEP_LAST(5), BEST_EFFORT` is a profile whose remaining policies are all defaults.
+A parameter name containing `__map_<key>` is shown as `<key>`,
+since a mapped parameter stands for one parameter per runtime key.
+
+Descriptions are rendered as plain text.
+Markup written in a NoDL description is not interpreted,
+because a description is prose that other NoDL consumers render too, not Sphinx markup.
+
+Several nodes can be documented on one page.
+Each rendered section gets its own identifier, so headings do not collide.
+
+### Failures
+
+A document that cannot be loaded, validated, resolved, or merged raises a directive error,
+carrying the directive's own source location.
+Sphinx reports it as a warning against that line,
+and a doc build run with `-W` fails there rather than publishing a page that documents less than the node does.
+
+### Rebuilds
+
+The document and every file it includes are registered as build dependencies of the page.
+An incremental `sphinx-build` therefore re-renders the page when a NoDL file it draws from changes.
+
+## The summary core
+
+The formatting decisions live in `nodl_docgen.summarize`, which is pure:
+it maps a `nodl_schema` document tree to a `NodeSummary` of plain strings, with no Sphinx or docutils imports.
+
+```python
+from pathlib import Path
+
+from nodl_schema import load_nodl_with_doc_tree
+from nodl_docgen.summarize import summarize_tree
+
+_, tree = load_nodl_with_doc_tree(Path('my_node.nodl.yaml').resolve())
+summary = summarize_tree(tree)
+print(summary.parameters)
+```
+
+`nodl_docgen.directives` turns a `NodeSummary` into docutils nodes.
+Emitting nodes rather than nested-parsing generated markdown is what makes the directive behave identically in MyST and in reStructuredText sources,
+since docutils is Sphinx's own intermediate representation.
+
+## Relationship to other packages
+
+`nodl_docgen` loads and resolves documents with `nodl_schema`, and inherits its `include` handling,
+so a `nodl://` reference points at a document that `ament_nodl` registered.
+The extension reads NoDL from a path or the ament index only;
+it does not observe a running node, which is what `nodl_observe` and `ros2nodl` do.

--- a/nodl_docgen/rosdoc2.yaml
+++ b/nodl_docgen/rosdoc2.yaml
@@ -1,0 +1,14 @@
+type: 'rosdoc2 config'
+version: 1
+
+---
+settings:
+    # Document the Python API and generate the per-package index for docs.ros.org.
+    always_run_sphinx_apidoc: true
+    generate_package_index: true
+
+builders:
+    - sphinx: {
+        name: 'nodl_docgen',
+        output_dir: ''
+    }


### PR DESCRIPTION
Closes https://github.com/ros-tooling/nodl/issues/130

Finishes up the end-to-end first pass of `nodl_docgen` [design](https://github.com/ros-tooling/nodl/issues/130) by documenting the package itself, and adding a tutorial with example rendered document in the toplevel docs.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>