### PR TITLE
CMake integration for `nodl_generate_cpp`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         # ctest per RMW; the integration test self-starts rmw_zenohd for zenoh).
         uses: ros-tooling/action-ros-ci@v0.4
         with:
-          package-name: ament_nodl nodl nodl_observe nodl_schema ros2nodl test_ament_nodl nodl_generator_cpp
+          package-name: ament_nodl nodl nodl_observe nodl_schema ros2nodl test_ament_nodl nodl_generator_cpp test_nodl_generator_cpp
           target-ros2-distro: ${{ matrix.ros }}
       - uses: actions/upload-artifact@v4
         if: >-

--- a/nodl_common_interfaces/CMakeLists.txt
+++ b/nodl_common_interfaces/CMakeLists.txt
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+cmake_minimum_required(VERSION 3.22)
+project(nodl_common_interfaces)
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_nodl REQUIRED)
+
+ament_nodl_register(node
+  FILE nodl/rclcpp_node.nodl.yaml
+  PACKAGE rclcpp)
+
+ament_nodl_register(lifecycle_node
+  FILE nodl/rclcpp_lifecycle_node.nodl.yaml
+  PACKAGE rclcpp_lifecycle)
+
+ament_package()

--- a/nodl_common_interfaces/nodl/rclcpp_lifecycle_node.nodl.yaml
+++ b/nodl_common_interfaces/nodl/rclcpp_lifecycle_node.nodl.yaml
@@ -1,0 +1,41 @@
+---
+# NoDL interface description for rclcpp_lifecycle::LifecycleNode.
+#
+# This file is a stand-in until rclcpp_lifecycle ships its own .nodl.yaml.
+# It is registered in the ament index as nodl://rclcpp_lifecycle/lifecycle_node.
+
+nodl_version: 2
+description: rclcpp_lifecycle::LifecycleNode interface
+
+codegen:
+  cpp:
+    role: BASE_CLASS
+    class: rclcpp_lifecycle::LifecycleNode
+    header: rclcpp_lifecycle/lifecycle_node.hpp
+
+include:
+  - ref: local://rclcpp_node.nodl.yaml
+
+publishers:
+  - name: transition_event
+    type: lifecycle_msgs/msg/TransitionEvent
+    qos:
+      history: KEEP_LAST
+      depth: 1
+      reliability: RELIABLE
+
+service_servers:
+  - name: ~/change_state
+    type: lifecycle_msgs/srv/ChangeState
+
+  - name: ~/get_state
+    type: lifecycle_msgs/srv/GetState
+
+  - name: ~/get_available_states
+    type: lifecycle_msgs/srv/GetAvailableStates
+
+  - name: ~/get_available_transitions
+    type: lifecycle_msgs/srv/GetAvailableTransitions
+
+  - name: ~/get_transition_graph
+    type: lifecycle_msgs/srv/GetAvailableTransitions

--- a/nodl_common_interfaces/nodl/rclcpp_node.nodl.yaml
+++ b/nodl_common_interfaces/nodl/rclcpp_node.nodl.yaml
@@ -1,0 +1,54 @@
+---
+# NoDL interface description for rclcpp::Node.
+#
+# This file is a stand-in until rclcpp ships its own .nodl.yaml.
+# It is registered in the ament index as nodl://rclcpp/node.
+
+nodl_version: 2
+description: rclcpp::Node base class interface
+
+codegen:
+  cpp:
+    role: BASE_CLASS
+    class: rclcpp::Node
+    header: rclcpp/rclcpp.hpp
+
+parameters:
+  use_sim_time:
+    type: bool
+    default_value: false
+    description: Use simulation time
+
+publishers:
+  - name: /rosout
+    type: rcl_interfaces/msg/Log
+    qos:
+      history: KEEP_LAST
+      depth: 1
+      reliability: RELIABLE
+
+  - name: /parameter_events
+    type: rcl_interfaces/msg/ParameterEvent
+    qos:
+      history: KEEP_LAST
+      depth: 1
+      reliability: RELIABLE
+
+service_servers:
+  - name: ~/describe_parameters
+    type: rcl_interfaces/srv/DescribeParameters
+
+  - name: ~/get_parameters
+    type: rcl_interfaces/srv/GetParameters
+
+  - name: ~/get_parameter_types
+    type: rcl_interfaces/srv/GetParameterTypes
+
+  - name: ~/list_parameters
+    type: rcl_interfaces/srv/ListParameters
+
+  - name: ~/set_parameters
+    type: rcl_interfaces/srv/SetParameters
+
+  - name: ~/set_parameters_atomically
+    type: rcl_interfaces/srv/SetParametersAtomically

--- a/nodl_common_interfaces/package.xml
+++ b/nodl_common_interfaces/package.xml
@@ -1,23 +1,21 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>nodl</name>
+  <name>nodl_common_interfaces</name>
   <version>0.0.0</version>
-  <description>ROS 2 Node Definition Language (NoDL) metapackage.</description>
+  <description>
+    NoDL interface descriptions for standard ROS 2 node base classes (rclcpp::Node, rclcpp_lifecycle::LifecycleNode).
+
+    These descriptions will eventually ship with the upstream packages themselves.
+    Until then, this package registers them in the ament index so that nodl://rclcpp/node and
+    nodl://rclcpp_lifecycle/lifecycle_node resolve correctly.
+  </description>
   <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>
   <author email="hello@alistairenglish.com">Alistair English</author>
-  <author email="me@emersonknapp.com">Emerson Knapp</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
-  <exec_depend>ament_nodl</exec_depend>
-  <exec_depend>nodl_generator_cpp</exec_depend>
-  <exec_depend>nodl_schema</exec_depend>
-  <exec_depend>ros2nodl</exec_depend>
-  <exec_depend>nodl_common_interfaces</exec_depend>
-
-  <doc_depend>nodl_docgen</doc_depend>
+  <buildtool_depend>ament_nodl</buildtool_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nodl_generator_cpp/CMakeLists.txt
+++ b/nodl_generator_cpp/CMakeLists.txt
@@ -8,4 +8,9 @@ find_package(ament_cmake_python REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME})
 
-ament_package()
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package(CONFIG_EXTRAS "nodl_generate_cpp-extras.cmake.in")

--- a/nodl_generator_cpp/cmake/nodl_generate_cpp.cmake
+++ b/nodl_generator_cpp/cmake/nodl_generate_cpp.cmake
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# nodl_generate_cpp(TARGET NODL_FILE)
+#
+# Generate an rclcpp base-node class from a NoDL document and expose it
+# as a STATIC library target that the caller can link against.
+#
+# Example::
+#
+#   find_package(nodl_generator_cpp REQUIRED)
+#
+#   nodl_generate_cpp(my_node_base my_node.nodl.yaml)
+#
+#   add_executable(my_node src/my_node.cpp)
+#   target_link_libraries(my_node PRIVATE my_node_base)
+#
+# :param TARGET: Name of the library target to create.  Also used as the
+#   C++ class stem (``<TARGET>Base``) and for the generated filenames.
+# :type TARGET: string
+# :param NODL_FILE: Path to the ``.nodl.yaml`` file, relative to
+#   ``CMAKE_CURRENT_SOURCE_DIR``.
+# :type NODL_FILE: string
+#
+# @public
+#
+macro(nodl_generate_cpp TARGET NODL_FILE)
+  # ── paths ───────────────────────────────────────────────────────────
+  set(_nodl_file "${CMAKE_CURRENT_SOURCE_DIR}/${NODL_FILE}")
+  set(_output_dir "${CMAKE_CURRENT_BINARY_DIR}/nodl_generated/${TARGET}")
+  set(_deps_file "${_output_dir}/${TARGET}_deps.cmake")
+
+  # ── configure-time: emit deps ──────────────────────────────────────
+  # Runs the generator in --cmake-deps mode which writes a small CMake
+  # file containing NODL_SOURCES, ROS_DEPS, and GENERATED_FILES.
+  file(MAKE_DIRECTORY "${_output_dir}")
+  execute_process(
+    COMMAND "${Python3_EXECUTABLE}" -m nodl_generator_cpp
+      --nodl-file "${_nodl_file}"
+      --output-dir "${_output_dir}"
+      --target-name "${TARGET}"
+      --cmake-deps
+    RESULT_VARIABLE _nodl_result
+  )
+  if(NOT _nodl_result EQUAL 0)
+    message(FATAL_ERROR
+      "nodl_generate_cpp: --cmake-deps failed for target '${TARGET}' "
+      "(file: ${_nodl_file})")
+  endif()
+  include("${_deps_file}")
+
+  # ── watch all NoDL sources for reconfigure ─────────────────────────
+  # Every file in the include tree is a configure-dependency.  Any
+  # change to the root or any transitive include triggers a reconfigure
+  # so the deps file is always up to date.
+  set_property(DIRECTORY APPEND PROPERTY
+    CMAKE_CONFIGURE_DEPENDS ${${TARGET}_NODL_SOURCES})
+
+  # ── find_package for ROS dependencies ──────────────────────────────
+  foreach(_dep IN LISTS ${TARGET}_ROS_DEPS)
+    find_package(${_dep} REQUIRED)
+  endforeach()
+
+  # ── build-time: code generation ────────────────────────────────────
+  # Prepend the output directory to each generated filename so CMake
+  # can track them as concrete build products.
+  set(_generated_paths "")
+  foreach(_f IN LISTS ${TARGET}_GENERATED_FILES)
+    list(APPEND _generated_paths "${_output_dir}/${_f}")
+  endforeach()
+
+  add_custom_command(
+    OUTPUT ${_generated_paths}
+    COMMAND "${Python3_EXECUTABLE}" -m nodl_generator_cpp
+      --nodl-file "${_nodl_file}"
+      --output-dir "${_output_dir}"
+      --target-name "${TARGET}"
+    DEPENDS ${${TARGET}_NODL_SOURCES}
+    COMMENT "nodl_generate_cpp: ${NODL_FILE} -> ${TARGET}"
+    VERBATIM
+  )
+
+  # ── create the library target ──────────────────────────────────────
+  add_library(${TARGET} STATIC)
+  foreach(_f IN LISTS _generated_paths)
+    if(_f MATCHES "\\.cpp$")
+      target_sources(${TARGET} PRIVATE "${_f}")
+    endif()
+  endforeach()
+  target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${_output_dir}>
+  )
+
+  # ── wire up ament ROS dependencies ─────────────────────────────────
+  ament_target_dependencies(${TARGET} PUBLIC ${${TARGET}_ROS_DEPS})
+
+  # ── generate_parameter_library dependencies (when params present) ──
+  # The generated parameter header (from generate_parameter_library_py)
+  # includes fmt, rsl, parameter_traits, etc.  Mirror the same link
+  # set that generate_parameter_library's own CMake macro uses.
+  list(FIND ${TARGET}_GENERATED_FILES "${TARGET}_parameters.hpp" _has_params_idx)
+  if(NOT _has_params_idx EQUAL -1)
+    find_package(generate_parameter_library REQUIRED)
+    target_link_libraries(${TARGET} PUBLIC
+      fmt::fmt
+      parameter_traits::parameter_traits
+      rclcpp_lifecycle::rclcpp_lifecycle
+      rsl::rsl
+      tcb_span::tcb_span
+      tl_expected::tl_expected
+    )
+  endif()
+endmacro()

--- a/nodl_generator_cpp/cmake/nodl_generate_cpp.cmake
+++ b/nodl_generator_cpp/cmake/nodl_generate_cpp.cmake
@@ -91,23 +91,39 @@ macro(nodl_generate_cpp TARGET NODL_FILE)
     $<BUILD_INTERFACE:${_output_dir}>
   )
 
-  # ── wire up ament ROS dependencies ─────────────────────────────────
-  ament_target_dependencies(${TARGET} PUBLIC ${${TARGET}_ROS_DEPS})
+  # ── wire up ROS dependencies ────────────────────────────────────────
+  # ${pkg_TARGETS} is available since Foxy and works across all
+  # supported distros (Humble → Lyrical), unlike ament_target_dependencies
+  # which was removed in Lyrical.
+  foreach(_dep IN LISTS ${TARGET}_ROS_DEPS)
+    target_link_libraries(${TARGET} PUBLIC ${${_dep}_TARGETS})
+  endforeach()
 
   # ── generate_parameter_library dependencies (when params present) ──
   # The generated parameter header (from generate_parameter_library_py)
-  # includes fmt, rsl, parameter_traits, etc.  Mirror the same link
-  # set that generate_parameter_library's own CMake macro uses.
+  # includes fmt, rsl, etc.  Mirror the same link set that
+  # generate_parameter_library's own CMake macro uses.
+  # Target names changed across distros, so we use if(TARGET) guards.
   list(FIND ${TARGET}_GENERATED_FILES "${TARGET}_parameters.hpp" _has_params_idx)
   if(NOT _has_params_idx EQUAL -1)
     find_package(generate_parameter_library REQUIRED)
-    target_link_libraries(${TARGET} PUBLIC
+    set(_nodl_genparamlib_deps
       fmt::fmt
-      parameter_traits::parameter_traits
+      rclcpp::rclcpp
       rclcpp_lifecycle::rclcpp_lifecycle
       rsl::rsl
       tcb_span::tcb_span
-      tl_expected::tl_expected
     )
+    # tl_expected::tl_expected (Humble/Jazzy) → tl::expected (Kilted+)
+    if(TARGET tl::expected)
+      list(APPEND _nodl_genparamlib_deps tl::expected)
+    elseif(TARGET tl_expected::tl_expected)
+      list(APPEND _nodl_genparamlib_deps tl_expected::tl_expected)
+    endif()
+    # parameter_traits present in Humble/Jazzy, removed in Kilted+
+    if(TARGET parameter_traits::parameter_traits)
+      list(APPEND _nodl_genparamlib_deps parameter_traits::parameter_traits)
+    endif()
+    target_link_libraries(${TARGET} PUBLIC ${_nodl_genparamlib_deps})
   endif()
 endmacro()

--- a/nodl_generator_cpp/nodl_generate_cpp-extras.cmake.in
+++ b/nodl_generator_cpp/nodl_generate_cpp-extras.cmake.in
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Auto-included when a downstream package calls find_package(nodl_generator_cpp).
+
+# Resolves ${Python3_EXECUTABLE} for the build-time codegen step the macro invokes.
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+include("${nodl_generator_cpp_DIR}/nodl_generate_cpp.cmake")

--- a/nodl_generator_cpp/package.xml
+++ b/nodl_generator_cpp/package.xml
@@ -12,6 +12,7 @@
 
   <exec_depend>nodl_schema</exec_depend>
   <exec_depend>generate_parameter_library_py</exec_depend>
+  <exec_depend>generate_parameter_library</exec_depend>
 
   <test_depend>python3-pytest</test_depend>
   <test_depend>nodl_schema</test_depend>

--- a/test_nodl_generator_cpp/CMakeLists.txt
+++ b/test_nodl_generator_cpp/CMakeLists.txt
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+cmake_minimum_required(VERSION 3.22)
+project(test_nodl_generator_cpp)
+
+find_package(ament_cmake REQUIRED)
+find_package(nodl_generator_cpp REQUIRED)
+
+# --- Generate base-node libraries from NoDL documents ---
+
+nodl_generate_cpp(minimal_node       nodl/minimal_node.nodl.yaml)
+nodl_generate_cpp(pub_sub_node       nodl/pub_sub_node.nodl.yaml)
+nodl_generate_cpp(services_node      nodl/services_node.nodl.yaml)
+nodl_generate_cpp(params_node        nodl/params_node.nodl.yaml)
+nodl_generate_cpp(kitchen_sink_node  nodl/kitchen_sink_node.nodl.yaml)
+nodl_generate_cpp(lifecycle_node     nodl/lifecycle_node.nodl.yaml)
+
+# --- Build tests — if these compile and link, the generator works ---
+
+add_executable(test_minimal_node      src/test_minimal_node.cpp)
+target_link_libraries(test_minimal_node PRIVATE minimal_node)
+
+add_executable(test_pub_sub_node      src/test_pub_sub_node.cpp)
+target_link_libraries(test_pub_sub_node PRIVATE pub_sub_node)
+
+add_executable(test_services_node     src/test_services_node.cpp)
+target_link_libraries(test_services_node PRIVATE services_node)
+
+add_executable(test_params_node       src/test_params_node.cpp)
+target_link_libraries(test_params_node PRIVATE params_node)
+
+add_executable(test_kitchen_sink_node src/test_kitchen_sink_node.cpp)
+target_link_libraries(test_kitchen_sink_node PRIVATE kitchen_sink_node)
+
+add_executable(test_lifecycle_node    src/test_lifecycle_node.cpp)
+target_link_libraries(test_lifecycle_node PRIVATE lifecycle_node)
+
+ament_package()

--- a/test_nodl_generator_cpp/nodl/kitchen_sink_node.nodl.yaml
+++ b/test_nodl_generator_cpp/nodl/kitchen_sink_node.nodl.yaml
@@ -1,0 +1,52 @@
+---
+# All entity types together: publishers, subscriptions, service servers,
+# service clients, action servers, action clients, and parameters.
+
+nodl_version: 2
+
+include:
+  - ref: nodl://rclcpp/node
+
+parameters:
+  max_speed:
+    type: double
+    default_value: 1.5
+    description: Maximum speed in m/s
+    validation:
+      gt<>: [0.0]
+  robot_name:
+    type: string
+    default_value: bot
+    read_only: true
+
+publishers:
+  - name: status
+    type: std_msgs/msg/String
+    qos:
+      history: KEEP_LAST
+      depth: 10
+      reliability: RELIABLE
+
+subscriptions:
+  - name: cmd_vel
+    type: geometry_msgs/msg/Twist
+    qos:
+      history: KEEP_LAST
+      depth: 1
+      reliability: BEST_EFFORT
+
+service_servers:
+  - name: trigger
+    type: std_srvs/srv/Trigger
+
+service_clients:
+  - name: set_bool
+    type: std_srvs/srv/SetBool
+
+action_servers:
+  - name: fibonacci
+    type: example_interfaces/action/Fibonacci
+
+action_clients:
+  - name: count
+    type: example_interfaces/action/Fibonacci

--- a/test_nodl_generator_cpp/nodl/lifecycle_node.nodl.yaml
+++ b/test_nodl_generator_cpp/nodl/lifecycle_node.nodl.yaml
@@ -1,0 +1,23 @@
+---
+# LifecycleNode base class with publishers and subscriptions.
+
+nodl_version: 2
+
+include:
+  - ref: nodl://rclcpp_lifecycle/lifecycle_node
+
+publishers:
+  - name: status
+    type: std_msgs/msg/String
+    qos:
+      history: KEEP_LAST
+      depth: 10
+      reliability: RELIABLE
+
+subscriptions:
+  - name: cmd_vel
+    type: geometry_msgs/msg/Twist
+    qos:
+      history: KEEP_LAST
+      depth: 1
+      reliability: BEST_EFFORT

--- a/test_nodl_generator_cpp/nodl/minimal_node.nodl.yaml
+++ b/test_nodl_generator_cpp/nodl/minimal_node.nodl.yaml
@@ -1,0 +1,7 @@
+---
+# Simplest valid codegen input: the mandatory base class include, no own entities.
+
+nodl_version: 2
+
+include:
+  - ref: nodl://rclcpp/node

--- a/test_nodl_generator_cpp/nodl/params_node.nodl.yaml
+++ b/test_nodl_generator_cpp/nodl/params_node.nodl.yaml
@@ -1,0 +1,22 @@
+---
+# Parameters via generate_parameter_library.
+
+nodl_version: 2
+
+include:
+  - ref: nodl://rclcpp/node
+
+parameters:
+  max_speed:
+    type: double
+    default_value: 1.5
+    description: Maximum speed in m/s
+    validation:
+      gt<>: [0.0]
+  robot_name:
+    type: string
+    default_value: bot
+    read_only: true
+  enabled:
+    type: bool
+    default_value: true

--- a/test_nodl_generator_cpp/nodl/pub_sub_node.nodl.yaml
+++ b/test_nodl_generator_cpp/nodl/pub_sub_node.nodl.yaml
@@ -1,0 +1,23 @@
+---
+# Publishers and subscriptions.
+
+nodl_version: 2
+
+include:
+  - ref: nodl://rclcpp/node
+
+publishers:
+  - name: status
+    type: std_msgs/msg/String
+    qos:
+      history: KEEP_LAST
+      depth: 10
+      reliability: RELIABLE
+
+subscriptions:
+  - name: cmd_vel
+    type: geometry_msgs/msg/Twist
+    qos:
+      history: KEEP_LAST
+      depth: 1
+      reliability: BEST_EFFORT

--- a/test_nodl_generator_cpp/nodl/services_node.nodl.yaml
+++ b/test_nodl_generator_cpp/nodl/services_node.nodl.yaml
@@ -1,0 +1,15 @@
+---
+# Service servers and clients.
+
+nodl_version: 2
+
+include:
+  - ref: nodl://rclcpp/node
+
+service_servers:
+  - name: trigger
+    type: std_srvs/srv/Trigger
+
+service_clients:
+  - name: set_bool
+    type: std_srvs/srv/SetBool

--- a/test_nodl_generator_cpp/package.xml
+++ b/test_nodl_generator_cpp/package.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>test_nodl_generator_cpp</name>
+  <version>0.0.0</version>
+  <description>
+    Integration tests for nodl_generator_cpp.
+    Exercises the nodl_generate_cpp() CMake macro end-to-end:
+    code generation, compilation, and linking against real ROS headers.
+  </description>
+  <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
+  <license>Apache-2.0</license>
+  <author email="hello@alistairenglish.com">Alistair English</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>nodl_generator_cpp</buildtool_depend>
+
+  <build_depend>nodl_common_interfaces</build_depend>
+
+  <build_depend>example_interfaces</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>lifecycle_msgs</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rclcpp_action</build_depend>
+  <build_depend>rclcpp_lifecycle</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/test_nodl_generator_cpp/src/test_kitchen_sink_node.cpp
+++ b/test_nodl_generator_cpp/src/test_kitchen_sink_node.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#include <memory>
+
+#include "kitchen_sink_node.hpp"  // NOLINT(build/include_subdir)
+
+class TestNode : public KitchenSinkNodeBase
+{
+  void on_cmd_vel(geometry_msgs::msg::Twist::ConstSharedPtr /*msg*/) override
+  {}
+
+  void on_trigger(
+    std_srvs::srv::Trigger::Request::SharedPtr /*request*/,
+    std_srvs::srv::Trigger::Response::SharedPtr /*response*/) override
+  {}
+
+  rclcpp_action::GoalResponse on_fibonacci_goal(
+    const rclcpp_action::GoalUUID & /*uuid*/,
+    std::shared_ptr<const example_interfaces::action::Fibonacci::Goal> /*goal*/) override
+  {
+    return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+  }
+
+  rclcpp_action::CancelResponse on_fibonacci_cancel(
+    std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::action::Fibonacci>>
+    /*goal_handle*/) override
+  {
+    return rclcpp_action::CancelResponse::ACCEPT;
+  }
+
+  void on_fibonacci_accepted(std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::action::Fibonacci>>
+                             /*goal_handle*/) override
+  {}
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<TestNode>();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/test_nodl_generator_cpp/src/test_lifecycle_node.cpp
+++ b/test_nodl_generator_cpp/src/test_lifecycle_node.cpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#include <memory>
+
+#include "lifecycle_node.hpp"  // NOLINT(build/include_subdir)
+
+class TestNode : public LifecycleNodeBase
+{
+  void on_cmd_vel(geometry_msgs::msg::Twist::ConstSharedPtr /*msg*/) override
+  {}
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<TestNode>();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/test_nodl_generator_cpp/src/test_minimal_node.cpp
+++ b/test_nodl_generator_cpp/src/test_minimal_node.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#include <memory>
+
+#include "minimal_node.hpp"  // NOLINT(build/include_subdir)
+
+class TestNode : public MinimalNodeBase
+{};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<TestNode>();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/test_nodl_generator_cpp/src/test_params_node.cpp
+++ b/test_nodl_generator_cpp/src/test_params_node.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#include <memory>
+
+#include "params_node.hpp"  // NOLINT(build/include_subdir)
+
+class TestNode : public ParamsNodeBase
+{
+public:
+  TestNode()
+  {
+    // Verify parameter access compiles (param_listener_ and params_ are protected).
+    auto params = param_listener_.get_params();
+    (void)params.max_speed;
+    (void)params.robot_name;
+    (void)params.enabled;
+  }
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<TestNode>();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/test_nodl_generator_cpp/src/test_pub_sub_node.cpp
+++ b/test_nodl_generator_cpp/src/test_pub_sub_node.cpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#include <memory>
+
+#include "pub_sub_node.hpp"  // NOLINT(build/include_subdir)
+
+class TestNode : public PubSubNodeBase
+{
+  void on_cmd_vel(geometry_msgs::msg::Twist::ConstSharedPtr /*msg*/) override
+  {}
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<TestNode>();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/test_nodl_generator_cpp/src/test_services_node.cpp
+++ b/test_nodl_generator_cpp/src/test_services_node.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#include <memory>
+
+#include "services_node.hpp"  // NOLINT(build/include_subdir)
+
+class TestNode : public ServicesNodeBase
+{
+  void on_trigger(
+    std_srvs::srv::Trigger::Request::SharedPtr /*request*/,
+    std_srvs::srv::Trigger::Response::SharedPtr /*response*/) override
+  {}
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<TestNode>();
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
Adds the `nodl_generate_cpp()` CMake macro so users can generate and link C++ code from NoDL files in one step:

```cmake
find_package(nodl_generator_cpp REQUIRED)
nodl_generate_cpp(my_node_base my_node.nodl.yaml)
target_link_libraries(my_node PRIVATE my_node_base)
```